### PR TITLE
Only wrap in Surface component if surface can be extracted from context when using proxy

### DIFF
--- a/packages/hyperion-autologging/src/ALSurfaceProxy.ts
+++ b/packages/hyperion-autologging/src/ALSurfaceProxy.ts
@@ -10,12 +10,11 @@ import { useALSurfaceContext } from './ALSurfaceContext';
 import * as IReactDOM from "@hyperion/hyperion-react/src/IReactDOM";
 import { SurfacePropsExtension } from './ALSurfacePropsExtension';
 import { FlowletManagerType, SurfaceComponent } from './ALSurface';
-import { assert } from '@hyperion/global';
 
 
 export type InitOptions =
   Readonly<{
-    ReactModule: { createElement: typeof React.createElement };
+    ReactModule: { createElement: typeof React.createElement, Fragment: typeof React.Fragment };
     IReactDOMModule: IReactDOM.IReactDOMModuleExports;
     flowletManager: FlowletManagerType;
   }>;
@@ -35,21 +34,23 @@ type ProxyInitOptions =
  * If we can find a way around this limitation, we can use a simpler logic
  * like the following:
  */
-function SurfaceProxy(props: React.PropsWithChildren<ProxyInitOptions>) {
+function SurfaceProxy(props: React.PropsWithChildren<ProxyInitOptions>): React.ReactElement {
   const { ReactModule, surfaceComponent, flowletManager, children } = props;
   const { surface, flowlet } = useALSurfaceContext();
-  assert(surface != null, 'Surface cannot be null when proxying Surface.');
-  assert(flowlet != null, 'Flowlet cannot be null when proxying Surface.');
-  return ReactModule.createElement(
-    surfaceComponent,
-    {
-      __ext: new SurfacePropsExtension(flowlet),
-      flowlet: flowlet,
-      flowletManager: flowletManager,
-      fullSurfaceString: surface,
-    },
-    children
-  );
+  if (surface != null && flowlet != null) {
+    return ReactModule.createElement(
+      surfaceComponent,
+      {
+        __ext: new SurfacePropsExtension(flowlet),
+        flowlet: flowlet,
+        flowletManager: flowletManager,
+        fullSurfaceString: surface,
+      },
+      children
+    );
+  } else {
+    return ReactModule.createElement(ReactModule.Fragment, {}, children);
+  }
 }
 
 export function init(options: ProxyInitOptions): void {

--- a/packages/hyperion-react-testapp/src/App.tsx
+++ b/packages/hyperion-react-testapp/src/App.tsx
@@ -9,6 +9,7 @@ import LargeComp from './component/LargeComponent';
 import Counter from "./component/Counter";
 import NestedComponent from './component/NestedComponent';
 import * as IReact from "./IReact";
+import { PortalBodyContainerComponent } from './component/PortalComponent';
 
 function InitComp() {
   const [count, setCount] = React.useState(0);
@@ -41,6 +42,9 @@ function App() {
         <NestedComponent></NestedComponent>
         <LargeComp depth={1} maxDepth={maxDepth}></LargeComp>
       </div>
+      <div>
+       <PortalBodyContainerComponent message="Portal outside of Surface"></PortalBodyContainerComponent>
+      </div>
 
 
 
@@ -51,7 +55,7 @@ function App() {
 export default App;
 
 {/* <h1>Large tree without interception:</h1>
-     
+
 
         <InitComp></InitComp>
 


### PR DESCRIPTION
The assertions were still letting through constructions of surfaceComponent,  with a passed null flowlet.  Causing a run time error accessing `name` from passed flowlet.

