### PR TITLE
Enable marking of network requests with flowlet name.

### DIFF
--- a/packages/hyperion-react-testapp/src/AutoLoggingWrapper.ts
+++ b/packages/hyperion-react-testapp/src/AutoLoggingWrapper.ts
@@ -56,7 +56,8 @@ export function init() {
     },
     network: {
       channel,
-      requestFilter: request => !/robots/.test(request.url.toString())
+      requestFilter: request => !/robots/.test(request.url.toString()),
+      requestFlowletMarker: 'flowlet'
     }
   });
 

--- a/packages/hyperion-react-testapp/src/AutoLoggingWrapper.ts
+++ b/packages/hyperion-react-testapp/src/AutoLoggingWrapper.ts
@@ -57,7 +57,12 @@ export function init() {
     network: {
       channel,
       requestFilter: request => !/robots/.test(request.url.toString()),
-      requestFlowletMarker: 'flowlet'
+      requestUrlMarker: (request, params) => {
+        const flowlet = FlowletManager.top();
+        if (flowlet) {
+          params.set('flowlet', flowlet.getFullName());
+        }
+      }
     }
   });
 

--- a/packages/hyperion-react-testapp/src/component/DynamicSvgComponent.tsx
+++ b/packages/hyperion-react-testapp/src/component/DynamicSvgComponent.tsx
@@ -22,7 +22,7 @@ export default function (/* props: Props */) {
 
   const links = [
     "https://hyperionjs.com/img/hyperion.svg",
-    "robots.txt",
+    "robots.txt?a=1",
     // "https://dev.w3.org/SVG/tools/svgweb/samples/svg-files/facebook.svg",
     // "https://www.svgrepo.com/show/4733/samples.svg",
   ];


### PR DESCRIPTION
With this commit, one can pass a query param name `requestFlowletMarker` to enable the code that adds the query param with current flowlet name to the url of the request. That way, backend services can connect the requess to what was going on in the client at the time.