### PR TITLE
Simplify the AutoLogging.init to prevent confusion.

### DIFF
--- a/packages/hyperion-autologging/src/AutoLogging.ts
+++ b/packages/hyperion-autologging/src/AutoLogging.ts
@@ -47,9 +47,14 @@ export type InitResults = Readonly<{
 
 let cachedResults: InitResults | null = null;
 
-export function init(options: InitOptions): InitResults {
+/**
+ * 
+ * @param options enables various features with their own init option
+ * @returns true if initilized (the first time) or false if it is already initialized.
+ */
+export function init(options: InitOptions): boolean {
   if (cachedResults !== null) {
-    return cachedResults;
+    return false;
   }
 
   if (options.componentNameValidator) {
@@ -93,7 +98,7 @@ export function init(options: InitOptions): InitResults {
     }),
   };
 
-  return cachedResults;
+  return true;
 }
 
 export function getSurfaceRenderer(defaultALSurfaceHOC?: ALSurface.ALSurfaceHOC): ALSurface.ALSurfaceHOC {


### PR DESCRIPTION
It seems like returning cached results for `.init` function sometimes causes confusion. It is better to have only one way to get that results, (e.g. via `getSurfaceRenderer()` function.

The new signature returns a boolean to signal if AutoLogging was already initialized. That way, shared components in various applications can try to eagerly init logging if the application itself has not already done so.