### PR TITLE
Propagate elementName extracted in capture

### DIFF
--- a/packages/hyperion-autologging/src/ALUIEventPublisher.ts
+++ b/packages/hyperion-autologging/src/ALUIEventPublisher.ts
@@ -18,17 +18,17 @@ import { AUTO_LOGGING_SURFACE } from "./ALSurfaceConsts";
 export type ALUIEvent = Readonly<{
   event: string,
   element: Element,
+  elementName?: string | null,
   isTrusted: boolean,
 }>;
 
 export type ALUIEventCaptureData = Readonly<
   ALUIEvent &
   ALReactElementEvent &
+  ALFlowletEvent &
   {
-    flowlet: ALFlowlet,
     captureTimestamp: number,
     surface: string | null,
-    elementName: string | null,
     autoLoggingID: ALID
   }
 >;
@@ -172,7 +172,7 @@ export function publish(options: InitOptions): void {
   });
 
   function updateLastUIEvent(eventData: ALUIEventCaptureData) {
-    const { event, captureTimestamp, element, isTrusted, reactComponentName, reactComponentStack } = eventData;
+    const { event, captureTimestamp, element, elementName, isTrusted, reactComponentName, reactComponentStack } = eventData;
 
     if (lastUIEvent != null) {
       const { timedEmitter } = lastUIEvent;
@@ -182,6 +182,7 @@ export function publish(options: InitOptions): void {
     const data: ALUIEventData = {
       event,
       element,
+      elementName,
       eventTimestamp: captureTimestamp,
       autoLoggingID: getOrSetAutoLoggingID(element),
       flowlet,


### PR DESCRIPTION
We extract elementName in the capture phase of the UI event publisher but it's ultimately dropped when publishing al_ui_event.  Propagate the lookup when the element is still available so that subscribers don't have to look it up again, where potentially the element may no longer be available or name has been mutated after the initial action.