### PR TITLE
Created a hyperionDOM bundle to separate the dom related logic from core

### DIFF
--- a/packages/hyperion-dom/src/IElement.ts
+++ b/packages/hyperion-dom/src/IElement.ts
@@ -47,4 +47,3 @@ export const toggleAttribute = interceptMethod('toggleAttribute', IElementtProto
 
 export const id = interceptElementAttribute("id", IElementtPrototype);
 export const innerHTML = interceptAttribute("innerHTML", IElementtPrototype);
-export const style = interceptAttribute("style", IElementtPrototype);

--- a/packages/hyperion-dom/src/IHTMLElement.ts
+++ b/packages/hyperion-dom/src/IHTMLElement.ts
@@ -2,6 +2,7 @@
  * Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved.
  */
 
+import { interceptAttribute } from "@hyperion/hyperion-core/src/AttributeInterceptor";
 import { DOMShadowPrototype, sampleHTMLElement } from "./DOMShadowPrototype";
 import * as IElement from "./IElement";
 
@@ -13,3 +14,5 @@ export const IHTMLElementtPrototype = new DOMShadowPrototype(
     nodeType: document.ELEMENT_NODE
   }
 );
+
+export const style = interceptAttribute("style", IHTMLElementtPrototype);

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -18,13 +18,18 @@ export default defineConfig({
         "@hyperion/hyperion-core/src/AttributeInterceptor",
         "@hyperion/hyperion-core/src/intercept",
         "@hyperion/hyperion-core/src/IRequire",
+      ],
+      "hyperionDOM": [
+        "@hyperion/hyperion-dom/src/IEventTarget",
         "@hyperion/hyperion-dom/src/INode",
         "@hyperion/hyperion-dom/src/IElement_",
+        "@hyperion/hyperion-dom/src/IElement",
+        "@hyperion/hyperion-dom/src/IHTMLElement",
         "@hyperion/hyperion-dom/src/IWindow",
         "@hyperion/hyperion-dom/src/IXMLHttpRequest",
+        "@hyperion/hyperion-dom/src/ICSSStyleDeclaration",
       ],
       "hyperionTrackElementsWithAttributes": [
-        "@hyperion/hyperion-dom/src/IElement",
         "@hyperion/hyperion-util/src/trackElementsWithAttributes",
       ],
       "hyperionSyncMutationObserver": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,9 +12,16 @@ export { getVirtualPropertyValue, setVirtualPropertyValue } from "@hyperion/hype
 export { interceptFunction } from "@hyperion/hyperion-core/src/FunctionInterceptor";
 export { interceptMethod } from "@hyperion/hyperion-core/src/MethodInterceptor";
 export { interceptConstructor, interceptConstructorMethod } from "@hyperion/hyperion-core/src/ConstructorInterceptor";
-export * as IEventTarget from "@hyperion/hyperion-dom/src/IEventTarget";
-export * as ICSSStyleDeclaration from "@hyperion/hyperion-dom/src/ICSSStyleDeclaration";
 export * as IRequire from "@hyperion/hyperion-core/src/IRequire";
+
+// hyperionDOM
+export * as IEventTarget from "@hyperion/hyperion-dom/src/IEventTarget";
+// export * as INode from "@hyperion/hyperion-dom/src/INode";
+export * as IElement from "@hyperion/hyperion-dom/src/IElement";
+export * as IHTMLElement from "@hyperion/hyperion-dom/src/IHTMLElement";
+export * as ICSSStyleDeclaration from "@hyperion/hyperion-dom/src/ICSSStyleDeclaration";
+// export * as IWindow from "@hyperion/hyperion-dom/src/IWindow";
+// export * as IXMLHttpRequest from "@hyperion/hyperion-dom/src/IXMLHttpRequest";
 
 // hyperionTrackElementsWithAttributes
 export { trackElementsWithAttributes } from "@hyperion/hyperion-util/src/trackElementsWithAttributes";


### PR DESCRIPTION
1- Fixed the .style interception which should belong to HTMLElement rather than Element.
2- Created a separate hyperionDOM bundle so that dom related code is separated from core functionality for use in external applications.