### PR TITLE
Fixed the link between request/response events in fetch

### DIFF
--- a/packages/hyperion-react-testapp/src/AutoLoggingWrapper.ts
+++ b/packages/hyperion-react-testapp/src/AutoLoggingWrapper.ts
@@ -10,7 +10,6 @@ import React from 'react';
 import * as ReactDOM from "react-dom";
 import ReactDev from "react/jsx-dev-runtime";
 import { FlowletManager } from "./FlowletManager";
-
 export let interceptionStatus = "disabled";
 
 export function init() {
@@ -69,14 +68,23 @@ export function init() {
   ([
     'al_surface_mount',
     'al_surface_unmount',
-    'al_ui_event',
     'al_heartbeat_event',
-    'al_surface_mutation_event',
-    'al_network_request',
-    'al_network_response',
   ] as const).forEach(eventName => {
     channel.on(eventName).add(ev => {
       console.log(eventName, ev, performance.now());
+    });
+
+  });
+
+  ([
+    'al_ui_event',
+    'al_surface_mutation_event',
+    'al_network_request',
+    'al_network_response',
+    'al_network_response',
+  ] as const).forEach(eventName => {
+    channel.on(eventName).add(ev => {
+      console.log(eventName, ev, performance.now(), ev.flowlet?.getFullName());
     });
 
   });


### PR DESCRIPTION
Since fetch handling need several async processes to read the response value, we often lose the previous value of `requestEvent` since new versions override it.
Xhr does not have this problem because the value is one per instance of XHR.

To achieve the same effect with fetch, copied the value of `requestEvent` to the Promise instance itself. Since everytime fetch is called a new Promise instance is returned, we won't lose the `requestEvent` value in between multiple calls.