### PR TITLE
Separate eventIndex from UI events

### DIFF
--- a/packages/hyperion-autologging/src/ALType.ts
+++ b/packages/hyperion-autologging/src/ALType.ts
@@ -10,9 +10,23 @@ export type ALFlowletEvent = Readonly<{
   flowlet: ALFlowlet;
 }>;
 
-export type ALLoggableEvent = Readonly<{
-  eventIndex: number,
+export type ALTimedEvent = Readonly<{
   eventTimestamp: number,
+}>;
+
+/**
+ * Generally we will have publishers that generate various events.
+ * In some cases, the event is final and we want that to be logged eventually.
+ * In such cases, we need to add an eventIndex to keep track events.
+ * 
+ * In some cases, publisher may generate an event but there is an expectation
+ * that applications may fileter some of them out (e.g. network, mousemove, ...)
+ * In such cases, the publishers should use the ALEvent base type instead
+ * for their events to signal to the subscribers that they need to add extra
+ * information as needed.
+ */
+export type ALLoggableEvent = ALTimedEvent & Readonly<{
+  eventIndex: number,
 }>;
 
 export type ALReactElementEvent = Readonly<{

--- a/packages/hyperion-autologging/src/ALUIEventPublisher.ts
+++ b/packages/hyperion-autologging/src/ALUIEventPublisher.ts
@@ -4,16 +4,16 @@
 
 'use strict';
 import { Channel } from "@hyperion/hook/src/Channel";
-import { ALID, getOrSetAutoLoggingID } from "./ALID";
+import performanceAbsoluteNow from "@hyperion/hyperion-util/src/performanceAbsoluteNow";
 import { TimedTrigger } from "@hyperion/hyperion-util/src/TimedTrigger";
 import * as Types from "@hyperion/hyperion-util/src/Types";
+import { ALFlowlet, ALFlowletManager } from "./ALFlowletManager";
+import { ALID, getOrSetAutoLoggingID } from "./ALID";
 import { getElementName, getInteractable, trackInteractable } from "./ALInteractableDOMElement";
-import { ALFlowletManager, ALFlowlet } from "./ALFlowletManager";
-import { getSurfacePath } from "./ALSurfaceUtils";
-import performanceAbsoluteNow from "@hyperion/hyperion-util/src/performanceAbsoluteNow";
-import { ALFlowletEvent, ALLoggableEvent, ALReactElementEvent } from "./ALType";
 import { ComponentNameValidator, getReactComponentData_THIS_CAN_BREAK, ReactComponentData } from "./ALReactUtils";
 import { AUTO_LOGGING_SURFACE } from "./ALSurfaceConsts";
+import { getSurfacePath } from "./ALSurfaceUtils";
+import { ALFlowletEvent, ALReactElementEvent, ALTimedEvent } from "./ALType";
 
 export type ALUIEvent = Readonly<{
   event: string,
@@ -24,6 +24,7 @@ export type ALUIEvent = Readonly<{
 
 export type ALUIEventCaptureData = Readonly<
   ALUIEvent &
+  ALFlowletEvent &
   ALReactElementEvent &
   ALFlowletEvent &
   {
@@ -41,9 +42,9 @@ export type ALUIEventBubbleData = Readonly<
 >;
 
 type ALLoggableUIEvent = Readonly<
+  ALTimedEvent &
   ALUIEvent &
   ALFlowletEvent &
-  ALLoggableEvent &
   ALReactElementEvent &
   {
     autoLoggingID: ALID,
@@ -187,12 +188,6 @@ export function publish(options: InitOptions): void {
       autoLoggingID: getOrSetAutoLoggingID(element),
       flowlet,
       isTrusted,
-      /**
-       * eventIndex will be overridden in the subscriber, we are passing in a value here because
-       * Flow requires it but because some al_ui_events will be filtered out before emitting
-       * events to Falco, we can't generate the event_index here
-       */
-      eventIndex: 0,
       reactComponentName,
       reactComponentStack,
     };

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -45,6 +45,7 @@ export default defineConfig({
         "@hyperion/hyperion-autologging/src/ALFlowletManager",
         "@hyperion/hyperion-autologging/src/ALSurface",
         "@hyperion/hyperion-autologging/src/ALSurfaceContext",
+        "@hyperion/hyperion-autologging/src/ALEventIndex",
         "@hyperion/hyperion-autologging/src/ALInteractableDOMElement",
         "@hyperion/hyperion-autologging/src/AutoLogging",
       ]

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,5 +37,6 @@ export * as IReactDOM from "@hyperion/hyperion-react/src/IReactDOM";
 export { Channel } from "@hyperion/hook/src/Channel";
 export { ALFlowlet, ALFlowletManager } from "@hyperion/hyperion-autologging/src/ALFlowletManager";
 export { useALSurfaceContext } from "@hyperion/hyperion-autologging/src/ALSurfaceContext";
+export * as ALEventIndex from "@hyperion/hyperion-autologging/src/ALEventIndex";
 export * as ALInteractableDOMElement from "@hyperion/hyperion-autologging/src/ALInteractableDOMElement";
 export * as AutoLogging from "@hyperion/hyperion-autologging/src/AutoLogging";


### PR DESCRIPTION
Since a lot of UI events might be filtered by subscribers before they are logged, this commit removes that field from the events.

Other 'finalzied' events can continue to generate eventIndex.

Also, exported the `ALEventIndex` module to allow external tools use it.