### PR TITLE
Surface Mutation Publisher

### DIFF
--- a/packages/hyperion-autologging/src/ALInteractableDOMElement.ts
+++ b/packages/hyperion-autologging/src/ALInteractableDOMElement.ts
@@ -138,11 +138,11 @@ let installHandlers = () => {
 
   onReactDOMElement.add((_component, props: ReactComponentObjectProps) => {
     if (props != null) {
-      for (const event of TrackedEvents) {
+      TrackedEvents.forEach(event => {
         if (props[SYNTHETIC_MOUSE_EVENT_HANDLER_MAP[event]] != null) {
           props[`data-${event}able`] = '1';
         }
-      }
+      });
     }
   });
 

--- a/packages/hyperion-autologging/src/ALInteractableDOMElement.ts
+++ b/packages/hyperion-autologging/src/ALInteractableDOMElement.ts
@@ -146,7 +146,7 @@ let installHandlers = () => {
     }
   });
 
-  installHandlers = () => { }; // Done doing stuff! 
+  installHandlers = () => { }; // Done doing stuff!
 }
 
 export function trackInteractable(events: Array<string>): void {

--- a/packages/hyperion-autologging/src/ALReactUtils.ts
+++ b/packages/hyperion-autologging/src/ALReactUtils.ts
@@ -1,0 +1,92 @@
+/**
+ * (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+ */
+
+'use strict';
+
+export type ReactComponentData = Readonly<{
+  name: string | null,
+  stack: Array<string>,
+}>;
+
+export type ComponentNameValidator = (name: string) => boolean;
+
+const defaultComponentNameValidator: ComponentNameValidator = (_: string) => {
+  return true;
+};
+
+type ReactInternalFiber = Readonly<{
+  key: string | null,
+  // memoizedProps can be any object
+  memoizedProps: { [key: string]: any },
+  return: ReactInternalFiber | null,
+  type: string | ReactInternalFiberType | null,
+  _debugSource: { fileName: string | null, lineNumber: number | null } | null,
+}>;
+
+type ReactInternalFiberType = Readonly<{
+  displayName?: string,
+  name?: string,
+  render: ReactInternalFiberType,
+}>;
+
+const getReactInternalFiber = (element: Element): ReactInternalFiber | null => {
+  const key = Object.keys(element).find(key => key.startsWith('__reactFiber$'));
+  const el = element as {[k: string]: any};
+  return key != null ? el[key] : null;
+};
+
+const getReactComponentName = (
+  componentType: ReactInternalFiberType,
+): string | null => {
+  // Because of React name minimization in prod, we can't use componentType.name
+  const displayName = componentType.displayName ?? componentType.name;
+  if (displayName == null) {
+    return null;
+  }
+  const match = displayName.match(/.*\[from (.*)\.react\]/);
+  return match?.[1] ?? displayName;
+};
+
+export function getReactComponentData_THIS_CAN_BREAK(
+  node: Element | null,
+  componentNameIsValid: ComponentNameValidator | null,
+): ReactComponentData | null {
+  if (node == null) {
+    return null;
+  }
+
+  const componentNameValidator = componentNameIsValid
+    ? componentNameIsValid
+    : defaultComponentNameValidator;
+  const element: Element = node;
+  try {
+    let name: string | null = null;
+    const stack = [];
+    let fiber = getReactInternalFiber(element);
+    while (fiber) {
+      const fiberType = fiber.type;
+      if (fiberType == null || typeof fiberType === 'string') {
+        fiber = fiber.return;
+        continue;
+      }
+      let componentName = getReactComponentName(fiberType);
+      if (componentName == null && fiberType.render != null) {
+        componentName = getReactComponentName(fiberType.render);
+      }
+      if (componentName != null && componentName !== '') {
+        stack.push(componentName);
+        if (name == null && componentNameValidator(componentName)) {
+          name = componentName;
+        }
+      }
+      fiber = fiber.return;
+    }
+    return stack.length > 0 ? { name, stack } : null;
+  } catch (err) {
+    if (__DEV__) {
+      throw err;
+    }
+    return null;
+  }
+}

--- a/packages/hyperion-autologging/src/ALSurfaceMutationPublisher.ts
+++ b/packages/hyperion-autologging/src/ALSurfaceMutationPublisher.ts
@@ -7,7 +7,7 @@
 import type { ALChannelSurfaceEvent } from './ALSurface';
 import type { Channel } from "@hyperion/hook/src/Channel";
 import * as Types from "@hyperion/hyperion-util/src/Types";
-import { ALLoggableEvent } from "./ALType";
+import { ALLoggableEvent, ALReactElementEvent } from "./ALType";
 
 import { ALFlowlet, ALFlowletManager } from "./ALFlowletManager";
 import * as ALID from './ALID';
@@ -17,14 +17,12 @@ import { ComponentNameValidator, getReactComponentData_THIS_CAN_BREAK, ReactComp
 import { AUTO_LOGGING_SURFACE } from './ALSurfaceConsts';
 import { getElementName } from './ALInteractableDOMElement';
 
-type ALMutationEvent =  Readonly<{
+type ALMutationEvent = ALReactElementEvent & Readonly<{
   event: 'mount_component' | 'unmount_component';
   element: HTMLElement,
   elementName: string | null,
   mountedDuration?: number;
   flowlet?: ALFlowlet | null;
-  reactComponentName?: string | null,
-  reactComponentStack?: string[] | null,
 }>;
 
 export type AdsALSurfaceMutationEventData = Readonly<
@@ -39,15 +37,13 @@ export type ALChannelSurfaceMutationEvent = Readonly<{
 
 export type ALSurfaceMutationChannel = Channel<ALChannelSurfaceMutationEvent & ALChannelSurfaceEvent>;
 
-type SurfaceInfo = {
+type SurfaceInfo = ALReactElementEvent & {
   surface: string,
   element: HTMLElement,
   addTime: number,
   removeTime?: number,
   addFlowlet: ALFlowlet | null,
   removeFlowlet?: ALFlowlet | null,
-  reactComponentName?: string | null,
-  reactComponentStack?: string[] | null,
   elementName: string | null,
 };
 

--- a/packages/hyperion-autologging/src/ALSurfaceMutationPublisher.ts
+++ b/packages/hyperion-autologging/src/ALSurfaceMutationPublisher.ts
@@ -1,0 +1,169 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved.
+ */
+
+'use strict';
+
+import type { ALChannelSurfaceEvent } from './ALSurface';
+import type { Channel } from "@hyperion/hook/src/Channel";
+import * as Types from "@hyperion/hyperion-util/src/Types";
+import { ALLoggableEvent } from "./ALType";
+
+import { ALFlowlet, ALFlowletManager } from "./ALFlowletManager";
+import * as ALID from './ALID';
+import * as ALEventIndex from './ALEventIndex';
+// import {getAutoLoggingQPLEvent, onInteraction} from 'AdsALProfiler';
+// import AdsALUIState from 'AdsALUIState';
+import performanceAbsoluteNow from '@hyperion/hyperion-util/src/performanceAbsoluteNow';
+
+
+
+type SurfaceInfo = {
+  surface: string,
+  element: HTMLElement,
+  addTime: number,
+  removeTime?: number,
+  addFlowlet: ALFlowlet | null,
+  removeFlowlet?: ALFlowlet | null,
+};
+
+
+const activeSurfaces = new Map<string, SurfaceInfo>();
+
+export type AdsALSurfaceMutationEventData = Readonly<
+  ALLoggableEvent &
+  {
+    event: 'mount_component' | 'unmount_component';
+    element: HTMLElement,
+    mountedDuration?: number;
+    mutationImpl: 'surface';
+    flowlet?: ALFlowlet | null;
+  }
+>;
+
+export type ALChannelSurfaceMutationEvent = Readonly<{
+  al_mutation_event: [AdsALSurfaceMutationEventData],
+}
+>;
+
+export type ALSurfaceMutationChannel = Channel<ALChannelSurfaceMutationEvent & ALChannelSurfaceEvent>;
+
+export type InitOptions = Types.Options<{
+  channel: ALSurfaceMutationChannel;
+  flowletManager: ALFlowletManager;
+  cacheElementInfo: boolean;
+  domSurfaceAttributeName: string;
+}>;
+
+
+export function publish(options: InitOptions): void {
+  const { domSurfaceAttributeName, channel, flowletManager, cacheElementInfo } = options;
+
+  function processNode(node: Node, action: 'added' | 'removed') {
+    const timestamp = performanceAbsoluteNow();
+
+    const flowlet = flowletManager.top();
+    if (!(node instanceof HTMLElement) || /LINK|SCRIPT/.test(node.nodeName)) {
+      return;
+    }
+    const surface = node.getAttribute(domSurfaceAttributeName);
+    if (surface == null) {
+      return;
+    }
+    switch (action) {
+      case 'added': {
+        if (cacheElementInfo) {
+          // AdsALUIState.getOrCreateCachedInfo(node);
+        }
+        let info = activeSurfaces.get(surface);
+        if (!info) {
+          info = {
+            surface,
+            element: node,
+            addTime: timestamp,
+            addFlowlet: flowlet,
+          };
+          activeSurfaces.set(surface, info);
+          emitSurfaceMutation(action, info);
+        } else if (node != info.element && node.contains(info.element)) {
+          /**
+          * This means we are seeing a node that is higher in the DOM
+          * and belongs to a surface that we have seen before.
+          * So, we can just update the surface=>node info.
+          *  */
+          info.element = node;
+          info.addFlowlet = flowlet;
+          info.addTime = timestamp;
+        }
+        break;
+      }
+      case 'removed': {
+        const info = activeSurfaces.get(surface);
+        if (info && info.element === node) {
+          info.removeFlowlet = flowlet;
+          info.removeTime = timestamp;
+          activeSurfaces.delete(surface);
+          emitSurfaceMutation(action, info);
+        }
+        break;
+      }
+    }
+  }
+
+  channel.addListener('al_surface_mount', event => {
+    const element = document.querySelector(
+      `[${domSurfaceAttributeName}='${event.surface}']`,
+    );
+    if (element != null) {
+      processNode(element, 'added');
+    }
+  });
+
+  channel.addListener('al_surface_unmount', event => {
+    const removeSurfaceNode = activeSurfaces.get(event.surface);
+    if (removeSurfaceNode) {
+      processNode(removeSurfaceNode.element, 'removed');
+    }
+  });
+
+
+  function emitSurfaceMutation(
+    action: 'added' | 'removed',
+    info: SurfaceInfo
+  ): void {
+    const { removeTime, element } = info;
+    switch (action) {
+      case 'added': {
+        channel.emit('al_mutation_event', {
+          event: 'mount_component',
+          eventTimestamp: info.addTime,
+          eventIndex: ALEventIndex.getEventIndex(),
+          element: info.element,
+          autoLoggingID: ALID.getOrSetAutoLoggingID(element),
+          flowlet: info.addFlowlet,
+          surface: info.surface,
+          mutationImpl: 'surface',
+        });
+        break;
+      }
+      case 'removed': {
+        if (removeTime == null) {
+          // Not expect to happen, error
+          break;
+        }
+        channel.emit('al_mutation_event', {
+          event: 'unmount_component',
+          eventTimestamp: removeTime,
+          eventIndex: ALEventIndex.getEventIndex(),
+          element,
+          autoLoggingID: ALID.getOrSetAutoLoggingID(element),
+          mountedDuration: (removeTime - info.addTime) / 1000,
+          flowlet: info.removeFlowlet,
+          surface: info.surface,
+          mutationImpl: 'surface',
+        });
+        break;
+      }
+    }
+  }
+}

--- a/packages/hyperion-autologging/src/ALSurfaceUtils.ts
+++ b/packages/hyperion-autologging/src/ALSurfaceUtils.ts
@@ -1,11 +1,8 @@
-import { AUTO_LOGGING_SURFACE } from "./ALSurfaceConsts";
-
-const SURFACE_SELECTOR = `[${AUTO_LOGGING_SURFACE}]`;
-
-export function getSurfacePath(node: HTMLElement | null): string| null {
-  return getAncestralSurfaceNode(node)?.getAttribute(AUTO_LOGGING_SURFACE) ?? null;
+export function getSurfacePath(node: HTMLElement | null, domSurfaceAttributeName: string): string| null {
+  const domSurfaceSelector = `[${domSurfaceAttributeName}]`;
+  return getAncestralSurfaceNode(node, domSurfaceSelector)?.getAttribute(domSurfaceAttributeName) ?? null;
 }
 
-export function getAncestralSurfaceNode(node: Element| null): Element| null {
-  return node?.closest(SURFACE_SELECTOR) ?? null;
+export function getAncestralSurfaceNode(node: Element | null, domSurfaceSelector: string): Element| null {
+  return node?.closest(domSurfaceSelector) ?? null;
 }

--- a/packages/hyperion-autologging/src/ALType.ts
+++ b/packages/hyperion-autologging/src/ALType.ts
@@ -15,3 +15,7 @@ export type ALLoggableEvent = Readonly<{
   eventTimestamp: number,
 }>;
 
+export type ALReactElementEvent = Readonly<{
+  reactComponentName?: string | null,
+  reactComponentStack?: string[] | null,
+}>;

--- a/packages/hyperion-autologging/src/index.ts
+++ b/packages/hyperion-autologging/src/index.ts
@@ -8,11 +8,13 @@ import * as Types from "@hyperion/hyperion-util/src/Types";
 import * as ALSurface from "./ALSurface";
 import * as ALUIeventPublisher from "./ALUIEventPublisher";
 import * as ALHeartbeat from "./ALHeartbeat";
+import * as ALSurfaceMutationPublisher from "./ALSurfaceMutationPublisher";
 
 export type InitOptions = Types.Options<{
   surface: ALSurface.InitOptions;
   uiEventPublisher?: ALUIeventPublisher.InitOptions;
   heartbeat?: ALHeartbeat.InitOptions;
+  surfaceMutationPublisher?: ALSurfaceMutationPublisher.InitOptions;
 }>;
 
 export function init(options: InitOptions): ALSurface.ALSurfaceHOC {
@@ -22,6 +24,10 @@ export function init(options: InitOptions): ALSurface.ALSurfaceHOC {
 
   if (options.heartbeat) {
     ALHeartbeat.start(options.heartbeat);
+  }
+
+  if (options.surfaceMutationPublisher) {
+    ALSurfaceMutationPublisher.publish(options.surfaceMutationPublisher);
   }
 
   return ALSurface.init(options.surface);

--- a/packages/hyperion-react-testapp/src/IReact.ts
+++ b/packages/hyperion-react-testapp/src/IReact.ts
@@ -48,6 +48,8 @@ export function init() {
     uiEventPublisher: {
       uiEvents: ['click'],
       flowletManager: FlowletManager,
+      cacheElementReactInfo: true,
+      componentNameValidator: (name: string) => !name.match(/(^Surface(Proxy)?)/),
       channel
     },
     heartbeat: {
@@ -57,7 +59,8 @@ export function init() {
     surfaceMutationPublisher: {
       channel,
       flowletManager: FlowletManager,
-      cacheElementInfo: false,
+      cacheElementReactInfo: true,
+      componentNameValidator: (name: string) => !name.match(/(^Surface(Proxy)?)/),
       domSurfaceAttributeName: 'data-surfaceid',
     }
   })
@@ -65,10 +68,10 @@ export function init() {
   Surface.init(surfaceRenderer);
 
   channel.on('al_surface_mount').add(ev => {
-    console.log('surface_mounted', ev, performance.now());
+    console.log('surface_mount', ev, performance.now());
   });
   channel.on('al_surface_unmount').add(ev => {
-    console.log('surface_unmounted', ev, performance.now());
+    console.log('surface_unmount', ev, performance.now());
   });
   channel.on('al_ui_event').add(ev => {
     console.log('ui_event', ev, performance.now());
@@ -76,7 +79,7 @@ export function init() {
   channel.on('al_heartbeat').add(ev => {
     console.log('heartbeat', ev, performance.now());
   });
-  channel.on('al_mutation_event').add(ev => {
+  channel.on('al_surface_mutation_event').add(ev => {
     console.log('surface_mutation_event', ev, performance.now());
   });
 }

--- a/packages/hyperion-react-testapp/src/IReact.ts
+++ b/packages/hyperion-react-testapp/src/IReact.ts
@@ -30,10 +30,12 @@ export function init() {
     ALHeartbeat.ALChannelHeartbeatEvent &
     ALSurfaceMutationPublisher.ALChannelSurfaceMutationEvent &
     { test: [number, string] }
-  >;
+  >();
   channel.on("test").add((i, s) => { // Showing channel can be extend beyond expected types
 
   });
+
+  const testCompValidator = (name: string) => !name.match(/(^Surface(Proxy)?)/);
 
   const surfaceRenderer = AutoLogging.init({
     surface: {
@@ -49,7 +51,7 @@ export function init() {
       uiEvents: ['click'],
       flowletManager: FlowletManager,
       cacheElementReactInfo: true,
-      componentNameValidator: (name: string) => !name.match(/(^Surface(Proxy)?)/),
+      componentNameValidator: testCompValidator,
       channel
     },
     heartbeat: {
@@ -60,7 +62,7 @@ export function init() {
       channel,
       flowletManager: FlowletManager,
       cacheElementReactInfo: true,
-      componentNameValidator: (name: string) => !name.match(/(^Surface(Proxy)?)/),
+      componentNameValidator: testCompValidator,
       domSurfaceAttributeName: 'data-surfaceid',
     }
   })

--- a/packages/hyperion-react-testapp/src/IReact.ts
+++ b/packages/hyperion-react-testapp/src/IReact.ts
@@ -5,6 +5,7 @@
 import { Channel } from "@hyperion/hook/src/Channel";
 import * as AutoLogging from "@hyperion/hyperion-autologging/src/";
 import * as ALHeartbeat from "@hyperion/hyperion-autologging/src/ALHeartbeat";
+import * as ALSurfaceMutationPublisher from "@hyperion/hyperion-autologging/src/ALSurfaceMutationPublisher";
 import type * as ALSurface from "@hyperion/hyperion-autologging/src/ALSurface";
 import * as ALUIEventPublisher from "@hyperion/hyperion-autologging/src/ALUIEventPublisher";
 import * as IReact from "@hyperion/hyperion-react/src/IReact";
@@ -27,6 +28,7 @@ export function init() {
     ALSurface.ALChannelSurfaceEvent &
     ALUIEventPublisher.ALChannelUIEvent &
     ALHeartbeat.ALChannelHeartbeatEvent &
+    ALSurfaceMutationPublisher.ALChannelSurfaceMutationEvent &
     { test: [number, string] }
   >;
   channel.on("test").add((i, s) => { // Showing channel can be extend beyond expected types
@@ -51,21 +53,30 @@ export function init() {
     heartbeat: {
       channel,
       heartbeatInterval: 30 * 1000
+    },
+    surfaceMutationPublisher: {
+      channel,
+      flowletManager: FlowletManager,
+      cacheElementInfo: false,
+      domSurfaceAttributeName: 'data-surfaceid',
     }
   })
 
   Surface.init(surfaceRenderer);
 
   channel.on('al_surface_mount').add(ev => {
-    console.log('mounted', ev, performance.now());
+    console.log('surface_mounted', ev, performance.now());
   });
   channel.on('al_surface_unmount').add(ev => {
-    console.log('unmounted', ev, performance.now());
+    console.log('surface_unmounted', ev, performance.now());
   });
   channel.on('al_ui_event').add(ev => {
     console.log('ui_event', ev, performance.now());
   });
   channel.on('al_heartbeat').add(ev => {
     console.log('heartbeat', ev, performance.now());
+  });
+  channel.on('al_mutation_event').add(ev => {
+    console.log('surface_mutation_event', ev, performance.now());
   });
 }

--- a/packages/hyperion-react-testapp/src/component/NestedComponent.tsx
+++ b/packages/hyperion-react-testapp/src/component/NestedComponent.tsx
@@ -2,8 +2,6 @@
  * Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved.
  */
 
-'use strict';
-
 import * as React from 'react';
 import { useState } from 'react';
 import ClassComponent from './ClassComponent';
@@ -11,6 +9,7 @@ import ForwardRefComponent from './ForwardRefComponent';
 import FuncComponent from './FuncComponent';
 import {PortalBodyContainerComponent, PortalComponent} from './PortalComponent';
 import { Props, Surface } from './Surface';
+import { ToggleSurfaceComponent } from './ToggleSurfaceComponent';
 
 class EmptyClassComponent extends React.Component<{}> {
   render(): React.ReactElement {
@@ -59,6 +58,7 @@ export default function AdsSpeedLabAutoLoggingImpl(_props: {}): React.ReactEleme
       <IndirectSurface message="indirect">
         <span>Indirect-child</span>
       </IndirectSurface>
+      <ToggleSurfaceComponent/>
     </div>,
   );
 }

--- a/packages/hyperion-react-testapp/src/component/ToggleSurfaceComponent.tsx
+++ b/packages/hyperion-react-testapp/src/component/ToggleSurfaceComponent.tsx
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved.
+ */
+
+import { useState } from "react";
+import { Surface } from "./Surface";
+
+// Toggles rendering a Surface component, useful for testing mount/unmount of Surface
+export function ToggleSurfaceComponent() {
+  const [isHidden, setHidden] = useState(true);
+
+  return (
+    <div style={{margin: "15px"}}>
+      <button onClick={(_) => setHidden(!isHidden)}>Toggle Surface Mutation Component</button>
+      { !isHidden ?
+        (
+          Surface({ surface: 'ToggleSurfaceComp' })(
+            <div>
+              <span style={{backgroundColor:"lightgreen"}}>A togglable Surface Component</span>
+            </div>
+          )
+        ) : null
+      }
+    </div>
+  );
+}


### PR DESCRIPTION
Added initial version of surface mutation publisher
- Some things to note:
   - In the original version we have a reliance on  (ads-specific) interaction callbacks (onAdd, onEnd) ending before we would process the mutation events,  see `schedulePostInteractionTask` and `onInteraction` in the old code. 
     - How should we handle this,  should we just arbitrarily choose a timeout and use `TimedTrigger`?  The initial PR is just firing them immediately and does not have a sense of added/removed/active.  Replaced with only `active`.
       
Included caching react element info for both the mutation publisher, and UI event publisher,  which is configurable via initoptions,  this is important as this is one of the first things fixed by IFB team when they first used the generic UI publisher.
- Some things to note:
   - The initial version is about as simple as it gets,  rather than port all the `ElementInfo`/`UIState` (virtualProperty setting etc.).  I just went with the basics and grab the info and store it in the initial event,  caching it, and then it is available when ultimately fired.
   
Also included some small fixes with surface attribute passing,  added to UI publisher, removed some hard reliance on the const and instead use init option specified surface attribute.
- We seem to be having some shared attributes across configuration,  maybe we could pull this into the top level configuration and pass it down along with feature-specific options.