### PR TITLE
Add surface to al_ui_event

### DIFF
--- a/packages/hyperion-autologging/src/ALUIEventPublisher.ts
+++ b/packages/hyperion-autologging/src/ALUIEventPublisher.ts
@@ -48,7 +48,7 @@ type ALLoggableUIEvent = Readonly<
   ALReactElementEvent &
   {
     autoLoggingID: ALID,
-    surface?: string,
+    surface?: string | null,
   }
 >;
 

--- a/packages/hyperion-autologging/src/ALUIEventPublisher.ts
+++ b/packages/hyperion-autologging/src/ALUIEventPublisher.ts
@@ -173,7 +173,7 @@ export function publish(options: InitOptions): void {
   });
 
   function updateLastUIEvent(eventData: ALUIEventCaptureData) {
-    const { event, captureTimestamp, element, elementName, isTrusted, reactComponentName, reactComponentStack } = eventData;
+    const { event, captureTimestamp, element, elementName, isTrusted, reactComponentName, reactComponentStack, surface } = eventData;
 
     if (lastUIEvent != null) {
       const { timedEmitter } = lastUIEvent;
@@ -190,6 +190,7 @@ export function publish(options: InitOptions): void {
       isTrusted,
       reactComponentName,
       reactComponentStack,
+      surface,
     };
 
     lastUIEvent = {


### PR DESCRIPTION
[ALUIEventData looks like it should have surface provided](https://github.com/facebook/hyperion/blob/main/packages/hyperion-autologging/src/ALUIEventPublisher.ts#L51) but it doesn't currently do this.

I'm just passing it through from the ALUIEventCaptureData.