### PR TITLE
Expose flowlet classes in the final build

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -42,7 +42,9 @@ export default defineConfig({
       ],
       "hyperionAutoLogging": [
         "@hyperion/hook/src/Channel",
+        "@hyperion/hyperion-autologging/src/ALFlowletManager",
         "@hyperion/hyperion-autologging/src/ALSurface",
+        "@hyperion/hyperion-autologging/src/ALSurfaceContext",
         "@hyperion/hyperion-autologging/src/ALInteractableDOMElement",
         "@hyperion/hyperion-autologging/src/AutoLogging",
       ]

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,8 @@
  */
 
 
+
+
 // hyperionCore
 export { getVirtualPropertyValue, setVirtualPropertyValue } from "@hyperion/hyperion-core/src/intercept";
 export { interceptFunction } from "@hyperion/hyperion-core/src/FunctionInterceptor";
@@ -32,6 +34,8 @@ export * as IReact from "@hyperion/hyperion-react/src/IReact";
 export * as IReactDOM from "@hyperion/hyperion-react/src/IReactDOM";
 
 // hyperionAutoLogging
+export { Channel } from "@hyperion/hook/src/Channel";
+export { ALFlowlet, ALFlowletManager } from "@hyperion/hyperion-autologging/src/ALFlowletManager";
+export { useALSurfaceContext } from "@hyperion/hyperion-autologging/src/ALSurfaceContext";
 export * as ALInteractableDOMElement from "@hyperion/hyperion-autologging/src/ALInteractableDOMElement";
 export * as AutoLogging from "@hyperion/hyperion-autologging/src/AutoLogging";
-export { Channel } from "@hyperion/hook/src/Channel";


### PR DESCRIPTION
This will eliminate the need for other apps to define their own and can simply instanciate an `ALFlowletManager` if they don't have other data to be stored in flowlet.