### PR TITLE
Adds basic ALElementInfo for caching element react info, and potentia…

### DIFF
--- a/packages/hyperion-autologging/src/ALElementInfo.ts
+++ b/packages/hyperion-autologging/src/ALElementInfo.ts
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved.
+ */
+
+'use strict';
+
+import { ComponentNameValidator, defaultComponentNameValidator, getReactComponentData_THIS_CAN_BREAK } from './ALReactUtils';
+import type { ReactComponentData } from './ALReactUtils';
+import { getVirtualPropertyValue, setVirtualPropertyValue } from '@hyperion/hyperion-core/src/intercept';
+
+const AL_ELEMENT_INFO_PROPNAME = '__alInfo';
+const AUTO_LOGGING_COMPONENT_TYPE = 'data-auto-logging-component-type';
+
+export default class ALElementInfo {
+  element: Element;
+  private reactComponentData: ReactComponentData | null = null;
+  private reactComponentType: string | null = null;
+  private componentNameValidator: ComponentNameValidator = defaultComponentNameValidator;
+
+  constructor(
+    element: Element,
+    componentNameValidator?: ComponentNameValidator,
+  ) {
+    this.element = element;
+    setVirtualPropertyValue(
+      element,
+      AL_ELEMENT_INFO_PROPNAME,
+      this,
+    );
+
+    this.componentNameValidator = componentNameValidator ?? this.componentNameValidator;
+    this._cacheInfo();
+  }
+
+  _cacheInfo(): void {
+    this.getReactComponentData();
+    this.getReactComponentType();
+  }
+
+  static get(element: Element): ALElementInfo | undefined {
+    return getVirtualPropertyValue<ALElementInfo>(
+      element,
+      AL_ELEMENT_INFO_PROPNAME,
+    );
+  }
+
+  static getOrCreate(element: Element, componentNameValidator?: ComponentNameValidator): ALElementInfo {
+    return ALElementInfo.get(element) ?? new ALElementInfo(element, componentNameValidator);
+  }
+
+  getReactComponentData(): ReactComponentData | null {
+    if (!this.reactComponentData) {
+      this.reactComponentData = getReactComponentData_THIS_CAN_BREAK(
+        this.element,
+        this.componentNameValidator,
+      );
+    }
+    return this.reactComponentData;
+  }
+
+  getReactComponentType(): string | null {
+    if (!this.reactComponentType) {
+      this.reactComponentType = this.element.getAttribute(AUTO_LOGGING_COMPONENT_TYPE);
+    }
+    return this.reactComponentType;
+  }
+}

--- a/packages/hyperion-autologging/src/ALElementInfo.ts
+++ b/packages/hyperion-autologging/src/ALElementInfo.ts
@@ -11,15 +11,24 @@ import { getVirtualPropertyValue, setVirtualPropertyValue } from '@hyperion/hype
 const AL_ELEMENT_INFO_PROPNAME = '__alInfo';
 const AUTO_LOGGING_COMPONENT_TYPE = 'data-auto-logging-component-type';
 
-export default class ALElementInfo {
+let componentNameValidator: ComponentNameValidator = defaultComponentNameValidator;
+/**
+ * Set a component validator function to use when extracting
+ * a component name for the event, utilized in ALElementInfo.
+ * The stack will remain unfiltered, but component name linked must be valid via validator.
+ * @param validator: callable passed a component name returning true if valid
+ */
+export function setComponentNameValidator(validator: ComponentNameValidator): void {
+  componentNameValidator = validator;
+}
+
+export class ALElementInfo {
   element: Element;
   private reactComponentData: ReactComponentData | null = null;
   private reactComponentType: string | null = null;
-  private componentNameValidator: ComponentNameValidator = defaultComponentNameValidator;
 
   constructor(
-    element: Element,
-    componentNameValidator?: ComponentNameValidator,
+    element: Element
   ) {
     this.element = element;
     setVirtualPropertyValue(
@@ -27,8 +36,6 @@ export default class ALElementInfo {
       AL_ELEMENT_INFO_PROPNAME,
       this,
     );
-
-    this.componentNameValidator = componentNameValidator ?? this.componentNameValidator;
     this._cacheInfo();
   }
 
@@ -44,15 +51,15 @@ export default class ALElementInfo {
     );
   }
 
-  static getOrCreate(element: Element, componentNameValidator?: ComponentNameValidator): ALElementInfo {
-    return ALElementInfo.get(element) ?? new ALElementInfo(element, componentNameValidator);
+  static getOrCreate(element: Element): ALElementInfo {
+    return ALElementInfo.get(element) ?? new ALElementInfo(element);
   }
 
   getReactComponentData(): ReactComponentData | null {
     if (!this.reactComponentData) {
       this.reactComponentData = getReactComponentData_THIS_CAN_BREAK(
         this.element,
-        this.componentNameValidator,
+        componentNameValidator,
       );
     }
     return this.reactComponentData;

--- a/packages/hyperion-autologging/src/ALReactUtils.ts
+++ b/packages/hyperion-autologging/src/ALReactUtils.ts
@@ -11,7 +11,7 @@ export type ReactComponentData = Readonly<{
 
 export type ComponentNameValidator = (name: string) => boolean;
 
-const defaultComponentNameValidator: ComponentNameValidator = (_: string) => {
+export const defaultComponentNameValidator: ComponentNameValidator = (_: string) => {
   return true;
 };
 

--- a/packages/hyperion-autologging/src/ALSurfaceMutationPublisher.ts
+++ b/packages/hyperion-autologging/src/ALSurfaceMutationPublisher.ts
@@ -16,7 +16,7 @@ import performanceAbsoluteNow from '@hyperion/hyperion-util/src/performanceAbsol
 import { ComponentNameValidator, defaultComponentNameValidator, ReactComponentData } from './ALReactUtils';
 import { AUTO_LOGGING_SURFACE } from './ALSurfaceConsts';
 import { getElementName } from './ALInteractableDOMElement';
-import ALElementInfo from './ALElementInfo';
+import { setComponentNameValidator, ALElementInfo } from './ALElementInfo';
 
 type ALMutationEvent = ALReactElementEvent & Readonly<{
   event: 'mount_component' | 'unmount_component';
@@ -61,6 +61,8 @@ export type InitOptions = Types.Options<{
 export function publish(options: InitOptions): void {
   const { domSurfaceAttributeName = AUTO_LOGGING_SURFACE, channel, flowletManager, cacheElementReactInfo, componentNameValidator = defaultComponentNameValidator } = options;
 
+  setComponentNameValidator(componentNameValidator);
+
   function processNode(node: Node, action: 'added' | 'removed') {
     const timestamp = performanceAbsoluteNow();
 
@@ -79,7 +81,7 @@ export function publish(options: InitOptions): void {
           let reactComponentData: ReactComponentData | null = null;
           let elementName: string | null = null;
           if (cacheElementReactInfo) {
-            const elementInfo = ALElementInfo.getOrCreate(node, componentNameValidator);
+            const elementInfo = ALElementInfo.getOrCreate(node);
             reactComponentData = elementInfo.getReactComponentData();
             elementName = getElementName(node);
           }

--- a/packages/hyperion-autologging/src/ALSurfaceMutationPublisher.ts
+++ b/packages/hyperion-autologging/src/ALSurfaceMutationPublisher.ts
@@ -13,9 +13,10 @@ import { ALFlowlet, ALFlowletManager } from "./ALFlowletManager";
 import * as ALID from './ALID';
 import * as ALEventIndex from './ALEventIndex';
 import performanceAbsoluteNow from '@hyperion/hyperion-util/src/performanceAbsoluteNow';
-import { ComponentNameValidator, getReactComponentData_THIS_CAN_BREAK, ReactComponentData } from './ALReactUtils';
+import { ComponentNameValidator, defaultComponentNameValidator, ReactComponentData } from './ALReactUtils';
 import { AUTO_LOGGING_SURFACE } from './ALSurfaceConsts';
 import { getElementName } from './ALInteractableDOMElement';
+import ALElementInfo from './ALElementInfo';
 
 type ALMutationEvent = ALReactElementEvent & Readonly<{
   event: 'mount_component' | 'unmount_component';
@@ -58,7 +59,7 @@ export type InitOptions = Types.Options<{
 }>;
 
 export function publish(options: InitOptions): void {
-  const { domSurfaceAttributeName = AUTO_LOGGING_SURFACE, channel, flowletManager, cacheElementReactInfo, componentNameValidator = null } = options;
+  const { domSurfaceAttributeName = AUTO_LOGGING_SURFACE, channel, flowletManager, cacheElementReactInfo, componentNameValidator = defaultComponentNameValidator } = options;
 
   function processNode(node: Node, action: 'added' | 'removed') {
     const timestamp = performanceAbsoluteNow();
@@ -78,7 +79,8 @@ export function publish(options: InitOptions): void {
           let reactComponentData: ReactComponentData | null = null;
           let elementName: string | null = null;
           if (cacheElementReactInfo) {
-            reactComponentData = getReactComponentData_THIS_CAN_BREAK(node, componentNameValidator);
+            const elementInfo = ALElementInfo.getOrCreate(node, componentNameValidator);
+            reactComponentData = elementInfo.getReactComponentData();
             elementName = getElementName(node);
           }
           info = {

--- a/packages/hyperion-autologging/src/ALSurfaceUtils.ts
+++ b/packages/hyperion-autologging/src/ALSurfaceUtils.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved.
+ */
+
+'use strict';
+
 export function getSurfacePath(node: HTMLElement | null, domSurfaceAttributeName: string): string| null {
   const domSurfaceSelector = `[${domSurfaceAttributeName}]`;
   return getAncestralSurfaceNode(node, domSurfaceSelector)?.getAttribute(domSurfaceAttributeName) ?? null;

--- a/packages/hyperion-autologging/src/ALUIEventPublisher.ts
+++ b/packages/hyperion-autologging/src/ALUIEventPublisher.ts
@@ -14,7 +14,7 @@ import { ComponentNameValidator, defaultComponentNameValidator, ReactComponentDa
 import { AUTO_LOGGING_SURFACE } from "./ALSurfaceConsts";
 import { getSurfacePath } from "./ALSurfaceUtils";
 import { ALFlowletEvent, ALReactElementEvent, ALTimedEvent } from "./ALType";
-import ALElementInfo from './ALElementInfo';
+import { setComponentNameValidator, ALElementInfo } from './ALElementInfo';
 
 export type ALUIEvent = Readonly<{
   event: string,
@@ -85,6 +85,8 @@ export type InitOptions = Types.Options<{
 export function publish(options: InitOptions): void {
   const { uiEvents, flowletManager, channel, domSurfaceAttributeName = AUTO_LOGGING_SURFACE, cacheElementReactInfo, componentNameValidator = defaultComponentNameValidator } = options;
 
+  setComponentNameValidator(componentNameValidator);
+
   const newEventsToPublish = uiEvents.filter(
     event => !PUBLISHED_EVENTS.has(event),
   );
@@ -120,7 +122,7 @@ export function publish(options: InitOptions): void {
       }
       let reactComponentData: ReactComponentData | null = null;
       if (cacheElementReactInfo) {
-        const elementInfo = ALElementInfo.getOrCreate(element, componentNameValidator);
+        const elementInfo = ALElementInfo.getOrCreate(element);
         reactComponentData = elementInfo.getReactComponentData();
       }
       const eventData: ALUIEventCaptureData = {
@@ -190,7 +192,6 @@ export function publish(options: InitOptions): void {
       autoLoggingID: getOrSetAutoLoggingID(element),
       flowlet,
       isTrusted,
-      surface,
       reactComponentName,
       reactComponentStack,
       surface,

--- a/packages/hyperion-autologging/src/ALUIEventPublisher.ts
+++ b/packages/hyperion-autologging/src/ALUIEventPublisher.ts
@@ -10,10 +10,11 @@ import * as Types from "@hyperion/hyperion-util/src/Types";
 import { ALFlowlet, ALFlowletManager } from "./ALFlowletManager";
 import { ALID, getOrSetAutoLoggingID } from "./ALID";
 import { getElementName, getInteractable, trackInteractable } from "./ALInteractableDOMElement";
-import { ComponentNameValidator, getReactComponentData_THIS_CAN_BREAK, ReactComponentData } from "./ALReactUtils";
+import { ComponentNameValidator, defaultComponentNameValidator, ReactComponentData } from "./ALReactUtils";
 import { AUTO_LOGGING_SURFACE } from "./ALSurfaceConsts";
 import { getSurfacePath } from "./ALSurfaceUtils";
 import { ALFlowletEvent, ALReactElementEvent, ALTimedEvent } from "./ALType";
+import ALElementInfo from './ALElementInfo';
 
 export type ALUIEvent = Readonly<{
   event: string,
@@ -82,7 +83,7 @@ export type InitOptions = Types.Options<{
 }>;
 
 export function publish(options: InitOptions): void {
-  const { uiEvents, flowletManager, channel, domSurfaceAttributeName = AUTO_LOGGING_SURFACE, cacheElementReactInfo, componentNameValidator = null } = options;
+  const { uiEvents, flowletManager, channel, domSurfaceAttributeName = AUTO_LOGGING_SURFACE, cacheElementReactInfo, componentNameValidator = defaultComponentNameValidator } = options;
 
   const newEventsToPublish = uiEvents.filter(
     event => !PUBLISHED_EVENTS.has(event),
@@ -119,7 +120,8 @@ export function publish(options: InitOptions): void {
       }
       let reactComponentData: ReactComponentData | null = null;
       if (cacheElementReactInfo) {
-        reactComponentData = getReactComponentData_THIS_CAN_BREAK(element, componentNameValidator);
+        const elementInfo = ALElementInfo.getOrCreate(element, componentNameValidator);
+        reactComponentData = elementInfo.getReactComponentData();
       }
       const eventData: ALUIEventCaptureData = {
         event: eventName,
@@ -188,6 +190,7 @@ export function publish(options: InitOptions): void {
       autoLoggingID: getOrSetAutoLoggingID(element),
       flowlet,
       isTrusted,
+      surface,
       reactComponentName,
       reactComponentStack,
       surface,


### PR DESCRIPTION
…lly other expensive operations down the line

- Also included, propagate surface that is looked up in capture, but not emitted in ui event
- Add missing copyright
- Update usage of cache react info to use elementinfo
	- if some other operation needs access to the same element info it can be cached across event types with virtual prop,  or in the case of double clicking the same button we now will only incur one lookup for component info
	  - On the other hand, if the stack is updated we get stale info