### PR TITLE
Sepearete shared init options

### DIFF
--- a/packages/hyperion-autologging/src/ALSurface.ts
+++ b/packages/hyperion-autologging/src/ALSurface.ts
@@ -19,6 +19,7 @@ import { AUTO_LOGGING_SURFACE } from './ALSurfaceConsts';
 import * as ALSurfaceContext from "./ALSurfaceContext";
 import type { SurfacePropsExtension } from "./ALSurfacePropsExtension";
 import * as SurfaceProxy from "./ALSurfaceProxy";
+import { ALSharedInitOptions } from "./ALType";
 
 
 type ALChannelSurfaceData = Readonly<{
@@ -56,6 +57,7 @@ export type SurfaceComponent = (props: IReactPropsExtension.ExtendedProps<Surfac
 ) => React.ReactElement;
 
 export type InitOptions = Types.Options<
+  ALSharedInitOptions &
   IReactFlowlet.InitOptions<ALFlowletDataType, FlowletType, FlowletManagerType> &
   ALSurfaceContext.InitOptions &
   SurfaceProxy.InitOptions &
@@ -66,8 +68,6 @@ export type InitOptions = Types.Options<
     };
     IReactModule: IReact.IReactModuleExports;
     IJsxRuntimeModule: IReact.IJsxRuntimeModuleExports;
-    flowletManager: FlowletManagerType;
-    domSurfaceAttributeName?: string;
     domFlowletAttributeName?: string;
     channel: ALChannel,
   }

--- a/packages/hyperion-autologging/src/ALSurfaceMutationPublisher.ts
+++ b/packages/hyperion-autologging/src/ALSurfaceMutationPublisher.ts
@@ -4,19 +4,18 @@
 
 'use strict';
 
-import type { ALChannelSurfaceEvent } from './ALSurface';
 import type { Channel } from "@hyperion/hook/src/Channel";
 import * as Types from "@hyperion/hyperion-util/src/Types";
-import { ALLoggableEvent, ALReactElementEvent } from "./ALType";
+import type { ALChannelSurfaceEvent } from './ALSurface';
+import { ALLoggableEvent, ALReactElementEvent, ALSharedInitOptions } from "./ALType";
 
-import { ALFlowlet, ALFlowletManager } from "./ALFlowletManager";
-import * as ALID from './ALID';
-import * as ALEventIndex from './ALEventIndex';
 import performanceAbsoluteNow from '@hyperion/hyperion-util/src/performanceAbsoluteNow';
-import { ComponentNameValidator, defaultComponentNameValidator, ReactComponentData, setComponentNameValidator } from './ALReactUtils';
-import { AUTO_LOGGING_SURFACE } from './ALSurfaceConsts';
-import { getElementName } from './ALInteractableDOMElement';
 import ALElementInfo from './ALElementInfo';
+import * as ALEventIndex from './ALEventIndex';
+import { ALFlowlet } from "./ALFlowletManager";
+import * as ALID from './ALID';
+import { getElementName } from './ALInteractableDOMElement';
+import { ReactComponentData } from './ALReactUtils';
 
 type ALMutationEvent = ALReactElementEvent & Readonly<{
   event: 'mount_component' | 'unmount_component';
@@ -52,18 +51,15 @@ type SurfaceInfo = ALReactElementEvent & {
 
 const activeSurfaces = new Map<string, SurfaceInfo>();
 
-export type InitOptions = Types.Options<{
-  channel: ALSurfaceMutationChannel;
-  flowletManager: ALFlowletManager;
-  cacheElementReactInfo: boolean;
-  domSurfaceAttributeName?: string;
-  componentNameValidator?: ComponentNameValidator;
-}>;
+export type InitOptions = Types.Options<
+  ALSharedInitOptions & {
+    channel: ALSurfaceMutationChannel;
+    cacheElementReactInfo: boolean;
+  }
+>;
 
 export function publish(options: InitOptions): void {
-  const { domSurfaceAttributeName = AUTO_LOGGING_SURFACE, channel, flowletManager, cacheElementReactInfo, componentNameValidator = defaultComponentNameValidator } = options;
-
-  setComponentNameValidator(componentNameValidator);
+  const { domSurfaceAttributeName, channel, flowletManager, cacheElementReactInfo } = options;
 
   function processNode(node: Node, action: 'added' | 'removed') {
     const timestamp = performanceAbsoluteNow();

--- a/packages/hyperion-autologging/src/ALType.ts
+++ b/packages/hyperion-autologging/src/ALType.ts
@@ -4,7 +4,8 @@
 
 'use strict';
 
-import { ALFlowlet } from './ALFlowletManager';
+import * as Types from "@hyperion/hyperion-util/src/Types";
+import { ALFlowlet, ALFlowletManager } from './ALFlowletManager';
 
 export type ALFlowletEvent = Readonly<{
   flowlet: ALFlowlet;
@@ -32,4 +33,9 @@ export type ALLoggableEvent = ALTimedEvent & Readonly<{
 export type ALReactElementEvent = Readonly<{
   reactComponentName?: string | null,
   reactComponentStack?: string[] | null,
+}>;
+
+export type ALSharedInitOptions = Types.Options<{
+  flowletManager: ALFlowletManager;
+  domSurfaceAttributeName: string;
 }>;

--- a/packages/hyperion-autologging/src/ALUIEventPublisher.ts
+++ b/packages/hyperion-autologging/src/ALUIEventPublisher.ts
@@ -7,14 +7,13 @@ import { Channel } from "@hyperion/hook/src/Channel";
 import performanceAbsoluteNow from "@hyperion/hyperion-util/src/performanceAbsoluteNow";
 import { TimedTrigger } from "@hyperion/hyperion-util/src/TimedTrigger";
 import * as Types from "@hyperion/hyperion-util/src/Types";
-import { ALFlowlet, ALFlowletManager } from "./ALFlowletManager";
+import ALElementInfo from './ALElementInfo';
+import { ALFlowlet } from "./ALFlowletManager";
 import { ALID, getOrSetAutoLoggingID } from "./ALID";
 import { getElementName, getInteractable, trackInteractable } from "./ALInteractableDOMElement";
-import { ComponentNameValidator, defaultComponentNameValidator, ReactComponentData, setComponentNameValidator } from "./ALReactUtils";
-import { AUTO_LOGGING_SURFACE } from "./ALSurfaceConsts";
+import { ReactComponentData } from "./ALReactUtils";
 import { getSurfacePath } from "./ALSurfaceUtils";
-import { ALFlowletEvent, ALReactElementEvent, ALTimedEvent } from "./ALType";
-import ALElementInfo from './ALElementInfo';
+import { ALFlowletEvent, ALReactElementEvent, ALSharedInitOptions, ALTimedEvent } from "./ALType";
 
 export type ALUIEvent = Readonly<{
   event: string,
@@ -73,19 +72,18 @@ type CurrentUIEvent = {
 const PUBLISHED_EVENTS = new Set<string>();
 type ALChannel = Channel<ALChannelUIEvent>;
 
-export type InitOptions = Types.Options<{
-  uiEvents: Array<string>;
-  flowletManager: ALFlowletManager;
-  channel: ALChannel;
-  cacheElementReactInfo: boolean;
-  domSurfaceAttributeName?: string;
-  componentNameValidator?: ComponentNameValidator;
-}>;
+export type InitOptions = Types.Options<
+  ALSharedInitOptions &
+  {
+    uiEvents: Array<string>;
+    channel: ALChannel;
+    cacheElementReactInfo: boolean;
+  }
+>;
 
 export function publish(options: InitOptions): void {
-  const { uiEvents, flowletManager, channel, domSurfaceAttributeName = AUTO_LOGGING_SURFACE, cacheElementReactInfo, componentNameValidator = defaultComponentNameValidator } = options;
+  const { uiEvents, flowletManager, channel, domSurfaceAttributeName, cacheElementReactInfo } = options;
 
-  setComponentNameValidator(componentNameValidator);
 
   const newEventsToPublish = uiEvents.filter(
     event => !PUBLISHED_EVENTS.has(event),

--- a/packages/hyperion-react-testapp/src/IReact.ts
+++ b/packages/hyperion-react-testapp/src/IReact.ts
@@ -30,20 +30,19 @@ export function init() {
   const testCompValidator = (name: string) => !name.match(/(^Surface(Proxy)?)/);
 
   AutoLogging.init({
+    flowletManager: FlowletManager,
+    domSurfaceAttributeName: 'data-surfaceid',
+    componentNameValidator: testCompValidator,
     surface: {
       ReactModule: React as any,
       IReactDOMModule,
       IReactModule,
       IJsxRuntimeModule,
-      flowletManager: FlowletManager,
       channel,
-      domSurfaceAttributeName: 'data-surfaceid'
     },
     uiEventPublisher: {
       uiEvents: ['click'],
-      flowletManager: FlowletManager,
       cacheElementReactInfo: true,
-      componentNameValidator: testCompValidator,
       channel
     },
     heartbeat: {
@@ -52,10 +51,7 @@ export function init() {
     },
     surfaceMutationPublisher: {
       channel,
-      flowletManager: FlowletManager,
       cacheElementReactInfo: true,
-      componentNameValidator: testCompValidator,
-      domSurfaceAttributeName: 'data-surfaceid',
     }
   });
 


### PR DESCRIPTION
In order to make sure some shared init options are not having different values for different features, separated them into a single place for the `AutoLogging.init`.