### PR TITLE
Fix issue where name prop/default props aren't copied from src to des…

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,9 @@
   },
   "author": "Mehrdad Reshadi",
   "module": "dist/.esm.js",
+  "engines": {
+    "npm": ">= 7.14.0"
+  },
   "size-limit": [
     {
       "path": "dist/.cjs.production.min.js",

--- a/packages/hyperion-core/src/PropertyInterceptor.ts
+++ b/packages/hyperion-core/src/PropertyInterceptor.ts
@@ -100,6 +100,11 @@ export function copyOwnProperties<T extends ObjectOrFunction>(src: T, dest: T, c
         return src.valueOf();
       }
     }
-    dest.prototype = src.prototype;
+    const nameProp = 'name';
+    // should always be true, but just in case
+    if (ownProps.includes(nameProp)) {
+      const nameDesc = Object.getOwnPropertyDescriptor(src, nameProp) as PropertyDescriptor;
+      Object.defineProperty(dest, nameProp, nameDesc || {});
+    }
   }
 }

--- a/packages/hyperion-core/test/FunctionInterceptor.test.ts
+++ b/packages/hyperion-core/test/FunctionInterceptor.test.ts
@@ -393,4 +393,16 @@ describe("test modern classes", () => {
     expect(observer.mock.results[1].value).toBe(output);
   });
 
+  test("test name prop copied to interceptor", () => {
+    function someFuncName(a: string, b: number) {
+      return a + b;
+    };
+    expect(someFuncName.name).toStrictEqual('someFuncName');
+
+    const fi = interceptFunction(someFuncName, false, null, "tester");
+
+    expect(someFuncName.name).toStrictEqual('someFuncName');
+    expect(fi.interceptor.name).toStrictEqual(someFuncName.name);
+  });
+
 });


### PR DESCRIPTION
…t in FunctionInterceptor

This fixes an issue we ran into,  particularly with functional react components, where the component name is not resolved when interception is enabled.  The issue is that `name` (most important for this case), `prototype`, and other default props included on any function when defined, are being skipped when copying from the source function to the destination in `copyOwnProperties`.  
https://github.com/facebookincubator/hyperion/blob/main/packages/hyperion-core/src/PropertyInterceptor.ts#L83
Since every function has these default props, they are being skipped with the above check.

Since most component lookups do `component.displayName ?? component.name` to resolve a react component name, for functional components intercepted,  `name` was coming back empty unless `displayName` was explicitly set.

I added this functionality to the `copySpecials` section but I could see the argument for this being outside of that flag and included in the default props copy behavior.

Edit: also I got the the below GH CI build error as well locally,  but I downgraded typescript to what's in package.json (without caret resolution) `npm install typescript@4.7.3` and the error went away.  Should we lock the version or address the type issue in this or a follow up PR?
