### PR TITLE
Re-add prototype copy removed in #10

### DIFF
--- a/packages/hyperion-core/src/PropertyInterceptor.ts
+++ b/packages/hyperion-core/src/PropertyInterceptor.ts
@@ -100,11 +100,12 @@ export function copyOwnProperties<T extends ObjectOrFunction>(src: T, dest: T, c
         return src.valueOf();
       }
     }
-    const nameProp = 'name';
-    // should always be true, but just in case
-    if (ownProps.includes(nameProp)) {
-      const nameDesc = Object.getOwnPropertyDescriptor(src, nameProp) as PropertyDescriptor;
-      Object.defineProperty(dest, nameProp, nameDesc || {});
+    dest.prototype = src.prototype;
+    const nameDesc = Object.getOwnPropertyDescriptor(src, 'name') as PropertyDescriptor;
+    try {
+      Object.defineProperty(dest, 'name', nameDesc);
+    } catch (e) {
+      __DEV__ && console.error("Adding property name threw exception: ", e);
     }
   }
 }

--- a/packages/hyperion-core/test/FunctionInterceptor.test.ts
+++ b/packages/hyperion-core/test/FunctionInterceptor.test.ts
@@ -393,7 +393,7 @@ describe("test modern classes", () => {
     expect(observer.mock.results[1].value).toBe(output);
   });
 
-  test("test name prop copied to interceptor", () => {
+  test("test prototype + name prop copied to interceptor", () => {
     function someFuncName(a: string, b: number) {
       return a + b;
     };
@@ -403,6 +403,12 @@ describe("test modern classes", () => {
 
     expect(someFuncName.name).toStrictEqual('someFuncName');
     expect(fi.interceptor.name).toStrictEqual(someFuncName.name);
+    expect(fi.interceptor.prototype).toStrictEqual(someFuncName.prototype);
+
+    const noProto = () => {};
+    expect(noProto.prototype).toBeUndefined();
+    const fiNoProto = interceptFunction(noProto, false, null, "tester");
+    expect(fiNoProto.interceptor.prototype).toBeUndefined();
   });
 
 });


### PR DESCRIPTION
Re add the prototype copy as I meant to leave it unchanged in #10.  Also it seems to work as is in chrome, and I'd rather not introduce this change until investigating further [`setPrototypeOf`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/setPrototypeOf):

<img width="448" alt="image" src="https://user-images.githubusercontent.com/6064408/188691719-353458ec-4321-4c1b-abc1-0f076c1b2ee8.png">
