### PR TITLE
Allow customizing the logger for asserts

### DIFF
--- a/packages/global/package.json
+++ b/packages/global/package.json
@@ -10,7 +10,7 @@
     "build": "tsc",
     "watch": "npm run build -- --watch",
     "start": "npm run watch",
-    "test": "jest"
+    "test": "npm run build & jest"
   },
   "workspaces": [
     "../devtools"

--- a/packages/global/src/assert.ts
+++ b/packages/global/src/assert.ts
@@ -16,6 +16,11 @@ const devOptions: Required<Options> = {
   logger: console,
 }
 
+export function setAssertLoggerOptions(options: Options): void {
+  devOptions.getCallStack = options.getCallStack ?? devOptions.getCallStack;
+  devOptions.logger = options.logger;
+}
+
 export function assert(condition: boolean | undefined, message: string, options?: Options): asserts condition {
   if (!condition) {
     const callStackGetter = options?.getCallStack ?? devOptions.getCallStack;

--- a/packages/global/test/assert.test.ts
+++ b/packages/global/test/assert.test.ts
@@ -3,7 +3,7 @@
  */
 
 import "jest";
-import { assert } from "../src/assert";
+import { setAssertLoggerOptions, assert } from "../src/assert";
 
 describe("test assert", () => {
   test("test assert message", () => {
@@ -12,4 +12,13 @@ describe("test assert", () => {
     expect(_message).toBe("test message");
   });
 
+  test("change default assert logger", () => {
+    const fn = jest.fn();
+    setAssertLoggerOptions({
+      logger: { error: fn }
+    });
+    assert(false, "test message");
+    expect(fn).toBeCalledTimes(1);
+    expect(fn.mock.calls[0][0]).toBe("test message");
+  })
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ export { Hook } from "@hyperion/hook/src/Hook";
 export { PipeableEmitter, Channel } from "@hyperion/hook/src/Channel";
 
 // hyperionCore
+export { setAssertLoggerOptions } from "@hyperion/global/src/assert";
 export { getVirtualPropertyValue, setVirtualPropertyValue } from "@hyperion/hyperion-core/src/intercept";
 export { interceptFunction } from "@hyperion/hyperion-core/src/FunctionInterceptor";
 export { interceptMethod } from "@hyperion/hyperion-core/src/MethodInterceptor";


### PR DESCRIPTION
Exposed a function to allow changing the default logger from console to anything else controlled by the app.