### PR TITLE
Added ClientSessionID that is tied to a session.

### DIFF
--- a/packages/hyperion-autologging/src/ALEventIndex.ts
+++ b/packages/hyperion-autologging/src/ALEventIndex.ts
@@ -4,8 +4,14 @@
 
 'use strict';
 
-// event index
-let _eventIndex = -1;
+import { SessionPersistentData } from "@hyperion/hyperion-util/src/SessionPersistentData";
+
+const _eventIndex = new SessionPersistentData<number>(
+  "alcei",
+  () => -1,
+  v => '' + v,
+  v => parseInt(v) || -1
+);
 
 /**
  * getEventIndex:
@@ -16,8 +22,7 @@ let _eventIndex = -1;
  * it must be consumed
  */
 export function getNextEventIndex(): number {
-  _eventIndex++;
-  return _eventIndex;
+  return _eventIndex.setValue(_eventIndex.getValue() + 1);
 }
 
 /**
@@ -25,5 +30,5 @@ export function getNextEventIndex(): number {
  * Returns the event index without incrementing, this is useful for linking to AutoLogging events externally
  */
 export function getLastUsedEventIndex(): number {
-  return _eventIndex;
+  return _eventIndex.getValue();
 }

--- a/packages/hyperion-autologging/src/ALID.ts
+++ b/packages/hyperion-autologging/src/ALID.ts
@@ -1,11 +1,13 @@
-
 /**
  * Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved.
  */
 
 'use strict';
 
-export type ALID = string;
+import type { GUID } from "@hyperion/hyperion-util/src/guid";
+import { guid } from "@hyperion/hyperion-util/src/guid";
+
+export type ALID = GUID;
 
 const AUTO_LOGGING_ID = 'data-auto-logging-id';
 
@@ -22,7 +24,3 @@ export function setAutoLoggingID(element: Element): ALID {
 export function getOrSetAutoLoggingID(element: Element): ALID {
   return getAutoLoggingID(element) ?? setAutoLoggingID(element);
 }
-function guid(): ALID {
-  return 'f' + (Math.random() * (1 << 30)).toString(16).replace('.', '');
-}
-

--- a/packages/hyperion-react-testapp/src/AutoLoggingWrapper.ts
+++ b/packages/hyperion-react-testapp/src/AutoLoggingWrapper.ts
@@ -11,6 +11,7 @@ import React from 'react';
 import * as ReactDOM from "react-dom";
 import ReactDev from "react/jsx-dev-runtime";
 import { FlowletManager } from "./FlowletManager";
+import { ClientSessionID } from "@hyperion/hyperion-util/src/ClientSessionID";
 
 export let interceptionStatus = "disabled";
 
@@ -32,6 +33,8 @@ export function init() {
   initFlowletTrackers(FlowletManager);
 
   const testCompValidator = (name: string) => !name.match(/(^Surface(Proxy)?)/);
+
+  console.log('csid:', ClientSessionID);
 
   AutoLogging.init({
     flowletManager: FlowletManager,

--- a/packages/hyperion-util/src/ClientSessionID.ts
+++ b/packages/hyperion-util/src/ClientSessionID.ts
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved.
+ */
+
+'use strict';
+
+import { SessionPersistentData } from "./SessionPersistentData";
+import { guid } from "./guid";
+
+export const ClientSessionID: string = new SessionPersistentData<string>(
+  "alcsid",
+  guid,
+  v => v,
+  v => v,
+).getValue();
+
+
+// (() => {
+//   const storage = getStorage();
+//   let id = storage?.getItem(CLIENT_SESSION_ID_FIELD);
+//   if (!id) {
+//     id = guid();
+//     storage?.setItem(CLIENT_SESSION_ID_FIELD, id);
+//   }
+//   return id;
+// })();

--- a/packages/hyperion-util/src/SessionPersistentData.ts
+++ b/packages/hyperion-util/src/SessionPersistentData.ts
@@ -1,0 +1,85 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved.
+ */
+
+'use strict';
+
+import { TimedTrigger } from "./TimedTrigger";
+
+function getStorage(): Storage | null {
+  let storage: Storage;
+  try {
+    storage = window.sessionStorage;
+    const x = "__storage_test__";
+    storage.setItem(x, x);
+    storage.removeItem(x);
+    return storage;
+  } catch (e) {
+    return null;
+  }
+}
+
+const SessionStorage = getStorage();
+
+export const SESSION_DATA_SAVE_INTERVAL = 100; //ms
+
+export class SessionPersistentData<T> {
+  private static runner: TimedTrigger | null = null;
+  private static pending = new Set<SessionPersistentData<any>>();
+  private schedule() {
+    if (!SessionPersistentData.runner) {
+      SessionPersistentData.runner = new TimedTrigger(
+        () => {
+          for (const i of SessionPersistentData.pending) {
+            i.save();
+          }
+          SessionPersistentData.pending.clear();
+          SessionPersistentData.runner = null;
+        },
+        SESSION_DATA_SAVE_INTERVAL
+      );
+    } else {
+      SessionPersistentData.runner.delay(); // If not saved yet, postpone
+    }
+    SessionPersistentData.pending.add(this);
+  }
+
+  private _data: T;
+
+  constructor(
+    private readonly fieldName: string,
+    missingValueInitializer: () => T,
+    private readonly stringify: (value: T) => string,
+    parser: (persistedValue: string) => T,
+  ) {
+    let persistedData = SessionStorage?.getItem(this.fieldName);
+    let data;
+    if (!persistedData) {
+      data = missingValueInitializer();
+      this.setValue(data);
+    } else {
+      data = parser(persistedData);
+    }
+    this._data = data;
+  }
+
+  private save() {
+    SessionStorage?.setItem(this.fieldName, this.stringify(this._data));
+  }
+
+
+  isPersisted(): boolean {
+    return SessionStorage !== null;
+  }
+
+  getValue(): T {
+    return this._data;
+  }
+
+  setValue(data: T): T {
+    this._data = data;
+    this.schedule();
+    return data;
+  }
+
+}

--- a/packages/hyperion-util/src/guid.ts
+++ b/packages/hyperion-util/src/guid.ts
@@ -1,0 +1,12 @@
+
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved.
+ */
+
+'use strict';
+
+export type GUID = string;
+
+export function guid(): GUID {
+  return 'f' + (Math.random() * (1 << 30)).toString(16).replace('.', '');
+}

--- a/packages/hyperion-util/test/SessionPersistentData.test.ts
+++ b/packages/hyperion-util/test/SessionPersistentData.test.ts
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved.
+ *
+  * @jest-environment jsdom
+ */
+
+import "jest";
+import { SESSION_DATA_SAVE_INTERVAL, SessionPersistentData } from "../src/SessionPersistentData";
+describe('test session persistent data', () => {
+  test('test data saved / restored correctly', (done) => {
+    const fieldName = "testValue";
+    const v1 = new SessionPersistentData(fieldName, () => "--", v => v, v => v);
+    v1.setValue("v2");
+    const lastValue = v1.setValue("V3");
+
+    setTimeout(
+      () => {
+        const v2 = new SessionPersistentData(fieldName, () => "--", v => v, v => v);
+        expect(v2.getValue()).toBe(lastValue);
+        done();
+      },
+      SESSION_DATA_SAVE_INTERVAL + 10
+    );
+  });
+});

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -30,6 +30,9 @@ export default defineConfig({
       "hyperionSyncMutationObserver": [
         "@hyperion/hyperion-util/src/SyncMutationObserver",
       ],
+      "hyperionUtil": [
+        "@hyperion/hyperion-util/src/ClientSessionID",
+      ],
       "hyperionFlowletCore": [
         "@hyperion/hyperion-flowlet/src/Flowlet",
         "@hyperion/hyperion-flowlet/src/FlowletManager",

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,11 @@ export { trackElementsWithAttributes } from "@hyperion/hyperion-util/src/trackEl
 // hyperionSyncMutationObserver
 export * as SyncMutationObserver from "@hyperion/hyperion-util/src/SyncMutationObserver";
 
+// hyperionUtil
+export { TimedTrigger } from "@hyperion/hyperion-util/src/TimedTrigger";
+export { SessionPersistentData } from "@hyperion/hyperion-util/src/SessionPersistentData";
+export { ClientSessionID } from "@hyperion/hyperion-util/src/ClientSessionID";
+
 // hyperionFlowletCore
 export { Flowlet } from "@hyperion/hyperion-flowlet/src/Flowlet";
 export { FlowletManager } from "@hyperion/hyperion-flowlet/src/FlowletManager";


### PR DESCRIPTION
Sometimes applications need a single session id that links all pages of the same origin together. This id must survive across page loads.

Using browser's `sessionStorage`, this commit creates one such ID and apps can use in their logging safely across pages.