### PR TITLE
Export ALInteractableDOMElement module

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -43,6 +43,7 @@ export default defineConfig({
       "hyperionAutoLogging": [
         "@hyperion/hook/src/Channel",
         "@hyperion/hyperion-autologging/src/ALSurface",
+        "@hyperion/hyperion-autologging/src/ALInteractableDOMElement",
         "@hyperion/hyperion-autologging/src/AutoLogging",
       ]
     },

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,5 +32,6 @@ export * as IReact from "@hyperion/hyperion-react/src/IReact";
 export * as IReactDOM from "@hyperion/hyperion-react/src/IReactDOM";
 
 // hyperionAutoLogging
+export * as ALInteractableDOMElement from "@hyperion/hyperion-autologging/src/ALInteractableDOMElement";
 export * as AutoLogging from "@hyperion/hyperion-autologging/src/AutoLogging";
 export { Channel } from "@hyperion/hook/src/Channel";


### PR DESCRIPTION
This module is needed by other utilities to track interactable elements.