### PR TITLE
Intercept useState and pass around flowlets to surface mutation events.

### DIFF
--- a/packages/hyperion-autologging/src/ALIReactFlowlet.ts
+++ b/packages/hyperion-autologging/src/ALIReactFlowlet.ts
@@ -41,7 +41,11 @@ export function init(options: InitOptions) {
       args[0] = flowletManager.wrap(args[0], fi.name);
       return args;
     });
-  })
+  });
+  IReactModule.useState.onValueMapperAdd(value => {
+    value[1] = flowletManager.wrap(value[1], IReactModule.useState.name);
+    return value;
+  });
 
   /**
  * The following interceptor methods (onArgsObserver/onValueObserver) run immediately 

--- a/packages/hyperion-autologging/src/ALNetworkPublisher.ts
+++ b/packages/hyperion-autologging/src/ALNetworkPublisher.ts
@@ -10,12 +10,11 @@ import * as IWindow from "@hyperion/hyperion-dom/src/IWindow";
 import * as IXMLHttpRequest from "@hyperion/hyperion-dom/src/IXMLHttpRequest";
 import performanceAbsoluteNow from "@hyperion/hyperion-util/src/performanceAbsoluteNow";
 import * as Types from "@hyperion/hyperion-util/src/Types";
-import { ALFlowletEvent, ALSharedInitOptions, ALTimedEvent } from "./ALType";
+import { ALOptionalFlowletEvent, ALSharedInitOptions, ALTimedEvent } from "./ALType";
 
-type ALNetworkEvent = ALTimedEvent & Omit<ALFlowletEvent, "flowlet"> & Readonly<{
+type ALNetworkEvent = ALTimedEvent & ALOptionalFlowletEvent & Readonly<{
   event: "network";
   initiatorType: "fetch" | "xmlhttprequest"; // https://developer.mozilla.org/en-US/docs/Web/API/PerformanceResourceTiming/initiatorType
-  flowlet: ALFlowletEvent['flowlet'] | null;
 }>;
 
 

--- a/packages/hyperion-autologging/src/ALType.ts
+++ b/packages/hyperion-autologging/src/ALType.ts
@@ -12,6 +12,10 @@ export type ALFlowletEvent = Readonly<{
   alFlowlet?: ALFlowlet;
 }>;
 
+export type ALOptionalFlowletEvent = Omit<ALFlowletEvent, 'flowlet'> & Readonly<{
+  flowlet: ALFlowlet | null;
+}>;
+
 export type ALTimedEvent = Readonly<{
   eventTimestamp: number,
 }>;

--- a/packages/hyperion-react-testapp/src/component/DynamicSvgComponent.tsx
+++ b/packages/hyperion-react-testapp/src/component/DynamicSvgComponent.tsx
@@ -33,14 +33,14 @@ export default function (/* props: Props */) {
   ];
 
   const onCallbackFetch = useCallback(() => {
-    setText("Loading via fetch ...");
+    // setText("Loading via fetch ..."); // Note if call these now, the corresponding component will be mounted. We want to mount alap to test the alflowlet flow
     for (const link of links) {
       fetch(link).then(response => response.text()).then(setText);
     }
   }, []);
 
   const onCallbackXHR = useCallback(() => {
-    setText("Loading via xhr ...");
+    // setText("Loading via xhr ..."); // Note if call these now, the corresponding component will be mounted. We want to mount alap to test the alflowlet flow
     for (const link of links) {
       const xhr = new XMLHttpRequest();
       xhr.open("GET", link);

--- a/packages/hyperion-react/src/IReact.ts
+++ b/packages/hyperion-react/src/IReact.ts
@@ -84,6 +84,8 @@ type JsxRuntimeModuleExports = {
 type ReactModuleExports = {
   createElement: typeof React.createElement;
 
+  forwardRef: typeof React.forwardRef;
+
   useCallback: typeof React.useCallback;
 
   useEffect: (effect: () => (void | (() => void)), deps?: Parameters<typeof React.useEffect>) => ReturnType<typeof React.useEffect>;
@@ -94,7 +96,7 @@ type ReactModuleExports = {
 
   useReducer: typeof React.useReducer;
 
-  forwardRef: typeof React.forwardRef;
+  useState: typeof React.useState;
 }
 
 export type IJsxRuntimeModuleExports = InterceptedModuleExports<JsxRuntimeModuleExports>;
@@ -137,12 +139,13 @@ export function intercept(moduleId: string, moduleExports: ReactModuleExports, f
       moduleExports,
       [
         'createElement',
+        'forwardRef',
         'useCallback',
         'useEffect',
         'useLayoutEffect',
         'useMemo',
         'useReducer',
-        'forwardRef',
+        'useState'
       ],
       failedExportsKeys
     );


### PR DESCRIPTION
Sometimes a late async function (e.g. network response processing) may call the `setter` function returned by a `useState`. That action may then trigger more re-render, etc. resulting more mount/unmount events.

In these cases, we want the `alflowlet` to be assigned to the surface rendering flows so we can link user event to the (un)mount of the ui elements.

by intercepting and wrapping the setter function returned from `useState` we basically trigger the mechanism that marks the flowlets with known `alflowlet`.

I updated the test app to clearly see the link between async network load and the surface mutation event.