### PR TITLE
A new algorithm to track flowlets in react

### DIFF
--- a/packages/hyperion-autologging/src/ALIReactFlowlet.ts
+++ b/packages/hyperion-autologging/src/ALIReactFlowlet.ts
@@ -1,0 +1,142 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved.
+ */
+
+import TestAndSet from "@hyperion/hyperion-util/src/TestAndSet";
+
+import type * as Types from "@hyperion/hyperion-util/src/Types";
+
+import { assert } from "@hyperion/global";
+import * as IReact from "@hyperion/hyperion-react/src/IReact";
+import * as IReactComponent from "@hyperion/hyperion-react/src/IReactComponent";
+import { ALFlowlet, ALFlowletManager } from "./ALFlowletManager";
+import { ALSurfaceContext, useALSurfaceContext } from "./ALSurfaceContext";
+
+export type InitOptions<> = Types.Options<
+  IReactComponent.InitOptions &
+  {
+    IReactModule: IReact.IReactModuleExports;
+    flowletManager: ALFlowletManager;
+    disableReactFlowlet?: boolean;
+  }
+>;
+
+let initialized = new TestAndSet();
+export function init(options: InitOptions) {
+  if (initialized.testAndSet() || options.disableReactFlowlet) {
+    return;
+  }
+
+  IReactComponent.init(options);
+
+  const { flowletManager, IReactModule } = options;
+
+  [
+    IReactModule.useCallback,
+    IReactModule.useEffect,
+    IReactModule.useLayoutEffect,
+    IReactModule.useReducer
+  ].forEach(fi => {
+    fi.onArgsMapperAdd(args => {
+      args[0] = flowletManager.wrap(args[0], fi.name);
+      return args;
+    });
+  })
+
+  /**
+ * The following interceptor methods (onArgsObserver/onValueObserver) run immediately 
+ * before & after intercepted method. So, we can push before and pop after so that
+ * the body of the method has access to flowlet.
+ * For class components, we store the flowlet in the `this` object.
+ * For function components, we have to keep that value and close on it (we could use useRef)
+ */
+
+  const IS_FLOWLET_SETUP_PROP = 'isFlowletSetup';
+
+  type ComponentWithFlowlet = React.Component<any> & {
+    _flowlet?: ALFlowlet | null | undefined
+  };
+
+  IReactComponent.onReactClassComponentIntercept.add(shadowComponent => {
+    const methods = [
+      shadowComponent.render,
+      shadowComponent.componentWillMount,
+      shadowComponent.componentDidMount,
+      shadowComponent.componentWillReceiveProps,
+      shadowComponent.shouldComponentUpdate,
+      shadowComponent.componentWillUpdate,
+      shadowComponent.componentDidUpdate,
+      shadowComponent.componentWillUnmount,
+      shadowComponent.componentDidCatch,
+    ];
+
+
+    methods.forEach(method => {
+      if (method.getData<boolean>(IS_FLOWLET_SETUP_PROP)) {
+        return;
+      }
+      method.setData(IS_FLOWLET_SETUP_PROP, true);
+
+      if (method === shadowComponent.render) {
+        method.onArgsObserverAdd(function (this: ComponentWithFlowlet) {
+          /**
+              * We cannot call hooks inside of the class components.
+              * Also, a class component can only have a single context assigned to it.
+              * So, we use this internal api/hack to get the value.
+              * This is ok, because this is a best effort and anyways most people are
+              * migrating away from class components.
+              */
+          const ctx = (ALSurfaceContext as any)._currentValue; // Unofficial internal value
+          const activeFlowlet = ctx?.flowlet;
+          if (activeFlowlet) {
+            flowletManager.push(activeFlowlet);
+            this._flowlet = activeFlowlet;
+          }
+        });
+      } else {
+        method.onArgsObserverAdd(function (this: ComponentWithFlowlet) {
+          const activeFlowlet = this._flowlet;
+          if (activeFlowlet) {
+            flowletManager.push(activeFlowlet);
+          }
+        });
+      }
+
+      method.onValueObserverAdd(function (this: ComponentWithFlowlet) {
+        const activeFlowlet = this._flowlet;
+        if (activeFlowlet) {
+          flowletManager.pop(activeFlowlet);
+        }
+      });
+    });
+  });
+
+  IReactComponent.onReactFunctionComponentIntercept.add(
+    fi => {
+      if (!fi.getData<boolean>(IS_FLOWLET_SETUP_PROP)) {
+        fi.setData(IS_FLOWLET_SETUP_PROP, true);
+
+        let activeFlowlet: ALFlowlet | undefined | null;
+        fi.onArgsObserverAdd(_props => {
+          const ctx = useALSurfaceContext();
+          activeFlowlet = ctx.flowlet;
+          if (activeFlowlet) {
+            flowletManager.push(activeFlowlet)
+          }
+        });
+        fi.onValueObserverAdd(() => {
+          if (activeFlowlet) {
+            if (__DEV__) {
+              assert(
+                activeFlowlet === useALSurfaceContext().flowlet,
+                "Invalid situation! The active flowlet changed!"
+              );
+            }
+            flowletManager.pop(activeFlowlet);
+          }
+        });
+      }
+    },
+  );
+
+}

--- a/packages/hyperion-autologging/src/ALSurface.ts
+++ b/packages/hyperion-autologging/src/ALSurface.ts
@@ -11,6 +11,7 @@ import * as IReact from "@hyperion/hyperion-react/src/IReact";
 import * as IReactComponent from "@hyperion/hyperion-react/src/IReactComponent";
 import * as IReactElementVisitor from '@hyperion/hyperion-react/src/IReactElementVisitor';
 import * as IReactFlowlet from "@hyperion/hyperion-react/src/IReactFlowlet";
+import * as ALIReactFlowlet from "./ALIReactFlowlet";
 import * as IReactPropsExtension from "@hyperion/hyperion-react/src/IReactPropsExtension";
 import * as Types from "@hyperion/hyperion-util/src/Types";
 import type * as React from 'react';
@@ -58,7 +59,8 @@ export type SurfaceComponent = (props: IReactPropsExtension.ExtendedProps<Surfac
 
 export type InitOptions = Types.Options<
   ALSharedInitOptions &
-  IReactFlowlet.InitOptions<ALFlowletDataType, FlowletType, FlowletManagerType> &
+  // IReactFlowlet.InitOptions<ALFlowletDataType, FlowletType, FlowletManagerType> &
+  ALIReactFlowlet.InitOptions &
   ALSurfaceContext.InitOptions &
   SurfaceProxy.InitOptions &
   {
@@ -176,7 +178,7 @@ function setupDomElementSurfaceAttribute(options: InitOptions): void {
 export function init(options: InitOptions): ALSurfaceHOC {
   const { ReactModule, flowletManager, domSurfaceAttributeName = AUTO_LOGGING_SURFACE } = options;
 
-  IReactFlowlet.init<DataType, FlowletType, FlowletManagerType>(options); // extensionCtor
+  ALIReactFlowlet.init(options);
 
   setupDomElementSurfaceAttribute(options);
   const SurfaceContext = ALSurfaceContext.init(options);

--- a/packages/hyperion-react-testapp/src/AutoLoggingWrapper.ts
+++ b/packages/hyperion-react-testapp/src/AutoLoggingWrapper.ts
@@ -4,12 +4,14 @@
 
 import { Channel } from "@hyperion/hook/src/Channel";
 import * as AutoLogging from "@hyperion/hyperion-autologging/src/AutoLogging";
+import { initFlowletTrackers } from "@hyperion/hyperion-flowlet/src/Index";
 import * as IReact from "@hyperion/hyperion-react/src/IReact";
 import * as IReactDOM from "@hyperion/hyperion-react/src/IReactDOM";
 import React from 'react';
 import * as ReactDOM from "react-dom";
 import ReactDev from "react/jsx-dev-runtime";
 import { FlowletManager } from "./FlowletManager";
+
 export let interceptionStatus = "disabled";
 
 export function init() {
@@ -26,6 +28,8 @@ export function init() {
   channel.on("test").add((i, s) => { // Showing channel can be extend beyond expected types
 
   });
+
+  initFlowletTrackers(FlowletManager);
 
   const testCompValidator = (name: string) => !name.match(/(^Surface(Proxy)?)/);
 

--- a/packages/hyperion-react/src/IReact.ts
+++ b/packages/hyperion-react/src/IReact.ts
@@ -83,6 +83,18 @@ type JsxRuntimeModuleExports = {
 
 type ReactModuleExports = {
   createElement: typeof React.createElement;
+
+  useCallback: typeof React.useCallback;
+
+  useEffect: (effect: () => (void | (() => void)), deps?: Parameters<typeof React.useEffect>) => ReturnType<typeof React.useEffect>;
+
+  useLayoutEffect: (effect: () => (void | (() => void)), deps?: Parameters<typeof React.useEffect>) => ReturnType<typeof React.useEffect>;
+
+  useMemo: typeof React.useMemo;
+
+  useReducer: typeof React.useReducer;
+
+  forwardRef: typeof React.forwardRef;
 }
 
 export type IJsxRuntimeModuleExports = InterceptedModuleExports<JsxRuntimeModuleExports>;
@@ -120,7 +132,20 @@ export function interceptRuntime(moduleId: string, moduleExports: JsxRuntimeModu
 
 export function intercept(moduleId: string, moduleExports: ReactModuleExports, failedExportsKeys?: ModuleExportsKeys<ReactModuleExports>): IReactModuleExports {
   if (!IReactModule) {
-    IReactModule = interceptModuleExports(moduleId, moduleExports, ['createElement'], failedExportsKeys);
+    IReactModule = interceptModuleExports(
+      moduleId,
+      moduleExports,
+      [
+        'createElement',
+        'useCallback',
+        'useEffect',
+        'useLayoutEffect',
+        'useMemo',
+        'useReducer',
+        'forwardRef',
+      ],
+      failedExportsKeys
+    );
   }
   return IReactModule;
 }


### PR DESCRIPTION
Two sets of changes are included in this commit:
1- a set of common hooks that have a function callback are intercepted in react. This set is then used to ensure those callbacks carry the flowlet of the render function forward.
2- In each render function, instead of relying on the prop extensions to detect the current flowlet, we use the the SurfaceContext to use the flowlet of the current surface. This flowlet is then picked up by other lifecycle methods or hooks and propagated.

I also updated the test app to ensure the full flowlet initialization is applied for all async browser api.

Together, this new algorithm give much bigger coverage for flowlets.