### PR TITLE
Adding a check for bubbling before pushing to the flowlet stack

### DIFF
--- a/packages/hyperion-autologging/src/ALUIEventPublisher.ts
+++ b/packages/hyperion-autologging/src/ALUIEventPublisher.ts
@@ -109,7 +109,7 @@ export function publish(options: InitOptions): void {
        * we need yet another distinguishing fact, for which we use timestamp
        */
       const autoLoggingID = getOrSetAutoLoggingID(element);
-      if (event.isTrusted) {
+      if (event.isTrusted && event.bubbles) {
         const ALFlowlet = flowletManager.flowletCtor;
         flowlet = new ALFlowlet(eventName, flowletManager.top());
         flowlet = new ALFlowlet(autoLoggingID, flowlet);


### PR DESCRIPTION
Some DOM Events, like mouseenter and mouseleave, do not bubble, so they never get popped from the flowlet stack. This causes them to build up and eventually produce a flowlet like this when a click occurs: `/am/mouseenter/f34a619a8ee7e44/ts1678309620612.2/mouseenter/f1fbc9edaa761a8/ts1678309620612.6/mouseenter/f1cc4c0efbca42c/ts1678309620612.8/mouseenter/f2beca6d129f2bc/ts1678309620613/mouseenter/f2c77d64eeb388c/ts1678309620613.2/click/f2c77d64eeb388c/ts1678309620714.6`

Adding this check to prevent this from happening.