### PR TITLE
Fixed the type of MutationEvent

### DIFF
--- a/packages/hyperion-autologging/src/ALSurfaceMutationPublisher.ts
+++ b/packages/hyperion-autologging/src/ALSurfaceMutationPublisher.ts
@@ -20,10 +20,12 @@ import ALElementInfo from './ALElementInfo';
 
 type ALMutationEvent = ALReactElementEvent & Readonly<{
   event: 'mount_component' | 'unmount_component';
-  element: HTMLElement,
-  elementName: string | null,
+  surface: string;
+  element: HTMLElement;
+  elementName: string | null;
   mountedDuration?: number;
   flowlet?: ALFlowlet | null;
+  autoLoggingID: ALID.ALID;
 }>;
 
 export type ALSurfaceMutationEventData = Readonly<

--- a/packages/hyperion-react-testapp/src/IReact.ts
+++ b/packages/hyperion-react-testapp/src/IReact.ts
@@ -59,19 +59,16 @@ export function init() {
     }
   });
 
-  channel.on('al_surface_mount').add(ev => {
-    console.log('surface_mount', ev, performance.now());
-  });
-  channel.on('al_surface_unmount').add(ev => {
-    console.log('surface_unmount', ev, performance.now());
-  });
-  channel.on('al_ui_event').add(ev => {
-    console.log('ui_event', ev, performance.now());
-  });
-  channel.on('al_heartbeat_event').add(ev => {
-    console.log('heartbeat', ev, performance.now());
-  });
-  channel.on('al_surface_mutation_event').add(ev => {
-    console.log('surface_mutation_event', ev, performance.now());
+  ([
+    'al_surface_mount',
+    'al_surface_unmount',
+    'al_ui_event',
+    'al_heartbeat_event',
+    'al_surface_mutation_event',
+  ] as const).forEach(eventName => {
+    channel.on(eventName).add(ev => {
+      console.log(eventName, ev, performance.now());
+    });
+
   });
 }


### PR DESCRIPTION
Some field were missing in the type, although the module actually reports them.
Since TS is using structural-typing, it won't give an error if 'extra' fields are passed to an object.