### PR TITLE
read ALSurfaceContext once per component

### DIFF
--- a/packages/hyperion-autologging/package.json
+++ b/packages/hyperion-autologging/package.json
@@ -25,8 +25,8 @@
     "@hyperion/hyperion-react": "*"
   },
   "peerDependencies": {
-    "@types/react": "^18.0.27",
-    "@types/react-dom": "^18.0.10"
+    "@types/react": "^18.2.7",
+    "@types/react-dom": "^18.2.4"
   },
   "devDependencies": {
     "@hyperion/devtools": "*",


### PR DESCRIPTION
In some cases, calling the `useALSurface` in the render of every component may lead to infinit loops inside of react engine.

This change applies two fixes:
1- Only read the surface context once per component instance. It stores the value in the `this` of class components, or a ref (using `useRef`) in functional components
2- It avoids calling the `useContext` directly, and only optimistically read the `Context._value` internal value.