### PR TITLE
Intercept Element.style and corresponding property methods.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -30,8 +30,8 @@
       // "cwd": "${workspaceRoot}/packages/hook",
       // "cwd": "${workspaceRoot}/packages/hyperion-autologging",
       // "cwd": "${workspaceRoot}/packages/hyperion-core",
-      // "cwd": "${workspaceRoot}/packages/hyperion-dom",
-      "cwd": "${workspaceRoot}/packages/hyperion-flowlet",
+      "cwd": "${workspaceRoot}/packages/hyperion-dom",
+      // "cwd": "${workspaceRoot}/packages/hyperion-flowlet",
       // "cwd": "${workspaceRoot}/packages/hyperion-react",
       // "cwd": "${workspaceRoot}/packages/hyperion-util",
       "runtimeArgs": [

--- a/packages/hyperion-dom/src/ICSSStyleDeclaration.ts
+++ b/packages/hyperion-dom/src/ICSSStyleDeclaration.ts
@@ -1,0 +1,13 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved.
+ */
+
+import { interceptMethod } from "@hyperion/hyperion-core/src/MethodInterceptor";
+import { DOMShadowPrototype, sampleHTMLElement } from "./DOMShadowPrototype";
+
+export const ICSSStyleDeclarationPrototype = new DOMShadowPrototype(CSSStyleDeclaration, null, { sampleObject: sampleHTMLElement.style, });
+ICSSStyleDeclarationPrototype.extension.useCaseInsensitivePropertyName = true;
+
+export const getPropertyValue = interceptMethod("getPropertyValue", ICSSStyleDeclarationPrototype);
+export const removeProperty = interceptMethod("removeProperty", ICSSStyleDeclarationPrototype);
+export const setProperty = interceptMethod("setProperty", ICSSStyleDeclarationPrototype);

--- a/packages/hyperion-dom/src/IElement.ts
+++ b/packages/hyperion-dom/src/IElement.ts
@@ -47,3 +47,4 @@ export const toggleAttribute = interceptMethod('toggleAttribute', IElementtProto
 
 export const id = interceptElementAttribute("id", IElementtPrototype);
 export const innerHTML = interceptAttribute("innerHTML", IElementtPrototype);
+export const style = interceptAttribute("style", IElementtPrototype);

--- a/packages/hyperion-dom/test/ICSSStyleDeclaration.test.ts
+++ b/packages/hyperion-dom/test/ICSSStyleDeclaration.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved.
+ *
+ * @jest-environment jsdom
+ */
+
+import "jest";
+import * as ICSSStyleDeclaration from "../src/ICSSStyleDeclaration";
+
+describe('test element style interception', () => {
+  false && test('test get/set/remove property', () => {
+    const setterArgs = jest.fn(function () {
+      console.log('setterArgs called', arguments);
+    });
+    const getterArgs = jest.fn(function () {
+      console.log('getterArgs called', arguments);
+    });
+    const getterValue = jest.fn(function () {
+      console.log('getterValue called', arguments);
+    });
+
+    ICSSStyleDeclaration.setProperty.onArgsObserverAdd(setterArgs);
+    ICSSStyleDeclaration.getPropertyValue.onArgsObserverAdd(getterArgs);
+    ICSSStyleDeclaration.getPropertyValue.onValueObserverAdd(getterValue);
+
+    let elem: HTMLElement;
+    elem = window.document.createElement("P");
+    elem.style.setProperty("display", "none");
+
+    expect(setterArgs).toBeCalledTimes(1);
+    expect(setterArgs.mock.calls[0][0]).toBe("display");
+    expect(setterArgs.mock.calls[0][1]).toBe("none");
+
+    const display = elem.style.getPropertyValue("display");
+    expect(display).toBe("none");
+
+    // Note that jest dom internally calls getPropertyValue itself one more time! So, instead of 1, we have 2 times call
+    expect(getterArgs).toBeCalledTimes(2);
+    expect(getterArgs.mock.calls[1][0]).toBe("display");
+
+    expect(getterValue).toBeCalledTimes(2);
+    expect(getterValue.mock.calls[0][0]).toBe("none");
+  });
+
+  test('test block setting block value', () => {
+    ICSSStyleDeclaration.setProperty.onArgsObserverAdd((property, value) => {
+      const blocked = (property === "display" && value === "block");
+      if (blocked) {
+        console.log("Will block:", property, value);
+      }
+      return blocked;
+    });
+
+    let elem: HTMLElement;
+    elem = window.document.createElement("P");
+
+    elem.style.setProperty("display", "flex");
+    let display = elem.style.getPropertyValue("display");
+    expect(display).toBe("flex");
+
+    elem.style.setProperty("display", "block");
+    display = elem.style.getPropertyValue("display");
+    expect(display).toBe("flex");
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ export { interceptFunction } from "@hyperion/hyperion-core/src/FunctionIntercept
 export { interceptMethod } from "@hyperion/hyperion-core/src/MethodInterceptor";
 export { interceptConstructor, interceptConstructorMethod } from "@hyperion/hyperion-core/src/ConstructorInterceptor";
 export * as IEventTarget from "@hyperion/hyperion-dom/src/IEventTarget";
+export * as ICSSStyleDeclaration from "@hyperion/hyperion-dom/src/ICSSStyleDeclaration";
 export * as IRequire from "@hyperion/hyperion-core/src/IRequire";
 
 // hyperionTrackElementsWithAttributes


### PR DESCRIPTION
This commit first intercepts the `Element.style` attribute, then adds interception for CSSStyleDeclaration and a few of its methods.

Also added a sample code as test to show how to block setting certain values.