### PR TITLE
Rename onArgs* and onValue* to onBeforeCallArgs* and onAfterReturnValue*

### DIFF
--- a/packages/hyperion-autologging/src/ALInteractableDOMElement.ts
+++ b/packages/hyperion-autologging/src/ALInteractableDOMElement.ts
@@ -85,7 +85,7 @@ function ignoreInteractiveElement(node: HTMLElement) {
 const TrackedEvents = new Set<string>();
 
 let installHandlers = () => {
-  IEventTarget.addEventListener.onBeforeCallArgsObserverAdd(function (
+  IEventTarget.addEventListener.onBeforeCallObserverAdd(function (
     this: EventTarget,
     event,
     _listener,
@@ -98,7 +98,7 @@ let installHandlers = () => {
     }
   });
 
-  IEventTarget.removeEventListener.onBeforeCallArgsObserverAdd(function (
+  IEventTarget.removeEventListener.onBeforeCallObserverAdd(function (
     this: EventTarget,
     event,
     _listener,

--- a/packages/hyperion-autologging/src/ALInteractableDOMElement.ts
+++ b/packages/hyperion-autologging/src/ALInteractableDOMElement.ts
@@ -85,7 +85,7 @@ function ignoreInteractiveElement(node: HTMLElement) {
 const TrackedEvents = new Set<string>();
 
 let installHandlers = () => {
-  IEventTarget.addEventListener.onArgsObserverAdd(function (
+  IEventTarget.addEventListener.onBeforeCallArgsObserverAdd(function (
     this: EventTarget,
     event,
     _listener,
@@ -98,7 +98,7 @@ let installHandlers = () => {
     }
   });
 
-  IEventTarget.removeEventListener.onArgsObserverAdd(function (
+  IEventTarget.removeEventListener.onBeforeCallArgsObserverAdd(function (
     this: EventTarget,
     event,
     _listener,

--- a/packages/hyperion-autologging/src/ALNetworkPublisher.ts
+++ b/packages/hyperion-autologging/src/ALNetworkPublisher.ts
@@ -124,7 +124,7 @@ function captureFetch(options: InitOptions): void {
      * Note that args mapper runs before args observer, so the following
      * changes will be picked up by the next observers, which is what we want
      */
-    IWindow.fetch.onArgsMapperAdd(args => {
+    IWindow.fetch.onBeforeCallArgsMapperAdd(args => {
       const urlParams = new URLSearchParams();
 
       let input = args[0];
@@ -161,7 +161,7 @@ function captureFetch(options: InitOptions): void {
     });
   }
 
-  IWindow.fetch.onArgsAndValueMapperAdd(([input, init]) => {
+  IWindow.fetch.onBeforeCallArgsAndAfterReturnValueMapperAdd(([input, init]) => {
     let ephemeralRequestEvent: ALNetworkResponseEvent['requestEvent'] | null;
     let request: RequestInfo = getFetchRequestInfo(input, init);
 
@@ -231,7 +231,7 @@ function captureXHR(options: InitOptions): void {
      * Note that args mapper runs before args observer, so the following
      * changes will be picked up by the next observers, which is what we want
      */
-    IXMLHttpRequest.open.onArgsMapperAdd(args => {
+    IXMLHttpRequest.open.onBeforeCallArgsMapperAdd(args => {
       const urlParams = new URLSearchParams();
 
       const [method, url] = args;
@@ -247,7 +247,7 @@ function captureXHR(options: InitOptions): void {
     });
   }
 
-  IXMLHttpRequest.open.onArgsObserverAdd(function (this, method, url) {
+  IXMLHttpRequest.open.onBeforeCallArgsObserverAdd(function (this, method, url) {
     const request: RequestInfo = typeof url === 'string'
       ? {
         method,
@@ -288,7 +288,7 @@ function captureXHR(options: InitOptions): void {
     // });
    */
   if (__DEV__) {
-    IXMLHttpRequest.constructor.onValueObserverAdd(xhr => {
+    IXMLHttpRequest.constructor.onAfterReturnValueObserverAdd(xhr => {
       [
         "abort",
         "error",
@@ -314,7 +314,7 @@ function captureXHR(options: InitOptions): void {
     });
   }
 
-  IXMLHttpRequest.send.onArgsObserverAdd(function (this, body) {
+  IXMLHttpRequest.send.onBeforeCallArgsObserverAdd(function (this, body) {
     const requestRaw = intercept.getVirtualPropertyValue<RequestInfo>(this, REQUEST_INFO_PROP_NAME);
     assert(requestRaw != null, `Unexpected situation! Request info is missing from xhr object`);
     const request = body instanceof Document ? requestRaw : {

--- a/packages/hyperion-autologging/src/ALNetworkPublisher.ts
+++ b/packages/hyperion-autologging/src/ALNetworkPublisher.ts
@@ -124,7 +124,7 @@ function captureFetch(options: InitOptions): void {
      * Note that args mapper runs before args observer, so the following
      * changes will be picked up by the next observers, which is what we want
      */
-    IWindow.fetch.onBeforeCallArgsMapperAdd(args => {
+    IWindow.fetch.onBeforeCallMapperAdd(args => {
       const urlParams = new URLSearchParams();
 
       let input = args[0];
@@ -161,7 +161,7 @@ function captureFetch(options: InitOptions): void {
     });
   }
 
-  IWindow.fetch.onBeforeCallArgsAndAfterReturnValueMapperAdd(([input, init]) => {
+  IWindow.fetch.onBeforeAndAfterCallMapperAdd(([input, init]) => {
     let ephemeralRequestEvent: ALNetworkResponseEvent['requestEvent'] | null;
     let request: RequestInfo = getFetchRequestInfo(input, init);
 
@@ -231,7 +231,7 @@ function captureXHR(options: InitOptions): void {
      * Note that args mapper runs before args observer, so the following
      * changes will be picked up by the next observers, which is what we want
      */
-    IXMLHttpRequest.open.onBeforeCallArgsMapperAdd(args => {
+    IXMLHttpRequest.open.onBeforeCallMapperAdd(args => {
       const urlParams = new URLSearchParams();
 
       const [method, url] = args;
@@ -247,7 +247,7 @@ function captureXHR(options: InitOptions): void {
     });
   }
 
-  IXMLHttpRequest.open.onBeforeCallArgsObserverAdd(function (this, method, url) {
+  IXMLHttpRequest.open.onBeforeCallObserverAdd(function (this, method, url) {
     const request: RequestInfo = typeof url === 'string'
       ? {
         method,
@@ -288,7 +288,7 @@ function captureXHR(options: InitOptions): void {
     // });
    */
   if (__DEV__) {
-    IXMLHttpRequest.constructor.onAfterReturnValueObserverAdd(xhr => {
+    IXMLHttpRequest.constructor.onAfterCallObserverAdd(xhr => {
       [
         "abort",
         "error",
@@ -314,7 +314,7 @@ function captureXHR(options: InitOptions): void {
     });
   }
 
-  IXMLHttpRequest.send.onBeforeCallArgsObserverAdd(function (this, body) {
+  IXMLHttpRequest.send.onBeforeCallObserverAdd(function (this, body) {
     const requestRaw = intercept.getVirtualPropertyValue<RequestInfo>(this, REQUEST_INFO_PROP_NAME);
     assert(requestRaw != null, `Unexpected situation! Request info is missing from xhr object`);
     const request = body instanceof Document ? requestRaw : {

--- a/packages/hyperion-autologging/src/ALSurface.ts
+++ b/packages/hyperion-autologging/src/ALSurface.ts
@@ -186,7 +186,7 @@ function setupDomElementSurfaceAttribute(options: InitOptions): void {
    * sure that is not added to the DOM tree.
    * The following code blocks the effect of `setAttribute` by returning true
    */
-  IElement.setAttribute.onArgsObserverAdd(function (
+  IElement.setAttribute.onBeforeCallArgsObserverAdd(function (
     this: Element,
     attrName,
     attrValue: any,

--- a/packages/hyperion-autologging/src/ALSurface.ts
+++ b/packages/hyperion-autologging/src/ALSurface.ts
@@ -186,7 +186,7 @@ function setupDomElementSurfaceAttribute(options: InitOptions): void {
    * sure that is not added to the DOM tree.
    * The following code blocks the effect of `setAttribute` by returning true
    */
-  IElement.setAttribute.onBeforeCallArgsObserverAdd(function (
+  IElement.setAttribute.onBeforeCallObserverAdd(function (
     this: Element,
     attrName,
     attrValue: any,

--- a/packages/hyperion-autologging/src/ALSurfaceProxy.ts
+++ b/packages/hyperion-autologging/src/ALSurfaceProxy.ts
@@ -65,7 +65,7 @@ export function init(options: ProxyInitOptions): void {
    * continue to work. So, we use that fact and wrap the node in another Surface
    * with the same flowlet and surface from the original surface context.
    */
-  IReactDOMModule.createPortal.onBeforeCallArgsMapperAdd(args => {
+  IReactDOMModule.createPortal.onBeforeCallMapperAdd(args => {
     const [node, container] = args;
 
     if (node != null) {

--- a/packages/hyperion-autologging/src/ALSurfaceProxy.ts
+++ b/packages/hyperion-autologging/src/ALSurfaceProxy.ts
@@ -65,7 +65,7 @@ export function init(options: ProxyInitOptions): void {
    * continue to work. So, we use that fact and wrap the node in another Surface
    * with the same flowlet and surface from the original surface context.
    */
-  IReactDOMModule.createPortal.onArgsMapperAdd(args => {
+  IReactDOMModule.createPortal.onBeforeCallArgsMapperAdd(args => {
     const [node, container] = args;
 
     if (node != null) {

--- a/packages/hyperion-autologging/src/ALTriggerFlowlet.ts
+++ b/packages/hyperion-autologging/src/ALTriggerFlowlet.ts
@@ -107,7 +107,7 @@ export function init(options: InitOptions) {
   });
 
   const IS_TRIGGER_FLOWLET_SETUP_PROP = 'isTriggerFlowletSetup';
-  IEventTarget.addEventListener.onBeforeCallArgsObserverAdd(function (this, eventType, _callback) {
+  IEventTarget.addEventListener.onBeforeCallObserverAdd(function (this, eventType, _callback) {
     if (!ALUIEventGroupPublishers.isSupported(eventType)) {
       return;
     }
@@ -151,7 +151,7 @@ export function init(options: InitOptions) {
 
     const interceptedSetter = interceptFunction(setActiveTriggerFlowlet);
     setActiveTriggerFlowlet = interceptedSetter.interceptor;
-    interceptedSetter.onBeforeCallArgsObserverAdd((triggerFlowlet, surface) => {
+    interceptedSetter.onBeforeCallObserverAdd((triggerFlowlet, surface) => {
       if (surface && triggerFlowlet) {
         // The following may not happen until react interception and flowlets actually are enabled.
         const surfaceFlowlet = ALSurfaceContextDataMap.get(surface);
@@ -227,7 +227,7 @@ export function init(options: InitOptions) {
       //   args[0] = flowletManager.wrap(args[0], fi.name);
       //   return args;
       // });
-      fi.onAfterReturnValueMapperAdd(value => {
+      fi.onAfterCallMapperAdd(value => {
         return flowletManager.wrap(value, fi.name);
       });
 
@@ -237,11 +237,11 @@ export function init(options: InitOptions) {
       IReactModule.useEffect,
       IReactModule.useLayoutEffect,
     ].forEach(fi => {
-      fi.onBeforeCallArgsMapperAdd(args => {
+      fi.onBeforeCallMapperAdd(args => {
         args[0] = flowletManager.wrap(args[0], fi.name);
         const setupInterceptor = getFunctionInterceptor(args[0]);
         if (setupInterceptor && !setupInterceptor.testAndSet(IS_TRIGGER_FLOWLET_SETUP_PROP)) {
-          setupInterceptor.onAfterReturnValueMapperAdd(cleanup => {
+          setupInterceptor.onAfterCallMapperAdd(cleanup => {
             if (cleanup) {
               return flowletManager.wrap(cleanup, fi.name + `_cleanup`);
             } else {
@@ -259,11 +259,11 @@ export function init(options: InitOptions) {
       IReactModule.useState,
       IReactModule.useReducer
     ].forEach(fi => {
-      fi.onAfterReturnValueMapperAdd(value => {
+      fi.onAfterCallMapperAdd(value => {
         value[1] = flowletManager.wrap(value[1], fi.name);
         const setterInterceptor = getFunctionInterceptor(value[1]);
         if (setterInterceptor && !setterInterceptor.testAndSet(IS_TRIGGER_FLOWLET_SETUP_PROP)) {
-          setterInterceptor?.onBeforeCallArgsObserverAdd(() => {
+          setterInterceptor?.onBeforeCallObserverAdd(() => {
             /**
              * when someone calls the setter, before anything happens we pickup the
              * trigger flowlet from the top of the stack. 
@@ -285,7 +285,7 @@ export function init(options: InitOptions) {
     IReactComponent.onReactClassComponentIntercept.add(shadowComponent => {
       const setState = shadowComponent.setState;
       if (!setState.testAndSet(IS_TRIGGER_FLOWLET_SETUP_PROP)) {
-        setState.onBeforeCallArgsObserverAdd(() => {
+        setState.onBeforeCallObserverAdd(() => {
           const triggerFlowlet = flowletManager.top()?.data.triggerFlowlet;
           setActiveTriggerFlowlet(triggerFlowlet, null);
         });
@@ -322,7 +322,7 @@ export function init(options: InitOptions) {
         component.contextType = ALSurfaceContext; // Just to be consistent
         (ictor.interceptor as any).contextType = ALSurfaceContext; // the real constructor used by the application
 
-        ictor.onAfterReturnValueObserverAdd((value: ComponentWithFlowlet & { context?: any }) => {
+        ictor.onAfterCallObserverAdd((value: ComponentWithFlowlet & { context?: any }) => {
           value._flowlet = value.context?.flowlet;
         });
       }
@@ -344,14 +344,14 @@ export function init(options: InitOptions) {
           return;
         }
 
-        method.onBeforeCallArgsObserverAdd(function (this: ComponentWithFlowlet) {
+        method.onBeforeCallObserverAdd(function (this: ComponentWithFlowlet) {
           const activeFlowlet = this._flowlet;
           if (activeFlowlet) {
             flowletManager.push(activeFlowlet);
           }
         });
 
-        method.onAfterReturnValueObserverAdd(function (this: ComponentWithFlowlet) {
+        method.onAfterCallObserverAdd(function (this: ComponentWithFlowlet) {
           const activeFlowlet = this._flowlet;
           if (activeFlowlet) {
             flowletManager.pop(activeFlowlet);
@@ -364,7 +364,7 @@ export function init(options: InitOptions) {
       fi => {
         if (!fi.testAndSet(IS_FLOWLET_SETUP_PROP)) {
 
-          fi.onBeforeCallArgsAndAfterReturnValueMapperAdd(([_props]) => {
+          fi.onBeforeAndAfterCallMapperAdd(([_props]) => {
             const ctx = useALSurfaceContext();
             const activeFlowlet = ctx?.flowlet;
             if (activeFlowlet) {

--- a/packages/hyperion-autologging/src/ALUIEventPublisher.ts
+++ b/packages/hyperion-autologging/src/ALUIEventPublisher.ts
@@ -237,7 +237,7 @@ export function publish(options: InitOptions): void {
      * If any of the actual event handlers call stopPropagation, we know that
      * our bubble handler will not be called, so we trigger it rightaway
      */
-    IEvent.stopPropagation.onArgsObserverAdd(function (this) {
+    IEvent.stopPropagation.onBeforeCallArgsObserverAdd(function (this) {
       if (lastUIEvent != null && lastUIEvent.data.domEvent === this) {
         lastUIEvent.data.metadata.propagation_was_stopped = "true";
         lastUIEvent.timedEmitter.run();

--- a/packages/hyperion-autologging/src/ALUIEventPublisher.ts
+++ b/packages/hyperion-autologging/src/ALUIEventPublisher.ts
@@ -237,7 +237,7 @@ export function publish(options: InitOptions): void {
      * If any of the actual event handlers call stopPropagation, we know that
      * our bubble handler will not be called, so we trigger it rightaway
      */
-    IEvent.stopPropagation.onBeforeCallArgsObserverAdd(function (this) {
+    IEvent.stopPropagation.onBeforeCallObserverAdd(function (this) {
       if (lastUIEvent != null && lastUIEvent.data.domEvent === this) {
         lastUIEvent.data.metadata.propagation_was_stopped = "true";
         lastUIEvent.timedEmitter.run();

--- a/packages/hyperion-core/src/FunctionInterceptor.ts
+++ b/packages/hyperion-core/src/FunctionInterceptor.ts
@@ -156,11 +156,11 @@ export class FunctionInterceptor<
   Name extends string,
   FuncType extends InterceptableFunction
 > extends PropertyInterceptor {
-  protected onArgsMapper?: OnArgsMapper<FuncType> | null;
-  protected onArgsObserver?: OnArgsObserver<FuncType> | null;
-  protected onValueMapper?: OnValueMapper<FuncType> | null;
-  protected onValueObserver?: OnValueObserver<FuncType> | null;
-  protected onArgsAndValueMapper?: OnArgsAndValueMapper<FuncType> | null;
+  protected onBeforeCallArgsMapper?: OnArgsMapper<FuncType> | null;
+  protected onBeforeCallArgsObserver?: OnArgsObserver<FuncType> | null;
+  protected onAfterReturnValueMapper?: OnValueMapper<FuncType> | null;
+  protected onAfterReturnValueObserver?: OnValueObserver<FuncType> | null;
+  protected onBeforeCallArgsAndReturnValueMapper?: OnArgsAndValueMapper<FuncType> | null;
 
   protected original: FuncType = unknownFunc;
   private customFunc?: FuncType;
@@ -241,28 +241,28 @@ export class FunctionInterceptor<
       [InterceptorState.Has_______________VO]: fi => function (this: any) {
         let result;
         result = fi.implementation.apply(this, <any>arguments);
-        fi.onValueObserver!.call.call(this, result);
+        fi.onAfterReturnValueObserver!.call.call(this, result);
         return result;
       },
 
       [InterceptorState.Has____________VM___]: fi => function (this: any) {
         let result;
         result = fi.implementation.apply(this, <any>arguments);
-        result = fi.onValueMapper!.call.call(this, result);
+        result = fi.onAfterReturnValueMapper!.call.call(this, result);
         return result;
       },
 
       [InterceptorState.Has____________VM_VO]: fi => function (this: any) {
         let result;
         result = fi.implementation.apply(this, <any>arguments);
-        result = fi.onValueMapper!.call.call(this, result);
-        fi.onValueObserver!.call.call(this, result);
+        result = fi.onAfterReturnValueMapper!.call.call(this, result);
+        fi.onAfterReturnValueObserver!.call.call(this, result);
         return result;
       },
 
       [InterceptorState.Has________AO_______]: fi => function (this: any) {
         let result;
-        if (!fi.onArgsObserver!.call.apply(this, <any>arguments)) {
+        if (!fi.onBeforeCallArgsObserver!.call.apply(this, <any>arguments)) {
           result = fi.implementation.apply(this, <any>arguments);
         }
         return result;
@@ -270,68 +270,68 @@ export class FunctionInterceptor<
 
       [InterceptorState.Has________AO_____VO]: fi => function (this: any) {
         let result;
-        if (!fi.onArgsObserver!.call.apply(this, <any>arguments)) {
+        if (!fi.onBeforeCallArgsObserver!.call.apply(this, <any>arguments)) {
           result = fi.implementation.apply(this, <any>arguments);
-          fi.onValueObserver!.call.call(this, result);
+          fi.onAfterReturnValueObserver!.call.call(this, result);
         }
         return result;
       },
 
       [InterceptorState.Has________AO__VM___]: fi => function (this: any) {
         let result;
-        if (!fi.onArgsObserver!.call.apply(this, <any>arguments)) {
+        if (!fi.onBeforeCallArgsObserver!.call.apply(this, <any>arguments)) {
           result = fi.implementation.apply(this, <any>arguments);
-          result = fi.onValueMapper!.call.call(this, result);
+          result = fi.onAfterReturnValueMapper!.call.call(this, result);
         }
         return result;
       },
 
       [InterceptorState.Has________AO__VM_VO]: fi => function (this: any) {
         let result;
-        if (!fi.onArgsObserver!.call.apply(this, <any>arguments)) {
+        if (!fi.onBeforeCallArgsObserver!.call.apply(this, <any>arguments)) {
           result = fi.implementation.apply(this, <any>arguments);
-          result = fi.onValueMapper!.call.call(this, result);
-          fi.onValueObserver!.call.call(this, result);
+          result = fi.onAfterReturnValueMapper!.call.call(this, result);
+          fi.onAfterReturnValueObserver!.call.call(this, result);
         }
         return result;
       },
 
       [InterceptorState.Has_____AM__________]: fi => function (this: any) {
         let result;
-        const filteredArgs = fi.onArgsMapper!.call.call(this, <any>arguments); //Pass as an array
+        const filteredArgs = fi.onBeforeCallArgsMapper!.call.call(this, <any>arguments); //Pass as an array
         result = fi.implementation.apply(this, filteredArgs);
         return result;
       },
 
       [InterceptorState.Has_____AM________VO]: fi => function (this: any) {
         let result;
-        const filteredArgs = fi.onArgsMapper!.call.call(this, <any>arguments); //Pass as an array
+        const filteredArgs = fi.onBeforeCallArgsMapper!.call.call(this, <any>arguments); //Pass as an array
         result = fi.implementation.apply(this, filteredArgs);
-        fi.onValueObserver!.call.call(this, result);
+        fi.onAfterReturnValueObserver!.call.call(this, result);
         return result;
       },
 
       [InterceptorState.Has_____AM_____VM___]: fi => function (this: any) {
         let result;
-        const filteredArgs = fi.onArgsMapper!.call.call(this, <any>arguments); //Pass as an array
+        const filteredArgs = fi.onBeforeCallArgsMapper!.call.call(this, <any>arguments); //Pass as an array
         result = fi.implementation.apply(this, filteredArgs);
-        result = fi.onValueMapper!.call.call(this, result);
+        result = fi.onAfterReturnValueMapper!.call.call(this, result);
         return result;
       },
 
       [InterceptorState.Has_____AM_____VM_VO]: fi => function (this: any) {
         let result;
-        const filteredArgs = fi.onArgsMapper!.call.call(this, <any>arguments); //Pass as an array
+        const filteredArgs = fi.onBeforeCallArgsMapper!.call.call(this, <any>arguments); //Pass as an array
         result = fi.implementation.apply(this, filteredArgs);
-        result = fi.onValueMapper!.call.call(this, result);
-        fi.onValueObserver!.call.call(this, result);
+        result = fi.onAfterReturnValueMapper!.call.call(this, result);
+        fi.onAfterReturnValueObserver!.call.call(this, result);
         return result;
       },
 
       [InterceptorState.Has_____AM_AO_______]: fi => function (this: any) {
         let result;
-        const filteredArgs = fi.onArgsMapper!.call.call(this, <any>arguments); //Pass as an array
-        if (!fi.onArgsObserver!.call.apply(this, filteredArgs)) {
+        const filteredArgs = fi.onBeforeCallArgsMapper!.call.call(this, <any>arguments); //Pass as an array
+        if (!fi.onBeforeCallArgsObserver!.call.apply(this, filteredArgs)) {
           result = fi.implementation.apply(this, filteredArgs);
         }
         return result;
@@ -339,38 +339,38 @@ export class FunctionInterceptor<
 
       [InterceptorState.Has_____AM_AO_____VO]: fi => function (this: any) {
         let result;
-        const filteredArgs = fi.onArgsMapper!.call.call(this, <any>arguments); //Pass as an array
-        if (!fi.onArgsObserver!.call.apply(this, filteredArgs)) {
+        const filteredArgs = fi.onBeforeCallArgsMapper!.call.call(this, <any>arguments); //Pass as an array
+        if (!fi.onBeforeCallArgsObserver!.call.apply(this, filteredArgs)) {
           result = fi.implementation.apply(this, filteredArgs);
-          fi.onValueObserver!.call.call(this, result);
+          fi.onAfterReturnValueObserver!.call.call(this, result);
         }
         return result;
       },
 
       [InterceptorState.Has_____AM_AO__VM___]: fi => function (this: any) {
         let result;
-        const filteredArgs = fi.onArgsMapper!.call.call(this, <any>arguments); //Pass as an array
-        if (!fi.onArgsObserver!.call.apply(this, filteredArgs)) {
+        const filteredArgs = fi.onBeforeCallArgsMapper!.call.call(this, <any>arguments); //Pass as an array
+        if (!fi.onBeforeCallArgsObserver!.call.apply(this, filteredArgs)) {
           result = fi.implementation.apply(this, filteredArgs);
-          result = fi.onValueMapper!.call.call(this, result);
+          result = fi.onAfterReturnValueMapper!.call.call(this, result);
         }
         return result;
       },
 
       [InterceptorState.Has_____AM_AO__VM_VO]: fi => function (this: any) {
         let result;
-        const filteredArgs = fi.onArgsMapper!.call.call(this, <any>arguments); //Pass as an array
-        if (!fi.onArgsObserver!.call.apply(this, filteredArgs)) {
+        const filteredArgs = fi.onBeforeCallArgsMapper!.call.call(this, <any>arguments); //Pass as an array
+        if (!fi.onBeforeCallArgsObserver!.call.apply(this, filteredArgs)) {
           result = fi.implementation.apply(this, filteredArgs);
-          result = fi.onValueMapper!.call.call(this, result);
-          fi.onValueObserver!.call.call(this, result);
+          result = fi.onAfterReturnValueMapper!.call.call(this, result);
+          fi.onAfterReturnValueObserver!.call.call(this, result);
         }
         return result;
       },
 
       [InterceptorState.Has_AVM______________]: fi => function (this: any) {
         let result;
-        const onValueMapper = fi.onArgsAndValueMapper!.call.call(this, <any>arguments);
+        const onValueMapper = fi.onBeforeCallArgsAndReturnValueMapper!.call.call(this, <any>arguments);
         result = fi.implementation.apply(this, <any>arguments);
         result = onValueMapper.call(this, result);
         return result;
@@ -378,36 +378,36 @@ export class FunctionInterceptor<
 
       [InterceptorState.Has_AVM____________VO]: fi => function (this: any) {
         let result;
-        const onValueMapper = fi.onArgsAndValueMapper!.call.call(this, <any>arguments);
+        const onValueMapper = fi.onBeforeCallArgsAndReturnValueMapper!.call.call(this, <any>arguments);
         result = fi.implementation.apply(this, <any>arguments);
-        fi.onValueObserver!.call.call(this, result);
+        fi.onAfterReturnValueObserver!.call.call(this, result);
         result = onValueMapper.call(this, result);
         return result;
       },
 
       [InterceptorState.Has_AVM_________VM___]: fi => function (this: any) {
         let result;
-        const onValueMapper = fi.onArgsAndValueMapper!.call.call(this, <any>arguments);
+        const onValueMapper = fi.onBeforeCallArgsAndReturnValueMapper!.call.call(this, <any>arguments);
         result = fi.implementation.apply(this, <any>arguments);
-        result = fi.onValueMapper!.call.call(this, result);
+        result = fi.onAfterReturnValueMapper!.call.call(this, result);
         result = onValueMapper.call(this, result);
         return result;
       },
 
       [InterceptorState.Has_AVM_________VM_VO]: fi => function (this: any) {
         let result;
-        const onValueMapper = fi.onArgsAndValueMapper!.call.call(this, <any>arguments);
+        const onValueMapper = fi.onBeforeCallArgsAndReturnValueMapper!.call.call(this, <any>arguments);
         result = fi.implementation.apply(this, <any>arguments);
-        result = fi.onValueMapper!.call.call(this, result);
-        fi.onValueObserver!.call.call(this, result);
+        result = fi.onAfterReturnValueMapper!.call.call(this, result);
+        fi.onAfterReturnValueObserver!.call.call(this, result);
         result = onValueMapper.call(this, result);
         return result;
       },
 
       [InterceptorState.Has_AVM_____AO_______]: fi => function (this: any) {
         let result;
-        if (!fi.onArgsObserver!.call.apply(this, <any>arguments)) {
-          const onValueMapper = fi.onArgsAndValueMapper!.call.call(this, <any>arguments);
+        if (!fi.onBeforeCallArgsObserver!.call.apply(this, <any>arguments)) {
+          const onValueMapper = fi.onBeforeCallArgsAndReturnValueMapper!.call.call(this, <any>arguments);
           result = fi.implementation.apply(this, <any>arguments);
           result = onValueMapper.call(this, result);
         }
@@ -416,10 +416,10 @@ export class FunctionInterceptor<
 
       [InterceptorState.Has_AVM_____AO_____VO]: fi => function (this: any) {
         let result;
-        if (!fi.onArgsObserver!.call.apply(this, <any>arguments)) {
-          const onValueMapper = fi.onArgsAndValueMapper!.call.call(this, <any>arguments);
+        if (!fi.onBeforeCallArgsObserver!.call.apply(this, <any>arguments)) {
+          const onValueMapper = fi.onBeforeCallArgsAndReturnValueMapper!.call.call(this, <any>arguments);
           result = fi.implementation.apply(this, <any>arguments);
-          fi.onValueObserver!.call.call(this, result);
+          fi.onAfterReturnValueObserver!.call.call(this, result);
           result = onValueMapper.call(this, result);
         }
         return result;
@@ -427,10 +427,10 @@ export class FunctionInterceptor<
 
       [InterceptorState.Has_AVM_____AO__VM___]: fi => function (this: any) {
         let result;
-        if (!fi.onArgsObserver!.call.apply(this, <any>arguments)) {
-          const onValueMapper = fi.onArgsAndValueMapper!.call.call(this, <any>arguments);
+        if (!fi.onBeforeCallArgsObserver!.call.apply(this, <any>arguments)) {
+          const onValueMapper = fi.onBeforeCallArgsAndReturnValueMapper!.call.call(this, <any>arguments);
           result = fi.implementation.apply(this, <any>arguments);
-          result = fi.onValueMapper!.call.call(this, result);
+          result = fi.onAfterReturnValueMapper!.call.call(this, result);
           result = onValueMapper.call(this, result);
         }
         return result;
@@ -438,11 +438,11 @@ export class FunctionInterceptor<
 
       [InterceptorState.Has_AVM_____AO__VM_VO]: fi => function (this: any) {
         let result;
-        if (!fi.onArgsObserver!.call.apply(this, <any>arguments)) {
-          const onValueMapper = fi.onArgsAndValueMapper!.call.call(this, <any>arguments);
+        if (!fi.onBeforeCallArgsObserver!.call.apply(this, <any>arguments)) {
+          const onValueMapper = fi.onBeforeCallArgsAndReturnValueMapper!.call.call(this, <any>arguments);
           result = fi.implementation.apply(this, <any>arguments);
-          result = fi.onValueMapper!.call.call(this, result);
-          fi.onValueObserver!.call.call(this, result);
+          result = fi.onAfterReturnValueMapper!.call.call(this, result);
+          fi.onAfterReturnValueObserver!.call.call(this, result);
           result = onValueMapper.call(this, result);
         }
         return result;
@@ -450,8 +450,8 @@ export class FunctionInterceptor<
 
       [InterceptorState.Has_AVM__AM__________]: fi => function (this: any) {
         let result;
-        const filteredArgs = fi.onArgsMapper!.call.call(this, <any>arguments); //Pass as an array
-        const onValueMapper = fi.onArgsAndValueMapper!.call.call(this, <any>arguments);
+        const filteredArgs = fi.onBeforeCallArgsMapper!.call.call(this, <any>arguments); //Pass as an array
+        const onValueMapper = fi.onBeforeCallArgsAndReturnValueMapper!.call.call(this, <any>arguments);
         result = fi.implementation.apply(this, filteredArgs);
         result = onValueMapper.call(this, result);
         return result;
@@ -459,40 +459,40 @@ export class FunctionInterceptor<
 
       [InterceptorState.Has_AVM__AM________VO]: fi => function (this: any) {
         let result;
-        const filteredArgs = fi.onArgsMapper!.call.call(this, <any>arguments); //Pass as an array
-        const onValueMapper = fi.onArgsAndValueMapper!.call.call(this, <any>arguments);
+        const filteredArgs = fi.onBeforeCallArgsMapper!.call.call(this, <any>arguments); //Pass as an array
+        const onValueMapper = fi.onBeforeCallArgsAndReturnValueMapper!.call.call(this, <any>arguments);
         result = fi.implementation.apply(this, filteredArgs);
-        fi.onValueObserver!.call.call(this, result);
+        fi.onAfterReturnValueObserver!.call.call(this, result);
         result = onValueMapper.call(this, result);
         return result;
       },
 
       [InterceptorState.Has_AVM__AM_____VM___]: fi => function (this: any) {
         let result;
-        const filteredArgs = fi.onArgsMapper!.call.call(this, <any>arguments); //Pass as an array
-        const onValueMapper = fi.onArgsAndValueMapper!.call.call(this, <any>arguments);
+        const filteredArgs = fi.onBeforeCallArgsMapper!.call.call(this, <any>arguments); //Pass as an array
+        const onValueMapper = fi.onBeforeCallArgsAndReturnValueMapper!.call.call(this, <any>arguments);
         result = fi.implementation.apply(this, filteredArgs);
-        result = fi.onValueMapper!.call.call(this, result);
+        result = fi.onAfterReturnValueMapper!.call.call(this, result);
         result = onValueMapper.call(this, result);
         return result;
       },
 
       [InterceptorState.Has_AVM__AM_____VM_VO]: fi => function (this: any) {
         let result;
-        const filteredArgs = fi.onArgsMapper!.call.call(this, <any>arguments); //Pass as an array
-        const onValueMapper = fi.onArgsAndValueMapper!.call.call(this, <any>arguments);
+        const filteredArgs = fi.onBeforeCallArgsMapper!.call.call(this, <any>arguments); //Pass as an array
+        const onValueMapper = fi.onBeforeCallArgsAndReturnValueMapper!.call.call(this, <any>arguments);
         result = fi.implementation.apply(this, filteredArgs);
-        result = fi.onValueMapper!.call.call(this, result);
-        fi.onValueObserver!.call.call(this, result);
+        result = fi.onAfterReturnValueMapper!.call.call(this, result);
+        fi.onAfterReturnValueObserver!.call.call(this, result);
         result = onValueMapper.call(this, result);
         return result;
       },
 
       [InterceptorState.Has_AVM__AM_AO_______]: fi => function (this: any) {
         let result;
-        const filteredArgs = fi.onArgsMapper!.call.call(this, <any>arguments); //Pass as an array
-        if (!fi.onArgsObserver!.call.apply(this, filteredArgs)) {
-          const onValueMapper = fi.onArgsAndValueMapper!.call.call(this, <any>arguments);
+        const filteredArgs = fi.onBeforeCallArgsMapper!.call.call(this, <any>arguments); //Pass as an array
+        if (!fi.onBeforeCallArgsObserver!.call.apply(this, filteredArgs)) {
+          const onValueMapper = fi.onBeforeCallArgsAndReturnValueMapper!.call.call(this, <any>arguments);
           result = fi.implementation.apply(this, filteredArgs);
           result = onValueMapper.call(this, result);
         }
@@ -501,11 +501,11 @@ export class FunctionInterceptor<
 
       [InterceptorState.Has_AVM__AM_AO_____VO]: fi => function (this: any) {
         let result;
-        const filteredArgs = fi.onArgsMapper!.call.call(this, <any>arguments); //Pass as an array
-        if (!fi.onArgsObserver!.call.apply(this, filteredArgs)) {
-          const onValueMapper = fi.onArgsAndValueMapper!.call.call(this, <any>arguments);
+        const filteredArgs = fi.onBeforeCallArgsMapper!.call.call(this, <any>arguments); //Pass as an array
+        if (!fi.onBeforeCallArgsObserver!.call.apply(this, filteredArgs)) {
+          const onValueMapper = fi.onBeforeCallArgsAndReturnValueMapper!.call.call(this, <any>arguments);
           result = fi.implementation.apply(this, filteredArgs);
-          fi.onValueObserver!.call.call(this, result);
+          fi.onAfterReturnValueObserver!.call.call(this, result);
           result = onValueMapper.call(this, result);
         }
         return result;
@@ -513,11 +513,11 @@ export class FunctionInterceptor<
 
       [InterceptorState.Has_AVM__AM_AO__VM___]: fi => function (this: any) {
         let result;
-        const filteredArgs = fi.onArgsMapper!.call.call(this, <any>arguments); //Pass as an array
-        if (!fi.onArgsObserver!.call.apply(this, filteredArgs)) {
-          const onValueMapper = fi.onArgsAndValueMapper!.call.call(this, <any>arguments);
+        const filteredArgs = fi.onBeforeCallArgsMapper!.call.call(this, <any>arguments); //Pass as an array
+        if (!fi.onBeforeCallArgsObserver!.call.apply(this, filteredArgs)) {
+          const onValueMapper = fi.onBeforeCallArgsAndReturnValueMapper!.call.call(this, <any>arguments);
           result = fi.implementation.apply(this, filteredArgs);
-          result = fi.onValueMapper!.call.call(this, result);
+          result = fi.onAfterReturnValueMapper!.call.call(this, result);
           result = onValueMapper.call(this, result);
         }
         return result;
@@ -525,12 +525,12 @@ export class FunctionInterceptor<
 
       [InterceptorState.Has_AVM__AM_AO__VM_VO]: fi => function (this: any) {
         let result;
-        const filteredArgs = fi.onArgsMapper!.call.call(this, <any>arguments); //Pass as an array
-        if (!fi.onArgsObserver!.call.apply(this, filteredArgs)) {
-          const onValueMapper = fi.onArgsAndValueMapper!.call.call(this, <any>arguments);
+        const filteredArgs = fi.onBeforeCallArgsMapper!.call.call(this, <any>arguments); //Pass as an array
+        if (!fi.onBeforeCallArgsObserver!.call.apply(this, filteredArgs)) {
+          const onValueMapper = fi.onBeforeCallArgsAndReturnValueMapper!.call.call(this, <any>arguments);
           result = fi.implementation.apply(this, filteredArgs);
-          result = fi.onValueMapper!.call.call(this, result);
-          fi.onValueObserver!.call.call(this, result);
+          result = fi.onAfterReturnValueMapper!.call.call(this, result);
+          fi.onAfterReturnValueObserver!.call.call(this, result);
           result = onValueMapper.call(this, result);
         }
         return result;
@@ -546,11 +546,11 @@ export class FunctionInterceptor<
         const ctor = ctors[i];
         assert(!!ctor, `unhandled interceptor state ${i}`);
         ctors[i] = fi => {
-          assert((i & InterceptorState.HasArgsMapper) === 0 || !!fi.onArgsMapper, `missing expected .onArgsFilter for state ${i}`);
-          assert((i & InterceptorState.HasArgsObserver) === 0 || !!fi.onArgsObserver, `missing expected .onArgsObserver for state ${i}`);
-          assert((i & InterceptorState.HasValueMapper) === 0 || !!fi.onValueMapper, `missing expected .onValueFilter for state ${i}`);
-          assert((i & InterceptorState.HasValueObserver) === 0 || !!fi.onValueObserver, `missing expected .onValueObserver for state ${i}`);
-          assert((i & InterceptorState.HasArgsAndValueMapper) === 0 || !!fi.onArgsAndValueMapper, `missing expected .onArgsAndValueMapper for state ${i}`);
+          assert((i & InterceptorState.HasArgsMapper) === 0 || !!fi.onBeforeCallArgsMapper, `missing expected .onArgsFilter for state ${i}`);
+          assert((i & InterceptorState.HasArgsObserver) === 0 || !!fi.onBeforeCallArgsObserver, `missing expected .onArgsObserver for state ${i}`);
+          assert((i & InterceptorState.HasValueMapper) === 0 || !!fi.onAfterReturnValueMapper, `missing expected .onValueFilter for state ${i}`);
+          assert((i & InterceptorState.HasValueObserver) === 0 || !!fi.onAfterReturnValueObserver, `missing expected .onValueObserver for state ${i}`);
+          assert((i & InterceptorState.HasArgsAndValueMapper) === 0 || !!fi.onBeforeCallArgsAndReturnValueMapper, `missing expected .onArgsAndValueMapper for state ${i}`);
           return ctor(fi);
         }
       }
@@ -561,11 +561,11 @@ export class FunctionInterceptor<
 
   private updateDispatcherFunc() {
     let state = 0;
-    state |= this.onArgsMapper ? InterceptorState.HasArgsMapper : 0;
-    state |= this.onArgsObserver ? InterceptorState.HasArgsObserver : 0;
-    state |= this.onValueMapper ? InterceptorState.HasValueMapper : 0;
-    state |= this.onValueObserver ? InterceptorState.HasValueObserver : 0;
-    state |= this.onArgsAndValueMapper ? InterceptorState.HasArgsAndValueMapper : 0;
+    state |= this.onBeforeCallArgsMapper ? InterceptorState.HasArgsMapper : 0;
+    state |= this.onBeforeCallArgsObserver ? InterceptorState.HasArgsObserver : 0;
+    state |= this.onAfterReturnValueMapper ? InterceptorState.HasValueMapper : 0;
+    state |= this.onAfterReturnValueObserver ? InterceptorState.HasValueObserver : 0;
+    state |= this.onBeforeCallArgsAndReturnValueMapper ? InterceptorState.HasArgsAndValueMapper : 0;
     //TODO: Check a cached version first
     const dispatcherCtor = FunctionInterceptor.dispatcherCtors[state];
     assert(!!dispatcherCtor, `unhandled interceptor state ${state}`);
@@ -573,86 +573,86 @@ export class FunctionInterceptor<
   }
 
   //#region helper function to lazily extend hooks
-  public onArgsMapperAdd(cb: OnArgsMapperFunc<FuncType>): typeof cb {
-    if (!this.onArgsMapper) {
-      this.onArgsMapper = new OnArgsMapper<FuncType>();
+  public onBeforeCallArgsMapperAdd(cb: OnArgsMapperFunc<FuncType>): typeof cb {
+    if (!this.onBeforeCallArgsMapper) {
+      this.onBeforeCallArgsMapper = new OnArgsMapper<FuncType>();
       this.updateDispatcherFunc();
     }
-    return this.onArgsMapper.add(cb);
+    return this.onBeforeCallArgsMapper.add(cb);
   }
-  public onArgsMapperRemove(cb: OnArgsMapperFunc<FuncType>): typeof cb {
-    if (this.onArgsMapper?.remove(cb)) {
+  public onBeforeCallArgsMapperRemove(cb: OnArgsMapperFunc<FuncType>): typeof cb {
+    if (this.onBeforeCallArgsMapper?.remove(cb)) {
       // Since we rely on the output of the callback, we should avoid empty list
-      if (!this.onArgsMapper.hasCallback()) {
-        this.onArgsMapper = null;
+      if (!this.onBeforeCallArgsMapper.hasCallback()) {
+        this.onBeforeCallArgsMapper = null;
       }
       this.updateDispatcherFunc();
     }
     return cb
   }
 
-  public onArgsObserverAdd(cb: OnArgsObserverFunc<FuncType>): typeof cb {
-    if (!this.onArgsObserver) {
-      this.onArgsObserver = new OnArgsObserver<FuncType>();
+  public onBeforeCallArgsObserverAdd(cb: OnArgsObserverFunc<FuncType>): typeof cb {
+    if (!this.onBeforeCallArgsObserver) {
+      this.onBeforeCallArgsObserver = new OnArgsObserver<FuncType>();
       this.updateDispatcherFunc();
     }
-    return this.onArgsObserver.add(cb);
+    return this.onBeforeCallArgsObserver.add(cb);
   }
-  public onArgsObserverRemove(cb: OnArgsObserverFunc<FuncType>): typeof cb {
-    if (this.onArgsObserver?.remove(cb)) {
+  public onBeforeCallArgsObserverRemove(cb: OnArgsObserverFunc<FuncType>): typeof cb {
+    if (this.onBeforeCallArgsObserver?.remove(cb)) {
       // Since we rely on the output of the callback, we should avoid empty list
-      if (!this.onArgsObserver.hasCallback()) {
-        this.onArgsObserver = null;
+      if (!this.onBeforeCallArgsObserver.hasCallback()) {
+        this.onBeforeCallArgsObserver = null;
       }
       this.updateDispatcherFunc();
     }
     return cb
   }
 
-  public onValueMapperAdd(cb: OnValueMapperFunc<FuncType>): typeof cb {
-    if (!this.onValueMapper) {
-      this.onValueMapper = new OnValueMapper<FuncType>();
+  public onAfterReturnValueMapperAdd(cb: OnValueMapperFunc<FuncType>): typeof cb {
+    if (!this.onAfterReturnValueMapper) {
+      this.onAfterReturnValueMapper = new OnValueMapper<FuncType>();
       this.updateDispatcherFunc();
     }
-    return this.onValueMapper.add(cb);
+    return this.onAfterReturnValueMapper.add(cb);
   }
-  public onValueMapperRemove(cb: OnValueMapperFunc<FuncType>): typeof cb {
-    if (this.onValueMapper?.remove(cb)) {
+  public onAfterReturnValueMapperRemove(cb: OnValueMapperFunc<FuncType>): typeof cb {
+    if (this.onAfterReturnValueMapper?.remove(cb)) {
       // Since we rely on the output of the callback, we should avoid empty list
-      if (!this.onValueMapper.hasCallback()) {
-        this.onValueMapper = null;
+      if (!this.onAfterReturnValueMapper.hasCallback()) {
+        this.onAfterReturnValueMapper = null;
       }
       this.updateDispatcherFunc();
     }
     return cb
   }
 
-  public onValueObserverAdd(cb: OnValueObserverFunc<FuncType>): typeof cb {
-    if (!this.onValueObserver) {
-      this.onValueObserver = new OnValueObserver<FuncType>();
+  public onAfterReturnValueObserverAdd(cb: OnValueObserverFunc<FuncType>): typeof cb {
+    if (!this.onAfterReturnValueObserver) {
+      this.onAfterReturnValueObserver = new OnValueObserver<FuncType>();
       this.updateDispatcherFunc();
     }
-    return this.onValueObserver.add(cb);
+    return this.onAfterReturnValueObserver.add(cb);
   }
-  public onValueObserverRemove(cb: OnValueObserverFunc<FuncType>): typeof cb {
-    if (this.onValueObserver?.remove(cb)) {
+  public onAfterReturnValueObserverRemove(cb: OnValueObserverFunc<FuncType>): typeof cb {
+    if (this.onAfterReturnValueObserver?.remove(cb)) {
       this.updateDispatcherFunc();
     }
     return cb
   }
 
-  public onArgsAndValueMapperAdd(cb: OnArgsAndValueMapperFunc<FuncType>): typeof cb {
-    if (!this.onArgsAndValueMapper) {
-      this.onArgsAndValueMapper = new OnArgsAndValueMapper<FuncType>();
+  public onBeforeCallArgsAndAfterReturnValueMapperAdd(cb: OnArgsAndValueMapperFunc<FuncType>): typeof cb {
+    if (!this.onBeforeCallArgsAndReturnValueMapper) {
+      this.onBeforeCallArgsAndReturnValueMapper = new OnArgsAndValueMapper<FuncType>();
       this.updateDispatcherFunc();
     }
-    return this.onArgsAndValueMapper.add(cb);
+    return this.onBeforeCallArgsAndReturnValueMapper.add(cb);
   }
-  public onArgsAndValueMapperRemove(cb: OnArgsAndValueMapperFunc<FuncType>): typeof cb {
-    if (this.onArgsAndValueMapper?.remove(cb)) {
+  public onBeforeCallArgsAndAfterReturnValueMapperRemove(cb: OnArgsAndValueMapperFunc<FuncType>): typeof cb {
+    if (this.onBeforeCallArgsAndReturnValueMapper?.remove(cb)) {
       // Since we rely on the output of the callback, we should avoid empty list
-      if (!this.onArgsAndValueMapper.hasCallback()) {
-        this.onArgsAndValueMapper = null;
+      if (!this.onBeforeCallArgsAndReturnValueMapper.hasCallback()) {
+        this.onBeforeCallArgsAndReturnValueMapper = null;
       }
       this.updateDispatcherFunc();
     }
@@ -683,8 +683,8 @@ type ExtendedFuncType<FuncType extends InterceptableFunction> =
   { [FuncExtensionPropName]?: GenericFunctionInterceptor<ExtendedFuncType<FuncType>> };
 
 export type GenericFunctionInterceptor<FuncType extends InterceptableFunction> =
-  FunctionInterceptor<FuncThisType<FuncType>, string, FuncType> &
-  { [index: string]: any };
+  FunctionInterceptor<FuncThisType<FuncType>, string, FuncType>
+// & { [index: string]: any };
 
 export function getFunctionInterceptor<FuncType extends InterceptableFunction>(
   func: ExtendedFuncType<FuncType> | null | undefined

--- a/packages/hyperion-core/test/AttributeInterceptor.test.ts
+++ b/packages/hyperion-core/test/AttributeInterceptor.test.ts
@@ -59,20 +59,20 @@ describe("test Attribute Interceptor", () => {
       observer.mockClear();
     }
 
-    IA.a.getter.onAfterReturnValueObserverAdd(observer);
-    IA.a.setter.onBeforeCallArgsObserverAdd(observer);
+    IA.a.getter.onAfterCallObserverAdd(observer);
+    IA.a.setter.onBeforeCallObserverAdd(observer);
 
-    IA.foo.getter.onAfterReturnValueObserverAdd(observer);
-    IA.foo.setter.onBeforeCallArgsObserverAdd(observer);
+    IA.foo.getter.onAfterCallObserverAdd(observer);
+    IA.foo.setter.onBeforeCallObserverAdd(observer);
 
-    IA.bar.getter.onAfterReturnValueObserverAdd(observer);
-    IA.bar.setter.onBeforeCallArgsObserverAdd(observer);
+    IA.bar.getter.onAfterCallObserverAdd(observer);
+    IA.bar.setter.onBeforeCallObserverAdd(observer);
 
-    IA.baz.getter.onAfterReturnValueObserverAdd(observer);
-    IA.baz.setter.onBeforeCallArgsObserverAdd(observer);
+    IA.baz.getter.onAfterCallObserverAdd(observer);
+    IA.baz.setter.onBeforeCallObserverAdd(observer);
 
-    IB.b.getter.onAfterReturnValueObserverAdd(observer);
-    IB.b.setter.onBeforeCallArgsObserverAdd(observer);
+    IB.b.getter.onAfterCallObserverAdd(observer);
+    IB.b.setter.onBeforeCallObserverAdd(observer);
 
     // a sequence of read/writes
     o.a = o.a + 20;
@@ -127,16 +127,16 @@ describe("test Attribute Interceptor", () => {
     const b = new B();
 
     const A_a_getter_observer = jest.fn();
-    IA.a.getter.onAfterReturnValueObserverAdd(A_a_getter_observer);
+    IA.a.getter.onAfterCallObserverAdd(A_a_getter_observer);
 
     const A_a_setter_observer = jest.fn();
-    IA.a.setter.onBeforeCallArgsObserverAdd(A_a_setter_observer);
+    IA.a.setter.onBeforeCallObserverAdd(A_a_setter_observer);
 
     const B_a_getter_observer = jest.fn();
-    IB.a.getter.onAfterReturnValueObserverAdd(B_a_getter_observer);
+    IB.a.getter.onAfterCallObserverAdd(B_a_getter_observer);
 
     const B_a_setter_observer = jest.fn();
-    IB.a.setter.onBeforeCallArgsObserverAdd(B_a_setter_observer);
+    IB.a.setter.onBeforeCallObserverAdd(B_a_setter_observer);
 
     a.a = 1;
     expect(A_a_setter_observer.mock.calls.length).toBe(1);

--- a/packages/hyperion-core/test/AttributeInterceptor.test.ts
+++ b/packages/hyperion-core/test/AttributeInterceptor.test.ts
@@ -59,20 +59,20 @@ describe("test Attribute Interceptor", () => {
       observer.mockClear();
     }
 
-    IA.a.getter.onValueObserverAdd(observer);
-    IA.a.setter.onArgsObserverAdd(observer);
+    IA.a.getter.onAfterReturnValueObserverAdd(observer);
+    IA.a.setter.onBeforeCallArgsObserverAdd(observer);
 
-    IA.foo.getter.onValueObserverAdd(observer);
-    IA.foo.setter.onArgsObserverAdd(observer);
+    IA.foo.getter.onAfterReturnValueObserverAdd(observer);
+    IA.foo.setter.onBeforeCallArgsObserverAdd(observer);
 
-    IA.bar.getter.onValueObserverAdd(observer);
-    IA.bar.setter.onArgsObserverAdd(observer);
+    IA.bar.getter.onAfterReturnValueObserverAdd(observer);
+    IA.bar.setter.onBeforeCallArgsObserverAdd(observer);
 
-    IA.baz.getter.onValueObserverAdd(observer);
-    IA.baz.setter.onArgsObserverAdd(observer);
+    IA.baz.getter.onAfterReturnValueObserverAdd(observer);
+    IA.baz.setter.onBeforeCallArgsObserverAdd(observer);
 
-    IB.b.getter.onValueObserverAdd(observer);
-    IB.b.setter.onArgsObserverAdd(observer);
+    IB.b.getter.onAfterReturnValueObserverAdd(observer);
+    IB.b.setter.onBeforeCallArgsObserverAdd(observer);
 
     // a sequence of read/writes
     o.a = o.a + 20;
@@ -127,16 +127,16 @@ describe("test Attribute Interceptor", () => {
     const b = new B();
 
     const A_a_getter_observer = jest.fn();
-    IA.a.getter.onValueObserverAdd(A_a_getter_observer);
+    IA.a.getter.onAfterReturnValueObserverAdd(A_a_getter_observer);
 
     const A_a_setter_observer = jest.fn();
-    IA.a.setter.onArgsObserverAdd(A_a_setter_observer);
+    IA.a.setter.onBeforeCallArgsObserverAdd(A_a_setter_observer);
 
     const B_a_getter_observer = jest.fn();
-    IB.a.getter.onValueObserverAdd(B_a_getter_observer);
+    IB.a.getter.onAfterReturnValueObserverAdd(B_a_getter_observer);
 
     const B_a_setter_observer = jest.fn();
-    IB.a.setter.onArgsObserverAdd(B_a_setter_observer);
+    IB.a.setter.onBeforeCallArgsObserverAdd(B_a_setter_observer);
 
     a.a = 1;
     expect(A_a_setter_observer.mock.calls.length).toBe(1);

--- a/packages/hyperion-core/test/ConstructorInterceptor.test.ts
+++ b/packages/hyperion-core/test/ConstructorInterceptor.test.ts
@@ -74,22 +74,22 @@ describe("test Constructor Interceptor", () => {
       result = [];
     }
 
-    IBCtor.onArgsMapperAdd(function (this, args) {
+    IBCtor.onBeforeCallArgsMapperAdd(function (this, args) {
       observer([...args]);
       args[0] += 1;
       args[1] += "-world";
       return args;
     })
-    IBCtor.onArgsObserverAdd(function (this, n, s) {
+    IBCtor.onBeforeCallArgsObserverAdd(function (this, n, s) {
       observer([n, s]);
     })
 
-    IBCtor.onValueMapperAdd(function (this, value) {
+    IBCtor.onAfterReturnValueMapperAdd(function (this, value) {
       observer(value);
       return value;
     })
 
-    IBCtor.onValueObserverAdd(function (this, value) {
+    IBCtor.onAfterReturnValueObserverAdd(function (this, value) {
       observer(value);
     })
 
@@ -111,19 +111,19 @@ describe("test Constructor Interceptor", () => {
     }
 
     // IAShadow.onAfterInterceptObj(argsObserver);
-    IBCtor.onArgsObserverAdd(function (value) {
+    IBCtor.onBeforeCallArgsObserverAdd(function (value) {
       observer(value);
     })
-    IBCtor.onArgsMapperAdd(function (this, value) {
+    IBCtor.onBeforeCallArgsMapperAdd(function (this, value) {
       const a0 = value[0];
       observer(a0);
       value[0] = a0 + 1;
       return value;
     })
-    IBCtor.onValueObserverAdd(function (this, value) {
+    IBCtor.onAfterReturnValueObserverAdd(function (this, value) {
       observer(value);
     })
-    IBCtor.onValueMapperAdd(function (this, value) {
+    IBCtor.onAfterReturnValueMapperAdd(function (this, value) {
       observer(value);
       return value;
     })
@@ -131,20 +131,20 @@ describe("test Constructor Interceptor", () => {
     const o = new Ctors.B(20);
     expectResultTobe("ctor", [20, 21, o, o]);
 
-    IA.a.getter.onValueObserverAdd(observer);
-    IA.a.setter.onArgsObserverAdd(observer);
+    IA.a.getter.onAfterReturnValueObserverAdd(observer);
+    IA.a.setter.onBeforeCallArgsObserverAdd(observer);
 
-    IA.foo.getter.onValueObserverAdd(observer);
-    IA.foo.setter.onArgsObserverAdd(observer);
+    IA.foo.getter.onAfterReturnValueObserverAdd(observer);
+    IA.foo.setter.onBeforeCallArgsObserverAdd(observer);
 
-    IA.bar.getter.onValueObserverAdd(observer);
-    IA.bar.setter.onArgsObserverAdd(observer);
+    IA.bar.getter.onAfterReturnValueObserverAdd(observer);
+    IA.bar.setter.onBeforeCallArgsObserverAdd(observer);
 
-    IA.baz.getter.onValueObserverAdd(observer);
-    IA.baz.setter.onArgsObserverAdd(observer);
+    IA.baz.getter.onAfterReturnValueObserverAdd(observer);
+    IA.baz.setter.onBeforeCallArgsObserverAdd(observer);
 
-    IB.b.getter.onValueObserverAdd(observer);
-    IB.b.setter.onArgsObserverAdd(observer);
+    IB.b.getter.onAfterReturnValueObserverAdd(observer);
+    IB.b.setter.onBeforeCallArgsObserverAdd(observer);
 
     // a sequence of read/writes
     o.a = o.a + 20;

--- a/packages/hyperion-core/test/ConstructorInterceptor.test.ts
+++ b/packages/hyperion-core/test/ConstructorInterceptor.test.ts
@@ -74,22 +74,22 @@ describe("test Constructor Interceptor", () => {
       result = [];
     }
 
-    IBCtor.onBeforeCallArgsMapperAdd(function (this, args) {
+    IBCtor.onBeforeCallMapperAdd(function (this, args) {
       observer([...args]);
       args[0] += 1;
       args[1] += "-world";
       return args;
     })
-    IBCtor.onBeforeCallArgsObserverAdd(function (this, n, s) {
+    IBCtor.onBeforeCallObserverAdd(function (this, n, s) {
       observer([n, s]);
     })
 
-    IBCtor.onAfterReturnValueMapperAdd(function (this, value) {
+    IBCtor.onAfterCallMapperAdd(function (this, value) {
       observer(value);
       return value;
     })
 
-    IBCtor.onAfterReturnValueObserverAdd(function (this, value) {
+    IBCtor.onAfterCallObserverAdd(function (this, value) {
       observer(value);
     })
 
@@ -111,19 +111,19 @@ describe("test Constructor Interceptor", () => {
     }
 
     // IAShadow.onAfterInterceptObj(argsObserver);
-    IBCtor.onBeforeCallArgsObserverAdd(function (value) {
+    IBCtor.onBeforeCallObserverAdd(function (value) {
       observer(value);
     })
-    IBCtor.onBeforeCallArgsMapperAdd(function (this, value) {
+    IBCtor.onBeforeCallMapperAdd(function (this, value) {
       const a0 = value[0];
       observer(a0);
       value[0] = a0 + 1;
       return value;
     })
-    IBCtor.onAfterReturnValueObserverAdd(function (this, value) {
+    IBCtor.onAfterCallObserverAdd(function (this, value) {
       observer(value);
     })
-    IBCtor.onAfterReturnValueMapperAdd(function (this, value) {
+    IBCtor.onAfterCallMapperAdd(function (this, value) {
       observer(value);
       return value;
     })
@@ -131,20 +131,20 @@ describe("test Constructor Interceptor", () => {
     const o = new Ctors.B(20);
     expectResultTobe("ctor", [20, 21, o, o]);
 
-    IA.a.getter.onAfterReturnValueObserverAdd(observer);
-    IA.a.setter.onBeforeCallArgsObserverAdd(observer);
+    IA.a.getter.onAfterCallObserverAdd(observer);
+    IA.a.setter.onBeforeCallObserverAdd(observer);
 
-    IA.foo.getter.onAfterReturnValueObserverAdd(observer);
-    IA.foo.setter.onBeforeCallArgsObserverAdd(observer);
+    IA.foo.getter.onAfterCallObserverAdd(observer);
+    IA.foo.setter.onBeforeCallObserverAdd(observer);
 
-    IA.bar.getter.onAfterReturnValueObserverAdd(observer);
-    IA.bar.setter.onBeforeCallArgsObserverAdd(observer);
+    IA.bar.getter.onAfterCallObserverAdd(observer);
+    IA.bar.setter.onBeforeCallObserverAdd(observer);
 
-    IA.baz.getter.onAfterReturnValueObserverAdd(observer);
-    IA.baz.setter.onBeforeCallArgsObserverAdd(observer);
+    IA.baz.getter.onAfterCallObserverAdd(observer);
+    IA.baz.setter.onBeforeCallObserverAdd(observer);
 
-    IB.b.getter.onAfterReturnValueObserverAdd(observer);
-    IB.b.setter.onBeforeCallArgsObserverAdd(observer);
+    IB.b.getter.onAfterCallObserverAdd(observer);
+    IB.b.setter.onBeforeCallObserverAdd(observer);
 
     // a sequence of read/writes
     o.a = o.a + 20;

--- a/packages/hyperion-core/test/FunctionInterceptor.test.ts
+++ b/packages/hyperion-core/test/FunctionInterceptor.test.ts
@@ -59,8 +59,8 @@ describe("test modern classes", () => {
     const func = (i: number, s: string) => i + s.length;
     func.x = 42;
     const fi = interceptFunction(func, false, null, "tester");
-    const argObserver = fi.onBeforeCallArgsObserverAdd(jest.fn());
-    const valueObserver = fi.onAfterReturnValueObserverAdd(jest.fn());
+    const argObserver = fi.onBeforeCallObserverAdd(jest.fn());
+    const valueObserver = fi.onAfterCallObserverAdd(jest.fn());
     expect(fi.getOriginal()).toStrictEqual(func);
     expect(fi.interceptor.x).toBe(func.x);
     const result = fi.interceptor(10, "12345");
@@ -200,7 +200,7 @@ describe("test modern classes", () => {
       let arg0Filtered = arg0;
 
       if (state & InterceptorState.HasArgsMapper) {
-        IA.a.onBeforeCallArgsMapperAdd(function (value) {
+        IA.a.onBeforeCallMapperAdd(function (value) {
           const a1 = value[0];
           expect(a1).toBe(arg0);
 
@@ -213,7 +213,7 @@ describe("test modern classes", () => {
       }
 
       if (state & InterceptorState.HasArgsObserver) {
-        IA.a.onBeforeCallArgsObserverAdd(value => {
+        IA.a.onBeforeCallObserverAdd(value => {
           result += value;
           expect(value).toBe(arg0Filtered);
         });
@@ -224,7 +224,7 @@ describe("test modern classes", () => {
       let value0Filtered = value0;
 
       if (state & InterceptorState.HasValueMapper) {
-        IA.a.onAfterReturnValueMapperAdd(value => {
+        IA.a.onAfterCallMapperAdd(value => {
           expect(value).toBe(value0);
           result += value;
           return `{${value}}`;
@@ -233,7 +233,7 @@ describe("test modern classes", () => {
         value0Filtered = `{${value0}}`;
       }
       if (state & InterceptorState.HasValueObserver) {
-        IA.a.onAfterReturnValueObserverAdd(value => {
+        IA.a.onAfterCallObserverAdd(value => {
           result += value;
           expect(value).toBe(value0Filtered);
         });
@@ -254,10 +254,10 @@ describe("test modern classes", () => {
   test("test .interception remove hooks", () => {
     const { IA, B } = testSetup();
     let hookCalled = 0;
-    IA.a.onBeforeCallArgsMapperRemove(IA.a.onBeforeCallArgsMapperAdd(value => (hookCalled++, value)));
-    IA.a.onBeforeCallArgsObserverRemove(IA.a.onBeforeCallArgsObserverAdd(_ => { hookCalled++ }));
-    IA.a.onAfterReturnValueMapperRemove(IA.a.onAfterReturnValueMapperAdd(value => (hookCalled++, value)));
-    IA.a.onAfterReturnValueObserverRemove(IA.a.onAfterReturnValueObserverAdd(_ => { hookCalled++ }));
+    IA.a.onBeforeCallMapperRemove(IA.a.onBeforeCallMapperAdd(value => (hookCalled++, value)));
+    IA.a.onBeforeCallObserverRemove(IA.a.onBeforeCallObserverAdd(_ => { hookCalled++ }));
+    IA.a.onAfterCallMapperRemove(IA.a.onAfterCallMapperAdd(value => (hookCalled++, value)));
+    IA.a.onAfterCallObserverRemove(IA.a.onAfterCallObserverAdd(_ => { hookCalled++ }));
 
     const o = new B();
     o.a('1');
@@ -267,7 +267,7 @@ describe("test modern classes", () => {
   test("test interception hooks this-arg type", () => {
     const { IA, A, IB, B } = testSetup();
     const o = new B();
-    IA.a.onBeforeCallArgsObserverAdd(function (this, value) {
+    IA.a.onBeforeCallObserverAdd(function (this, value) {
       expect(this instanceof A).toBe(true);
 
       expect(typeof this.a).toBe("function");
@@ -276,7 +276,7 @@ describe("test modern classes", () => {
       expect(typeof this.b).toBe("function");
     });
 
-    IB.b.onBeforeCallArgsObserverAdd(function (this) {
+    IB.b.onBeforeCallObserverAdd(function (this) {
       expect(this instanceof A).toBe(true);
       expect(this instanceof B).toBe(true);
 
@@ -298,9 +298,9 @@ describe("test modern classes", () => {
       result.push(value);
     };
 
-    IA.foo.onBeforeCallArgsObserverAdd(argsObserver);
-    IA.bar.onBeforeCallArgsObserverAdd(argsObserver)
-    IA.baz.onBeforeCallArgsObserverAdd(argsObserver)
+    IA.foo.onBeforeCallObserverAdd(argsObserver);
+    IA.bar.onBeforeCallObserverAdd(argsObserver)
+    IA.baz.onBeforeCallObserverAdd(argsObserver)
 
     o.foo = function (this, b) { return !b; }
     o.bar = n => 2 * n;
@@ -345,10 +345,10 @@ describe("test modern classes", () => {
     const b = new B();
 
     const A_foo_observer = jest.fn();
-    IA_foo.onBeforeCallArgsObserverAdd(A_foo_observer);
+    IA_foo.onBeforeCallObserverAdd(A_foo_observer);
 
     const B_foo_observer = jest.fn();
-    IB_foo.onBeforeCallArgsObserverAdd(B_foo_observer);
+    IB_foo.onBeforeCallObserverAdd(B_foo_observer);
 
     a.foo(1);
     expect(A_foo_observer.mock.calls.length).toBe(1);
@@ -365,8 +365,8 @@ describe("test modern classes", () => {
     const observer = jest.fn<number, [number]>(i => i);
     const fi = interceptFunction(observer);
     const argMappers = [
-      fi.onBeforeCallArgsMapperAdd(([i]) => [i * 2]),
-      fi.onBeforeCallArgsMapperAdd(([i]) => [i * 3]),
+      fi.onBeforeCallMapperAdd(([i]) => [i * 2]),
+      fi.onBeforeCallMapperAdd(([i]) => [i * 3]),
     ];
 
     const input = 1;
@@ -376,11 +376,11 @@ describe("test modern classes", () => {
     expect(observer.mock.calls[0][0]).toBe(output);
     expect(observer.mock.results[0].value).toBe(output);
 
-    argMappers.forEach(h => fi.onBeforeCallArgsMapperRemove(h));
+    argMappers.forEach(h => fi.onBeforeCallMapperRemove(h));
 
     const valueMappers = [
-      fi.onAfterReturnValueMapperAdd(i => i * 5),
-      fi.onAfterReturnValueMapperAdd(i => i * 7),
+      fi.onAfterCallMapperAdd(i => i * 5),
+      fi.onAfterCallMapperAdd(i => i * 7),
     ];
 
     output = fi.interceptor(input);
@@ -389,7 +389,7 @@ describe("test modern classes", () => {
     expect(observer.mock.calls[1][0]).toBe(input);
     expect(observer.mock.results[1].value).toBe(input);
 
-    valueMappers.forEach(h => fi.onAfterReturnValueMapperRemove(h));
+    valueMappers.forEach(h => fi.onAfterCallMapperRemove(h));
 
     output = fi.interceptor(input);
     expect(output).toBe(input);
@@ -419,14 +419,14 @@ describe("test modern classes", () => {
   test("arg observers blocking call", () => {
     const fn = jest.fn<void, [number]>(i => { });
     const fi = interceptFunction(fn);
-    fi.onBeforeCallArgsObserverAdd(i => i === 0); // filters 0
+    fi.onBeforeCallObserverAdd(i => i === 0); // filters 0
 
     fi.interceptor(0); // should be blocked
     fi.interceptor(1); // should go through
     expect(fn).toBeCalledTimes(1);
     expect(fn.mock.calls[0][0]).toBe(1);
 
-    fi.onBeforeCallArgsObserverAdd(i => i === 1); // filters 1
+    fi.onBeforeCallObserverAdd(i => i === 1); // filters 1
 
     fn.mockClear();
     fi.interceptor(0); // should be blocked
@@ -438,7 +438,7 @@ describe("test modern classes", () => {
     const fn = jest.fn<number, [number]>(i => i);
     const fi = interceptFunction(fn);
 
-    const handler1 = fi.onBeforeCallArgsAndAfterReturnValueMapperAdd(args => {
+    const handler1 = fi.onBeforeAndAfterCallMapperAdd(args => {
       args[0] *= 3;
       return value => {
         return value * 5;
@@ -451,7 +451,7 @@ describe("test modern classes", () => {
     expect(fn.mock.results[0].value).toBe((2 * 3));
     expect(result).toBe((2 * 3) * 5);
 
-    const handler2 = fi.onBeforeCallArgsAndAfterReturnValueMapperAdd(args => {
+    const handler2 = fi.onBeforeAndAfterCallMapperAdd(args => {
       args[0] *= 7;
       return value => {
         return value * 11;
@@ -464,8 +464,8 @@ describe("test modern classes", () => {
     expect(fn.mock.results[1].value).toBe(((2 * 3) * 7));
     expect(result).toBe((((2 * 3) * 7) * 5) * 11);
 
-    fi.onBeforeCallArgsAndAfterReturnValueMapperRemove(handler2);
-    fi.onBeforeCallArgsAndAfterReturnValueMapperRemove(handler1);
+    fi.onBeforeAndAfterCallMapperRemove(handler2);
+    fi.onBeforeAndAfterCallMapperRemove(handler1);
 
     result = fi.interceptor(2);
     expect(fn).toBeCalledTimes(3);
@@ -489,15 +489,15 @@ describe("test modern classes", () => {
     func = fi.interceptor;
 
     let ephemeralValue: number = 0;
-    fi.onBeforeCallArgsObserverAdd(i => {
+    fi.onBeforeCallObserverAdd(i => {
       ephemeralValue = i;
     });
-    fi.onAfterReturnValueObserverAdd(value => {
+    fi.onAfterCallObserverAdd(value => {
       expect(ephemeralValue).toBe(0);
     });
 
     let callCount = 0;
-    fi.onBeforeCallArgsAndAfterReturnValueMapperAdd(args => {
+    fi.onBeforeAndAfterCallMapperAdd(args => {
       callCount++;
       return value => {
         expect(value.length).toBe(args[0]);

--- a/packages/hyperion-core/test/IGlobalThis.test.ts
+++ b/packages/hyperion-core/test/IGlobalThis.test.ts
@@ -12,7 +12,7 @@ function wrapHandler(handler: Function | string, observer: jest.Mock<any, any>) 
     handler = new Function(handler);
   };
   const fi = interceptFunction(handler);
-  fi.onBeforeCallArgsObserverAdd(observer);
+  fi.onBeforeCallObserverAdd(observer);
   return fi.interceptor;
 }
 
@@ -20,7 +20,7 @@ describe('test Global Scope interception', () => {
 
   test('test setTImeout', async () => {
     const observer = jest.fn();
-    IGlobalThis.setTimeout.onBeforeCallArgsMapperAdd(args => {
+    IGlobalThis.setTimeout.onBeforeCallMapperAdd(args => {
       args[0] = wrapHandler(args[0], observer);
       return args;
     });
@@ -40,7 +40,7 @@ describe('test Global Scope interception', () => {
 
   test('test setInterval', async () => {
     const observer = jest.fn();
-    IGlobalThis.setInterval.onBeforeCallArgsMapperAdd(args => {
+    IGlobalThis.setInterval.onBeforeCallMapperAdd(args => {
       args[0] = wrapHandler(args[0], observer);
       return args;
     });

--- a/packages/hyperion-core/test/IGlobalThis.test.ts
+++ b/packages/hyperion-core/test/IGlobalThis.test.ts
@@ -12,7 +12,7 @@ function wrapHandler(handler: Function | string, observer: jest.Mock<any, any>) 
     handler = new Function(handler);
   };
   const fi = interceptFunction(handler);
-  fi.onArgsObserverAdd(observer);
+  fi.onBeforeCallArgsObserverAdd(observer);
   return fi.interceptor;
 }
 
@@ -20,7 +20,7 @@ describe('test Global Scope interception', () => {
 
   test('test setTImeout', async () => {
     const observer = jest.fn();
-    IGlobalThis.setTimeout.onArgsMapperAdd(args => {
+    IGlobalThis.setTimeout.onBeforeCallArgsMapperAdd(args => {
       args[0] = wrapHandler(args[0], observer);
       return args;
     });
@@ -40,7 +40,7 @@ describe('test Global Scope interception', () => {
 
   test('test setInterval', async () => {
     const observer = jest.fn();
-    IGlobalThis.setInterval.onArgsMapperAdd(args => {
+    IGlobalThis.setInterval.onBeforeCallArgsMapperAdd(args => {
       args[0] = wrapHandler(args[0], observer);
       return args;
     });

--- a/packages/hyperion-core/test/IPromise.test.ts
+++ b/packages/hyperion-core/test/IPromise.test.ts
@@ -13,15 +13,15 @@ describe('test Promise', () => {
     const argsObserver = jest.fn();
     const valueObserver = jest.fn();
 
-    const handler = IPromise.constructor.onBeforeCallArgsAndAfterReturnValueMapperAdd(args => {
+    const handler = IPromise.constructor.onBeforeAndAfterCallMapperAdd(args => {
       const executor = args[0];
       const fi = interceptFunction(executor);
       args[0] = fi.interceptor;
-      fi.onBeforeCallArgsMapperAdd(args => {
+      fi.onBeforeCallMapperAdd(args => {
         const resolve = args[0];
         const resolveFI = interceptFunction(resolve);
         args[0] = resolveFI.interceptor;
-        resolveFI.onBeforeCallArgsObserverAdd(argsObserver);
+        resolveFI.onBeforeCallObserverAdd(argsObserver);
         return args;
       })
       return value => {
@@ -39,18 +39,18 @@ describe('test Promise', () => {
     expect(argsObserver).toBeCalledWith(10);
     expect(valueObserver).toBeCalledWith(p);
 
-    IPromise.constructor.onBeforeCallArgsAndAfterReturnValueMapperRemove(handler);
+    IPromise.constructor.onBeforeAndAfterCallMapperRemove(handler);
   });
 
   test('test promise.then', async () => {
     const thenArgsObserver = jest.fn();
     const thenValueObserver = jest.fn();
 
-    const argsMapper = IPromise.then.onBeforeCallArgsMapperAdd(([onfulfilled, onrejected]) => {
+    const argsMapper = IPromise.then.onBeforeCallMapperAdd(([onfulfilled, onrejected]) => {
       if (onfulfilled) {
         const wrappedOnfulfilled = interceptFunction(onfulfilled);
-        wrappedOnfulfilled.onBeforeCallArgsObserverAdd(thenArgsObserver);
-        wrappedOnfulfilled.onAfterReturnValueObserverAdd(thenValueObserver);
+        wrappedOnfulfilled.onBeforeCallObserverAdd(thenArgsObserver);
+        wrappedOnfulfilled.onAfterCallObserverAdd(thenValueObserver);
         onfulfilled = wrappedOnfulfilled.interceptor;
       }
       return [onfulfilled, onrejected];
@@ -60,18 +60,18 @@ describe('test Promise', () => {
     expect(thenArgsObserver).toBeCalledWith(10);
     expect(thenValueObserver).toBeCalledWith(42);
 
-    IPromise.then.onBeforeCallArgsMapperRemove(argsMapper);
+    IPromise.then.onBeforeCallMapperRemove(argsMapper);
   });
 
   test('test promise.catch', async () => {
     const thenArgsObserver = jest.fn();
     const thenValueObserver = jest.fn();
 
-    const argsMapper1 = IPromise.then.onBeforeCallArgsMapperAdd(([onfulfilled, onrejected]) => {
+    const argsMapper1 = IPromise.then.onBeforeCallMapperAdd(([onfulfilled, onrejected]) => {
       if (onfulfilled) {
         const wrappedOnfulfilled = interceptFunction(onfulfilled);
-        wrappedOnfulfilled.onBeforeCallArgsObserverAdd(thenArgsObserver);
-        wrappedOnfulfilled.onAfterReturnValueObserverAdd(thenValueObserver);
+        wrappedOnfulfilled.onBeforeCallObserverAdd(thenArgsObserver);
+        wrappedOnfulfilled.onAfterCallObserverAdd(thenValueObserver);
         onfulfilled = wrappedOnfulfilled.interceptor;
       }
       return [onfulfilled, onrejected];
@@ -80,11 +80,11 @@ describe('test Promise', () => {
 
     const catchArgsObserver = jest.fn();
     const catchValueObserver = jest.fn();
-    const argsMapper2 = IPromise.Catch.onBeforeCallArgsMapperAdd(([onrejected]) => {
+    const argsMapper2 = IPromise.Catch.onBeforeCallMapperAdd(([onrejected]) => {
       if (onrejected) {
         const wrapped = interceptFunction(onrejected);
-        wrapped.onBeforeCallArgsObserverAdd(catchArgsObserver);
-        wrapped.onAfterReturnValueObserverAdd(catchValueObserver);
+        wrapped.onBeforeCallObserverAdd(catchArgsObserver);
+        wrapped.onAfterCallObserverAdd(catchValueObserver);
         onrejected = wrapped.interceptor;
       }
       return [onrejected];
@@ -98,7 +98,7 @@ describe('test Promise', () => {
     expect(thenArgsObserver).toBeCalledWith(510);
     expect(thenValueObserver).toBeCalledWith(542);
 
-    IPromise.then.onBeforeCallArgsMapperRemove(argsMapper1);
+    IPromise.then.onBeforeCallMapperRemove(argsMapper1);
 
   });
 
@@ -122,14 +122,14 @@ describe('test Promise', () => {
   ] as const).forEach(([interceptor, tester]) => {
     test(`test Promise.${interceptor.name} static method`, async () => {
       const argsObserver = jest.fn();
-      const handler = interceptor.onBeforeCallArgsObserverAdd(values => {
+      const handler = interceptor.onBeforeCallObserverAdd(values => {
         argsObserver(values);
       });
       try {
         await tester();
       } catch { }
       expect(argsObserver).toBeCalledTimes(1);
-      interceptor.onBeforeCallArgsObserverRemove(handler);
+      interceptor.onBeforeCallObserverRemove(handler);
     });
   });
 

--- a/packages/hyperion-core/test/IPromise.test.ts
+++ b/packages/hyperion-core/test/IPromise.test.ts
@@ -13,15 +13,15 @@ describe('test Promise', () => {
     const argsObserver = jest.fn();
     const valueObserver = jest.fn();
 
-    const handler = IPromise.constructor.onArgsAndValueMapperAdd(args => {
+    const handler = IPromise.constructor.onBeforeCallArgsAndAfterReturnValueMapperAdd(args => {
       const executor = args[0];
       const fi = interceptFunction(executor);
       args[0] = fi.interceptor;
-      fi.onArgsMapperAdd(args => {
+      fi.onBeforeCallArgsMapperAdd(args => {
         const resolve = args[0];
         const resolveFI = interceptFunction(resolve);
         args[0] = resolveFI.interceptor;
-        resolveFI.onArgsObserverAdd(argsObserver);
+        resolveFI.onBeforeCallArgsObserverAdd(argsObserver);
         return args;
       })
       return value => {
@@ -39,18 +39,18 @@ describe('test Promise', () => {
     expect(argsObserver).toBeCalledWith(10);
     expect(valueObserver).toBeCalledWith(p);
 
-    IPromise.constructor.onArgsAndValueMapperRemove(handler);
+    IPromise.constructor.onBeforeCallArgsAndAfterReturnValueMapperRemove(handler);
   });
 
   test('test promise.then', async () => {
     const thenArgsObserver = jest.fn();
     const thenValueObserver = jest.fn();
 
-    const argsMapper = IPromise.then.onArgsMapperAdd(([onfulfilled, onrejected]) => {
+    const argsMapper = IPromise.then.onBeforeCallArgsMapperAdd(([onfulfilled, onrejected]) => {
       if (onfulfilled) {
         const wrappedOnfulfilled = interceptFunction(onfulfilled);
-        wrappedOnfulfilled.onArgsObserverAdd(thenArgsObserver);
-        wrappedOnfulfilled.onValueObserverAdd(thenValueObserver);
+        wrappedOnfulfilled.onBeforeCallArgsObserverAdd(thenArgsObserver);
+        wrappedOnfulfilled.onAfterReturnValueObserverAdd(thenValueObserver);
         onfulfilled = wrappedOnfulfilled.interceptor;
       }
       return [onfulfilled, onrejected];
@@ -60,18 +60,18 @@ describe('test Promise', () => {
     expect(thenArgsObserver).toBeCalledWith(10);
     expect(thenValueObserver).toBeCalledWith(42);
 
-    IPromise.then.onArgsMapperRemove(argsMapper);
+    IPromise.then.onBeforeCallArgsMapperRemove(argsMapper);
   });
 
   test('test promise.catch', async () => {
     const thenArgsObserver = jest.fn();
     const thenValueObserver = jest.fn();
 
-    const argsMapper1 = IPromise.then.onArgsMapperAdd(([onfulfilled, onrejected]) => {
+    const argsMapper1 = IPromise.then.onBeforeCallArgsMapperAdd(([onfulfilled, onrejected]) => {
       if (onfulfilled) {
         const wrappedOnfulfilled = interceptFunction(onfulfilled);
-        wrappedOnfulfilled.onArgsObserverAdd(thenArgsObserver);
-        wrappedOnfulfilled.onValueObserverAdd(thenValueObserver);
+        wrappedOnfulfilled.onBeforeCallArgsObserverAdd(thenArgsObserver);
+        wrappedOnfulfilled.onAfterReturnValueObserverAdd(thenValueObserver);
         onfulfilled = wrappedOnfulfilled.interceptor;
       }
       return [onfulfilled, onrejected];
@@ -80,11 +80,11 @@ describe('test Promise', () => {
 
     const catchArgsObserver = jest.fn();
     const catchValueObserver = jest.fn();
-    const argsMapper2 = IPromise.Catch.onArgsMapperAdd(([onrejected]) => {
+    const argsMapper2 = IPromise.Catch.onBeforeCallArgsMapperAdd(([onrejected]) => {
       if (onrejected) {
         const wrapped = interceptFunction(onrejected);
-        wrapped.onArgsObserverAdd(catchArgsObserver);
-        wrapped.onValueObserverAdd(catchValueObserver);
+        wrapped.onBeforeCallArgsObserverAdd(catchArgsObserver);
+        wrapped.onAfterReturnValueObserverAdd(catchValueObserver);
         onrejected = wrapped.interceptor;
       }
       return [onrejected];
@@ -98,7 +98,7 @@ describe('test Promise', () => {
     expect(thenArgsObserver).toBeCalledWith(510);
     expect(thenValueObserver).toBeCalledWith(542);
 
-    IPromise.then.onArgsMapperRemove(argsMapper1);
+    IPromise.then.onBeforeCallArgsMapperRemove(argsMapper1);
 
   });
 
@@ -122,14 +122,14 @@ describe('test Promise', () => {
   ] as const).forEach(([interceptor, tester]) => {
     test(`test Promise.${interceptor.name} static method`, async () => {
       const argsObserver = jest.fn();
-      const handler = interceptor.onArgsObserverAdd(values => {
+      const handler = interceptor.onBeforeCallArgsObserverAdd(values => {
         argsObserver(values);
       });
       try {
         await tester();
       } catch { }
       expect(argsObserver).toBeCalledTimes(1);
-      interceptor.onArgsObserverRemove(handler);
+      interceptor.onBeforeCallArgsObserverRemove(handler);
     });
   });
 

--- a/packages/hyperion-core/test/IRequire.test.ts
+++ b/packages/hyperion-core/test/IRequire.test.ts
@@ -13,7 +13,7 @@ import * as TestModuleDefaultExports from "./IRequireTestModuleDefault";
 describe("Test interception of module exports", () => {
   test('Intercept normal module', () => {
     const IModule = IRequire.interceptModuleExports("IRequireTestModule", TestModule, ["foo"], []);
-    const handler = IModule.foo.onArgsObserverAdd(jest.fn(i => console.log(i)));
+    const handler = IModule.foo.onBeforeCallArgsObserverAdd(jest.fn(i => console.log(i)));
     TestModule.foo(10);
     expect(handler).toBeCalledTimes(1);
     expect(handler).toBeCalledWith(10);
@@ -22,7 +22,7 @@ describe("Test interception of module exports", () => {
   test('Intercept module with defaults', () => {
     const IModule = IRequire.interceptModuleExports("IRequireTestModuleDefaultExports", TestModuleDefaultExports, ["default"], []);
 
-    const handler = IModule.default.onArgsObserverAdd(jest.fn(i => console.log(i)));
+    const handler = IModule.default.onBeforeCallArgsObserverAdd(jest.fn(i => console.log(i)));
 
     TestModuleDefaultExports.default(20);
     expect(handler).toBeCalledTimes(1);

--- a/packages/hyperion-core/test/IRequire.test.ts
+++ b/packages/hyperion-core/test/IRequire.test.ts
@@ -13,7 +13,7 @@ import * as TestModuleDefaultExports from "./IRequireTestModuleDefault";
 describe("Test interception of module exports", () => {
   test('Intercept normal module', () => {
     const IModule = IRequire.interceptModuleExports("IRequireTestModule", TestModule, ["foo"], []);
-    const handler = IModule.foo.onBeforeCallArgsObserverAdd(jest.fn(i => console.log(i)));
+    const handler = IModule.foo.onBeforeCallObserverAdd(jest.fn(i => console.log(i)));
     TestModule.foo(10);
     expect(handler).toBeCalledTimes(1);
     expect(handler).toBeCalledWith(10);
@@ -22,7 +22,7 @@ describe("Test interception of module exports", () => {
   test('Intercept module with defaults', () => {
     const IModule = IRequire.interceptModuleExports("IRequireTestModuleDefaultExports", TestModuleDefaultExports, ["default"], []);
 
-    const handler = IModule.default.onBeforeCallArgsObserverAdd(jest.fn(i => console.log(i)));
+    const handler = IModule.default.onBeforeCallObserverAdd(jest.fn(i => console.log(i)));
 
     TestModuleDefaultExports.default(20);
     expect(handler).toBeCalledTimes(1);

--- a/packages/hyperion-core/test/Timers.test.ts
+++ b/packages/hyperion-core/test/Timers.test.ts
@@ -24,7 +24,7 @@ describe('Test interception via test. ', () => {
      * Goal is to see everyting continue to function correctly.
      */
     const x = require("../src/IGlobalThis");
-    x.setTimeout.onArgsObserverAdd(() => {
+    x.setTimeout.onBeforeCallArgsObserverAdd(() => {
       console.log("something");
     });
 

--- a/packages/hyperion-core/test/Timers.test.ts
+++ b/packages/hyperion-core/test/Timers.test.ts
@@ -24,7 +24,7 @@ describe('Test interception via test. ', () => {
      * Goal is to see everyting continue to function correctly.
      */
     const x = require("../src/IGlobalThis");
-    x.setTimeout.onBeforeCallArgsObserverAdd(() => {
+    x.setTimeout.onBeforeCallObserverAdd(() => {
       console.log("something");
     });
 

--- a/packages/hyperion-core/test/intercept.test.ts
+++ b/packages/hyperion-core/test/intercept.test.ts
@@ -144,24 +144,24 @@ describe("test interception mechanism", () => {
       result = [];
     }
 
-    IA.a1.getter.onValueObserverAdd(observer);
-    IA.a1.setter.onArgsObserverAdd(observer);
+    IA.a1.getter.onAfterReturnValueObserverAdd(observer);
+    IA.a1.setter.onBeforeCallArgsObserverAdd(observer);
 
-    IA.a2.getter.onValueObserverAdd(observer);
-    IA.a2.setter.onArgsObserverAdd(observer);
+    IA.a2.getter.onAfterReturnValueObserverAdd(observer);
+    IA.a2.setter.onBeforeCallArgsObserverAdd(observer);
 
-    IA.a3.getter.onValueObserverAdd(observer);
-    IA.a3.setter.onArgsObserverAdd(observer);
+    IA.a3.getter.onAfterReturnValueObserverAdd(observer);
+    IA.a3.setter.onBeforeCallArgsObserverAdd(observer);
 
-    IA.a4.getter.onValueObserverAdd(observer);
-    IA.a4.setter.onArgsObserverAdd(observer);
+    IA.a4.getter.onAfterReturnValueObserverAdd(observer);
+    IA.a4.setter.onBeforeCallArgsObserverAdd(observer);
 
-    IB.b.getter.onValueObserverAdd(observer);
-    IB.b.setter.onArgsObserverAdd(observer);
+    IB.b.getter.onAfterReturnValueObserverAdd(observer);
+    IB.b.setter.onBeforeCallArgsObserverAdd(observer);
 
     [IA.f1, IA.f2, IA.f3, IA.f4].forEach(fi => {
-      fi.onArgsObserverAdd(observer);
-      fi.onValueObserverAdd(observer);
+      fi.onBeforeCallArgsObserverAdd(observer);
+      fi.onAfterReturnValueObserverAdd(observer);
     });
 
     intercept(o);

--- a/packages/hyperion-core/test/intercept.test.ts
+++ b/packages/hyperion-core/test/intercept.test.ts
@@ -144,24 +144,24 @@ describe("test interception mechanism", () => {
       result = [];
     }
 
-    IA.a1.getter.onAfterReturnValueObserverAdd(observer);
-    IA.a1.setter.onBeforeCallArgsObserverAdd(observer);
+    IA.a1.getter.onAfterCallObserverAdd(observer);
+    IA.a1.setter.onBeforeCallObserverAdd(observer);
 
-    IA.a2.getter.onAfterReturnValueObserverAdd(observer);
-    IA.a2.setter.onBeforeCallArgsObserverAdd(observer);
+    IA.a2.getter.onAfterCallObserverAdd(observer);
+    IA.a2.setter.onBeforeCallObserverAdd(observer);
 
-    IA.a3.getter.onAfterReturnValueObserverAdd(observer);
-    IA.a3.setter.onBeforeCallArgsObserverAdd(observer);
+    IA.a3.getter.onAfterCallObserverAdd(observer);
+    IA.a3.setter.onBeforeCallObserverAdd(observer);
 
-    IA.a4.getter.onAfterReturnValueObserverAdd(observer);
-    IA.a4.setter.onBeforeCallArgsObserverAdd(observer);
+    IA.a4.getter.onAfterCallObserverAdd(observer);
+    IA.a4.setter.onBeforeCallObserverAdd(observer);
 
-    IB.b.getter.onAfterReturnValueObserverAdd(observer);
-    IB.b.setter.onBeforeCallArgsObserverAdd(observer);
+    IB.b.getter.onAfterCallObserverAdd(observer);
+    IB.b.setter.onBeforeCallObserverAdd(observer);
 
     [IA.f1, IA.f2, IA.f3, IA.f4].forEach(fi => {
-      fi.onBeforeCallArgsObserverAdd(observer);
-      fi.onAfterReturnValueObserverAdd(observer);
+      fi.onBeforeCallObserverAdd(observer);
+      fi.onAfterCallObserverAdd(observer);
     });
 
     intercept(o);

--- a/packages/hyperion-dom/test/ICSSStyleDeclaration.test.ts
+++ b/packages/hyperion-dom/test/ICSSStyleDeclaration.test.ts
@@ -19,9 +19,9 @@ describe('test element style interception', () => {
       console.log('getterValue called', arguments);
     });
 
-    ICSSStyleDeclaration.setProperty.onArgsObserverAdd(setterArgs);
-    ICSSStyleDeclaration.getPropertyValue.onArgsObserverAdd(getterArgs);
-    ICSSStyleDeclaration.getPropertyValue.onValueObserverAdd(getterValue);
+    ICSSStyleDeclaration.setProperty.onBeforeCallArgsObserverAdd(setterArgs);
+    ICSSStyleDeclaration.getPropertyValue.onBeforeCallArgsObserverAdd(getterArgs);
+    ICSSStyleDeclaration.getPropertyValue.onAfterReturnValueObserverAdd(getterValue);
 
     let elem: HTMLElement;
     elem = window.document.createElement("P");
@@ -43,7 +43,7 @@ describe('test element style interception', () => {
   });
 
   test('test block setting block value', () => {
-    ICSSStyleDeclaration.setProperty.onArgsObserverAdd((property, value) => {
+    ICSSStyleDeclaration.setProperty.onBeforeCallArgsObserverAdd((property, value) => {
       const blocked = (property === "display" && value === "block");
       if (blocked) {
         console.log("Will block:", property, value);

--- a/packages/hyperion-dom/test/ICSSStyleDeclaration.test.ts
+++ b/packages/hyperion-dom/test/ICSSStyleDeclaration.test.ts
@@ -19,9 +19,9 @@ describe('test element style interception', () => {
       console.log('getterValue called', arguments);
     });
 
-    ICSSStyleDeclaration.setProperty.onBeforeCallArgsObserverAdd(setterArgs);
-    ICSSStyleDeclaration.getPropertyValue.onBeforeCallArgsObserverAdd(getterArgs);
-    ICSSStyleDeclaration.getPropertyValue.onAfterReturnValueObserverAdd(getterValue);
+    ICSSStyleDeclaration.setProperty.onBeforeCallObserverAdd(setterArgs);
+    ICSSStyleDeclaration.getPropertyValue.onBeforeCallObserverAdd(getterArgs);
+    ICSSStyleDeclaration.getPropertyValue.onAfterCallObserverAdd(getterValue);
 
     let elem: HTMLElement;
     elem = window.document.createElement("P");
@@ -43,7 +43,7 @@ describe('test element style interception', () => {
   });
 
   test('test block setting block value', () => {
-    ICSSStyleDeclaration.setProperty.onBeforeCallArgsObserverAdd((property, value) => {
+    ICSSStyleDeclaration.setProperty.onBeforeCallObserverAdd((property, value) => {
       const blocked = (property === "display" && value === "block");
       if (blocked) {
         console.log("Will block:", property, value);

--- a/packages/hyperion-dom/test/IDocument.test.ts
+++ b/packages/hyperion-dom/test/IDocument.test.ts
@@ -14,8 +14,8 @@ describe('test Document interception', () => {
       result = [this, value];
     });
 
-    IDocument.createElement.onBeforeCallArgsObserverAdd(observer);
-    IDocument.createElement.onAfterReturnValueObserverAdd(value => result.push(value));
+    IDocument.createElement.onBeforeCallObserverAdd(observer);
+    IDocument.createElement.onAfterCallObserverAdd(value => result.push(value));
 
     let elem: Node;
     elem = window.document.createElement("P");

--- a/packages/hyperion-dom/test/IDocument.test.ts
+++ b/packages/hyperion-dom/test/IDocument.test.ts
@@ -14,8 +14,8 @@ describe('test Document interception', () => {
       result = [this, value];
     });
 
-    IDocument.createElement.onArgsObserverAdd(observer);
-    IDocument.createElement.onValueObserverAdd(value => result.push(value));
+    IDocument.createElement.onBeforeCallArgsObserverAdd(observer);
+    IDocument.createElement.onAfterReturnValueObserverAdd(value => result.push(value));
 
     let elem: Node;
     elem = window.document.createElement("P");

--- a/packages/hyperion-dom/test/IElement.test.ts
+++ b/packages/hyperion-dom/test/IElement.test.ts
@@ -11,7 +11,7 @@ import { VirtualAttribute } from "../src/VirtualAttribute";
 describe('test Element', () => {
   test('test getAttribute', () => {
     let result: any[] = [];
-    const observer = IElement.getAttribute.onBeforeCallArgsObserverAdd(function (this, value) {
+    const observer = IElement.getAttribute.onBeforeCallObserverAdd(function (this, value) {
       result.push(this);
       result.push(value);
     });
@@ -21,7 +21,7 @@ describe('test Element', () => {
     elem.getAttribute("test");
     expect(result).toStrictEqual([elem, "test"]);
 
-    IElement.getAttribute.onBeforeCallArgsObserverRemove(observer);
+    IElement.getAttribute.onBeforeCallObserverRemove(observer);
   });
 
   test('test innerHTML', () => {
@@ -30,11 +30,11 @@ describe('test Element', () => {
     let addedNodes: Node[] = [];
     let removedNodes: Node[] = [];
 
-    IElement.innerHTML.setter.onBeforeCallArgsObserverAdd(function (this, value) {
+    IElement.innerHTML.setter.onBeforeCallObserverAdd(function (this, value) {
       target = this;
       removedNodes = [...target.childNodes]; // child nodes is a live list, should make a copy
     });
-    IElement.innerHTML.setter.onAfterReturnValueObserverAdd(function (this) {
+    IElement.innerHTML.setter.onAfterCallObserverAdd(function (this) {
       // Now it is done, we can read the results
       expect(this).toBe(target);
       addedNodes = [...target.childNodes];
@@ -60,10 +60,10 @@ describe('test Element', () => {
 
 
     const vId = IElement.IElementtPrototype.getVirtualProperty<VirtualAttribute>("id");
-    vId.rawValue.getter.onAfterReturnValueObserverAdd(observer);
-    vId.rawValue.setter.onBeforeCallArgsObserverAdd(observer);
-    vId.processedValue.getter.onAfterReturnValueObserverAdd(observer);
-    vId.processedValue.setter.onBeforeCallArgsObserverAdd(observer);
+    vId.rawValue.getter.onAfterCallObserverAdd(observer);
+    vId.rawValue.setter.onBeforeCallObserverAdd(observer);
+    vId.processedValue.getter.onAfterCallObserverAdd(observer);
+    vId.processedValue.setter.onBeforeCallObserverAdd(observer);
 
     const elem = window.document.createElement("div");
     [

--- a/packages/hyperion-dom/test/IElement.test.ts
+++ b/packages/hyperion-dom/test/IElement.test.ts
@@ -11,7 +11,7 @@ import { VirtualAttribute } from "../src/VirtualAttribute";
 describe('test Element', () => {
   test('test getAttribute', () => {
     let result: any[] = [];
-    const observer = IElement.getAttribute.onArgsObserverAdd(function (this, value) {
+    const observer = IElement.getAttribute.onBeforeCallArgsObserverAdd(function (this, value) {
       result.push(this);
       result.push(value);
     });
@@ -21,7 +21,7 @@ describe('test Element', () => {
     elem.getAttribute("test");
     expect(result).toStrictEqual([elem, "test"]);
 
-    IElement.getAttribute.onArgsObserverRemove(observer);
+    IElement.getAttribute.onBeforeCallArgsObserverRemove(observer);
   });
 
   test('test innerHTML', () => {
@@ -30,11 +30,11 @@ describe('test Element', () => {
     let addedNodes: Node[] = [];
     let removedNodes: Node[] = [];
 
-    IElement.innerHTML.setter.onArgsObserverAdd(function (this, value) {
+    IElement.innerHTML.setter.onBeforeCallArgsObserverAdd(function (this, value) {
       target = this;
       removedNodes = [...target.childNodes]; // child nodes is a live list, should make a copy
     });
-    IElement.innerHTML.setter.onValueObserverAdd(function (this) {
+    IElement.innerHTML.setter.onAfterReturnValueObserverAdd(function (this) {
       // Now it is done, we can read the results
       expect(this).toBe(target);
       addedNodes = [...target.childNodes];
@@ -60,10 +60,10 @@ describe('test Element', () => {
 
 
     const vId = IElement.IElementtPrototype.getVirtualProperty<VirtualAttribute>("id");
-    vId.rawValue.getter.onValueObserverAdd(observer);
-    vId.rawValue.setter.onArgsObserverAdd(observer);
-    vId.processedValue.getter.onValueObserverAdd(observer);
-    vId.processedValue.setter.onArgsObserverAdd(observer);
+    vId.rawValue.getter.onAfterReturnValueObserverAdd(observer);
+    vId.rawValue.setter.onBeforeCallArgsObserverAdd(observer);
+    vId.processedValue.getter.onAfterReturnValueObserverAdd(observer);
+    vId.processedValue.setter.onBeforeCallArgsObserverAdd(observer);
 
     const elem = window.document.createElement("div");
     [

--- a/packages/hyperion-dom/test/IEvent.test.ts
+++ b/packages/hyperion-dom/test/IEvent.test.ts
@@ -11,7 +11,7 @@ import * as intercept from "@hyperion/hyperion-core/src/intercept";
 describe('test Event interception', () => {
   test('test base Event', () => {
     const stopPropagation = jest.fn();
-    IEvent.stopPropagation.onArgsObserverAdd(stopPropagation);
+    IEvent.stopPropagation.onBeforeCallArgsObserverAdd(stopPropagation);
 
     const eventIntercepted = jest.fn();
     IEvent.IEventPrototype.onBeforInterceptObj.add(eventIntercepted);

--- a/packages/hyperion-dom/test/IEvent.test.ts
+++ b/packages/hyperion-dom/test/IEvent.test.ts
@@ -11,7 +11,7 @@ import * as intercept from "@hyperion/hyperion-core/src/intercept";
 describe('test Event interception', () => {
   test('test base Event', () => {
     const stopPropagation = jest.fn();
-    IEvent.stopPropagation.onBeforeCallArgsObserverAdd(stopPropagation);
+    IEvent.stopPropagation.onBeforeCallObserverAdd(stopPropagation);
 
     const eventIntercepted = jest.fn();
     IEvent.IEventPrototype.onBeforInterceptObj.add(eventIntercepted);

--- a/packages/hyperion-dom/test/IEventListener.test.ts
+++ b/packages/hyperion-dom/test/IEventListener.test.ts
@@ -12,7 +12,7 @@ import * as IGlobalEventHandlers from "../src/IGlobalEventHandlers";
 function wrapListener<T extends CallbackType>(listener: T | null, observer: jest.Mock<any, any>) {
   const wrapped = interceptEventListener(listener);
   if (wrapped) {
-    wrapped.onBeforeCallArgsObserverAdd(observer);
+    wrapped.onBeforeCallObserverAdd(observer);
     if (listener && !isEventListenerObject(listener)) {
       return wrapped.interceptor;
     }
@@ -23,7 +23,7 @@ function wrapListener<T extends CallbackType>(listener: T | null, observer: jest
 describe('test event listener interception', () => {
   test("test event listener", async () => {
     const observer = jest.fn();
-    const handler = IEventTarget.addEventListener.onBeforeCallArgsMapperAdd(([type, listener]) => {
+    const handler = IEventTarget.addEventListener.onBeforeCallMapperAdd(([type, listener]) => {
       return [type, wrapListener(listener, observer)];
     });
 
@@ -37,12 +37,12 @@ describe('test event listener interception', () => {
     const r = await clicked;
     expect(r).toBe(1);
     expect(observer).toBeCalledTimes(1);
-    IEventTarget.addEventListener.onBeforeCallArgsMapperRemove(handler);
+    IEventTarget.addEventListener.onBeforeCallMapperRemove(handler);
   });
 
   test("test event listener object", async () => {
     const observer = jest.fn();
-    const handler = IEventTarget.addEventListener.onBeforeCallArgsMapperAdd(([type, listener]) => {
+    const handler = IEventTarget.addEventListener.onBeforeCallMapperAdd(([type, listener]) => {
       return [type, wrapListener(listener, observer)];
     });
 
@@ -57,12 +57,12 @@ describe('test event listener interception', () => {
     const r = await clicked;
     expect(r).toBe(1);
     expect(observer).toBeCalledTimes(1);
-    IEventTarget.addEventListener.onBeforeCallArgsMapperRemove(handler);
+    IEventTarget.addEventListener.onBeforeCallMapperRemove(handler);
   });
 
   test("test incomplete event listener object", async () => {
     const observer = jest.fn();
-    IEventTarget.addEventListener.onBeforeCallArgsMapperAdd(args => {
+    IEventTarget.addEventListener.onBeforeCallMapperAdd(args => {
       observer(...args);
       return args;
     });
@@ -78,13 +78,13 @@ describe('test event listener interception', () => {
     expect(observer.mock.calls.length).toBe(1);
     expect(observer.mock.calls[0][1]).toBe(emptyCallback)
     // expect(observer).toBeCalledTimes(1);
-    IEventTarget.addEventListener.onBeforeCallArgsMapperRemove(observer);
+    IEventTarget.addEventListener.onBeforeCallMapperRemove(observer);
   });
 
 
   test("test on-event listener", async () => {
     const observer = jest.fn();
-    const handler = IGlobalEventHandlers.onclick.setter.onBeforeCallArgsMapperAdd(([listener]) => {
+    const handler = IGlobalEventHandlers.onclick.setter.onBeforeCallMapperAdd(([listener]) => {
       return [wrapListener(listener, observer)];
     });
 
@@ -99,6 +99,6 @@ describe('test event listener interception', () => {
     const r = await clicked;
     expect(r).toBe(1);
     expect(observer).toBeCalledTimes(1);
-    IGlobalEventHandlers.onclick.setter.onBeforeCallArgsMapperRemove(handler);
+    IGlobalEventHandlers.onclick.setter.onBeforeCallMapperRemove(handler);
   });
 });

--- a/packages/hyperion-dom/test/IEventListener.test.ts
+++ b/packages/hyperion-dom/test/IEventListener.test.ts
@@ -12,7 +12,7 @@ import * as IGlobalEventHandlers from "../src/IGlobalEventHandlers";
 function wrapListener<T extends CallbackType>(listener: T | null, observer: jest.Mock<any, any>) {
   const wrapped = interceptEventListener(listener);
   if (wrapped) {
-    wrapped.onArgsObserverAdd(observer);
+    wrapped.onBeforeCallArgsObserverAdd(observer);
     if (listener && !isEventListenerObject(listener)) {
       return wrapped.interceptor;
     }
@@ -23,7 +23,7 @@ function wrapListener<T extends CallbackType>(listener: T | null, observer: jest
 describe('test event listener interception', () => {
   test("test event listener", async () => {
     const observer = jest.fn();
-    const handler = IEventTarget.addEventListener.onArgsMapperAdd(([type, listener]) => {
+    const handler = IEventTarget.addEventListener.onBeforeCallArgsMapperAdd(([type, listener]) => {
       return [type, wrapListener(listener, observer)];
     });
 
@@ -37,12 +37,12 @@ describe('test event listener interception', () => {
     const r = await clicked;
     expect(r).toBe(1);
     expect(observer).toBeCalledTimes(1);
-    IEventTarget.addEventListener.onArgsMapperRemove(handler);
+    IEventTarget.addEventListener.onBeforeCallArgsMapperRemove(handler);
   });
 
   test("test event listener object", async () => {
     const observer = jest.fn();
-    const handler = IEventTarget.addEventListener.onArgsMapperAdd(([type, listener]) => {
+    const handler = IEventTarget.addEventListener.onBeforeCallArgsMapperAdd(([type, listener]) => {
       return [type, wrapListener(listener, observer)];
     });
 
@@ -57,12 +57,12 @@ describe('test event listener interception', () => {
     const r = await clicked;
     expect(r).toBe(1);
     expect(observer).toBeCalledTimes(1);
-    IEventTarget.addEventListener.onArgsMapperRemove(handler);
+    IEventTarget.addEventListener.onBeforeCallArgsMapperRemove(handler);
   });
 
   test("test incomplete event listener object", async () => {
     const observer = jest.fn();
-    IEventTarget.addEventListener.onArgsMapperAdd(args => {
+    IEventTarget.addEventListener.onBeforeCallArgsMapperAdd(args => {
       observer(...args);
       return args;
     });
@@ -78,13 +78,13 @@ describe('test event listener interception', () => {
     expect(observer.mock.calls.length).toBe(1);
     expect(observer.mock.calls[0][1]).toBe(emptyCallback)
     // expect(observer).toBeCalledTimes(1);
-    IEventTarget.addEventListener.onArgsMapperRemove(observer);
+    IEventTarget.addEventListener.onBeforeCallArgsMapperRemove(observer);
   });
 
 
   test("test on-event listener", async () => {
     const observer = jest.fn();
-    const handler = IGlobalEventHandlers.onclick.setter.onArgsMapperAdd(([listener]) => {
+    const handler = IGlobalEventHandlers.onclick.setter.onBeforeCallArgsMapperAdd(([listener]) => {
       return [wrapListener(listener, observer)];
     });
 
@@ -99,6 +99,6 @@ describe('test event listener interception', () => {
     const r = await clicked;
     expect(r).toBe(1);
     expect(observer).toBeCalledTimes(1);
-    IGlobalEventHandlers.onclick.setter.onArgsMapperRemove(handler);
+    IGlobalEventHandlers.onclick.setter.onBeforeCallArgsMapperRemove(handler);
   });
 });

--- a/packages/hyperion-dom/test/INode.test.ts
+++ b/packages/hyperion-dom/test/INode.test.ts
@@ -14,17 +14,17 @@ describe('test Node interception', () => {
       result = [this, value];
     });
 
-    INode.insertBefore.onArgsObserverAdd(observer);
-    INode.removeChild.onArgsObserverAdd(observer);
-    INode.replaceChild.onArgsObserverAdd(observer);
+    INode.insertBefore.onBeforeCallArgsObserverAdd(observer);
+    INode.removeChild.onBeforeCallArgsObserverAdd(observer);
+    INode.replaceChild.onBeforeCallArgsObserverAdd(observer);
 
     const elem = window.document.createElement("p");
     const child1 = window.document.createElement("a");
     const child2 = window.document.createElement("b");
     let testCount = 0;
 
-    INode.appendChild.onArgsObserverRemove(
-      INode.appendChild.onArgsObserverAdd(function (this, node) {
+    INode.appendChild.onBeforeCallArgsObserverRemove(
+      INode.appendChild.onBeforeCallArgsObserverAdd(function (this, node) {
         expect([this, node]).toStrictEqual([elem, child1]);
         testCount++;
       })
@@ -32,20 +32,20 @@ describe('test Node interception', () => {
     elem.appendChild(child1);
     elem.appendChild(child2);
 
-    INode.removeChild.onArgsObserverAdd(function (this, node) {
+    INode.removeChild.onBeforeCallArgsObserverAdd(function (this, node) {
       expect([this, node]).toStrictEqual([elem, child2]);
       testCount++;
     });
     elem.removeChild(child2);
 
-    INode.insertBefore.onArgsObserverAdd(function (this, newNode, referenceNode) {
+    INode.insertBefore.onBeforeCallArgsObserverAdd(function (this, newNode, referenceNode) {
       expect([this, newNode, referenceNode]).toStrictEqual([elem, child2, child1]);
       testCount++;
     });
     elem.insertBefore(child2, child1);
     elem.removeChild(child2);
 
-    INode.replaceChild.onArgsObserverAdd(function (this, newChild, oldChild) {
+    INode.replaceChild.onBeforeCallArgsObserverAdd(function (this, newChild, oldChild) {
       expect([this, newChild, oldChild]).toStrictEqual([elem, child2, child1]);
       testCount++;
     });

--- a/packages/hyperion-dom/test/INode.test.ts
+++ b/packages/hyperion-dom/test/INode.test.ts
@@ -14,17 +14,17 @@ describe('test Node interception', () => {
       result = [this, value];
     });
 
-    INode.insertBefore.onBeforeCallArgsObserverAdd(observer);
-    INode.removeChild.onBeforeCallArgsObserverAdd(observer);
-    INode.replaceChild.onBeforeCallArgsObserverAdd(observer);
+    INode.insertBefore.onBeforeCallObserverAdd(observer);
+    INode.removeChild.onBeforeCallObserverAdd(observer);
+    INode.replaceChild.onBeforeCallObserverAdd(observer);
 
     const elem = window.document.createElement("p");
     const child1 = window.document.createElement("a");
     const child2 = window.document.createElement("b");
     let testCount = 0;
 
-    INode.appendChild.onBeforeCallArgsObserverRemove(
-      INode.appendChild.onBeforeCallArgsObserverAdd(function (this, node) {
+    INode.appendChild.onBeforeCallObserverRemove(
+      INode.appendChild.onBeforeCallObserverAdd(function (this, node) {
         expect([this, node]).toStrictEqual([elem, child1]);
         testCount++;
       })
@@ -32,20 +32,20 @@ describe('test Node interception', () => {
     elem.appendChild(child1);
     elem.appendChild(child2);
 
-    INode.removeChild.onBeforeCallArgsObserverAdd(function (this, node) {
+    INode.removeChild.onBeforeCallObserverAdd(function (this, node) {
       expect([this, node]).toStrictEqual([elem, child2]);
       testCount++;
     });
     elem.removeChild(child2);
 
-    INode.insertBefore.onBeforeCallArgsObserverAdd(function (this, newNode, referenceNode) {
+    INode.insertBefore.onBeforeCallObserverAdd(function (this, newNode, referenceNode) {
       expect([this, newNode, referenceNode]).toStrictEqual([elem, child2, child1]);
       testCount++;
     });
     elem.insertBefore(child2, child1);
     elem.removeChild(child2);
 
-    INode.replaceChild.onBeforeCallArgsObserverAdd(function (this, newChild, oldChild) {
+    INode.replaceChild.onBeforeCallObserverAdd(function (this, newChild, oldChild) {
       expect([this, newChild, oldChild]).toStrictEqual([elem, child2, child1]);
       testCount++;
     });

--- a/packages/hyperion-dom/test/IWindow.test.ts
+++ b/packages/hyperion-dom/test/IWindow.test.ts
@@ -16,8 +16,8 @@ describe('test Window interception', () => {
       result.push([this, value]);
     });
 
-    IWindow.fetch.onBeforeCallArgsObserverAdd(observer);
-    IWindow.fetch.onAfterReturnValueObserverAdd(observer);
+    IWindow.fetch.onBeforeCallObserverAdd(observer);
+    IWindow.fetch.onAfterCallObserverAdd(observer);
 
     if (typeof window.fetch !== "function") {
       window.fetch = function () {

--- a/packages/hyperion-dom/test/IWindow.test.ts
+++ b/packages/hyperion-dom/test/IWindow.test.ts
@@ -16,8 +16,8 @@ describe('test Window interception', () => {
       result.push([this, value]);
     });
 
-    IWindow.fetch.onArgsObserverAdd(observer);
-    IWindow.fetch.onValueObserverAdd(observer);
+    IWindow.fetch.onBeforeCallArgsObserverAdd(observer);
+    IWindow.fetch.onAfterReturnValueObserverAdd(observer);
 
     if (typeof window.fetch !== "function") {
       window.fetch = function () {

--- a/packages/hyperion-dom/test/IXMLHttpRequest.test.ts
+++ b/packages/hyperion-dom/test/IXMLHttpRequest.test.ts
@@ -87,11 +87,11 @@ describe('test XHR interception', () => {
     //   result = [this, value];
     // });
     // IWindow.XMLHttpRequest.onArgsObserverAdd(function (this, value) {
-    IXMLHttpRequest.constructor.onAfterReturnValueObserverAdd(function (this, value) {
+    IXMLHttpRequest.constructor.onAfterCallObserverAdd(function (this, value) {
       expect(value).toBeInstanceOf(XMLHttpRequest);
     });
 
-    IXMLHttpRequest.open.onBeforeCallArgsObserverAdd(function (this, method, url) {
+    IXMLHttpRequest.open.onBeforeCallObserverAdd(function (this, method, url) {
       result = [this, method, url];
     });
 

--- a/packages/hyperion-dom/test/IXMLHttpRequest.test.ts
+++ b/packages/hyperion-dom/test/IXMLHttpRequest.test.ts
@@ -87,11 +87,11 @@ describe('test XHR interception', () => {
     //   result = [this, value];
     // });
     // IWindow.XMLHttpRequest.onArgsObserverAdd(function (this, value) {
-    IXMLHttpRequest.constructor.onValueObserverAdd(function (this, value) {
+    IXMLHttpRequest.constructor.onAfterReturnValueObserverAdd(function (this, value) {
       expect(value).toBeInstanceOf(XMLHttpRequest);
     });
 
-    IXMLHttpRequest.open.onArgsObserverAdd(function (this, method, url) {
+    IXMLHttpRequest.open.onBeforeCallArgsObserverAdd(function (this, method, url) {
       result = [this, method, url];
     });
 

--- a/packages/hyperion-flowlet/src/FlowletWrappers.ts
+++ b/packages/hyperion-flowlet/src/FlowletWrappers.ts
@@ -151,18 +151,18 @@ export function initFlowletTrackers(flowletManager: FlowletManager) {
     IXMLHttpRequest.readystatechange,
     IXMLHttpRequest.ontimeout,
   ]) {
-    eventHandler.setter.onArgsMapperAdd(function (this, args: [any]) {
+    eventHandler.setter.onBeforeCallArgsMapperAdd(function (this, args: [any]) {
       const func = args[0];
       args[0] = flowletManager.wrap(func, eventHandler.name, void 0, getTriggerFlowletFromEvent);
       return args;
     });
   }
 
-  IEventTarget.addEventListener.onArgsMapperAdd(args => {
+  IEventTarget.addEventListener.onBeforeCallArgsMapperAdd(args => {
     args[1] = flowletManager.wrap(args[1], `${IEventTarget.addEventListener.name}(${args[0]})`, void 0, getTriggerFlowletFromEvent);
     return args;
   });
-  IEventTarget.removeEventListener.onArgsMapperAdd(args => {
+  IEventTarget.removeEventListener.onBeforeCallArgsMapperAdd(args => {
     args[1] = flowletManager.getWrappedOrOriginal(args[1]);
     return args;
   });
@@ -171,7 +171,7 @@ export function initFlowletTrackers(flowletManager: FlowletManager) {
     IGlobalThis.setTimeout,
     IGlobalThis.setInterval
   ]) {
-    fi.onArgsMapperAdd(args => {
+    fi.onBeforeCallArgsMapperAdd(args => {
       let handler = args[0];
       if (typeof handler === "string") {
         handler = new Function(handler);
@@ -186,7 +186,7 @@ export function initFlowletTrackers(flowletManager: FlowletManager) {
     IPromise.resolve,
     IPromise.reject
   ]) {
-    fi.onValueObserverAdd(value => {
+    fi.onAfterReturnValueObserverAdd(value => {
       if (!getTriggerFlowlet(value)) {
         const triggerFlowlet = flowletManager.top()?.data.triggerFlowlet;
         if (triggerFlowlet) {
@@ -202,7 +202,7 @@ export function initFlowletTrackers(flowletManager: FlowletManager) {
     IPromise.any,
     IPromise.race
   ]) {
-    fi.onArgsAndValueMapperAdd(args => {
+    fi.onBeforeCallArgsAndAfterReturnValueMapperAdd(args => {
       const iterable = args[0];
       return value => {
         const topTriggerFlowlet = getTriggerFlowlet(value) ?? flowletManager.top()?.data.triggerFlowlet;
@@ -232,7 +232,7 @@ export function initFlowletTrackers(flowletManager: FlowletManager) {
   }
 
 
-  IPromise.then.onArgsAndValueMapperAdd(function (this, args) {
+  IPromise.then.onBeforeCallArgsAndAfterReturnValueMapperAdd(function (this, args) {
     const triggerFlowlet = getTriggerFlowlet(this);
     args[0] = flowletManager.wrap(args[0], IPromise.then.name, void 0, () => triggerFlowlet);
     args[1] = flowletManager.wrap(args[1], IPromise.then.name, void 0, () => triggerFlowlet);
@@ -247,7 +247,7 @@ export function initFlowletTrackers(flowletManager: FlowletManager) {
     };
   });
 
-  IPromise.Catch.onArgsAndValueMapperAdd(function (this, args) {
+  IPromise.Catch.onBeforeCallArgsAndAfterReturnValueMapperAdd(function (this, args) {
     const triggerFlowlet = getTriggerFlowlet(this);
     args[0] = flowletManager.wrap(args[0], IPromise.then.name, void 0, () => triggerFlowlet);
     return value => {
@@ -260,5 +260,4 @@ export function initFlowletTrackers(flowletManager: FlowletManager) {
       return value;
     };
   });
-
 }

--- a/packages/hyperion-flowlet/src/FlowletWrappers.ts
+++ b/packages/hyperion-flowlet/src/FlowletWrappers.ts
@@ -151,18 +151,18 @@ export function initFlowletTrackers(flowletManager: FlowletManager) {
     IXMLHttpRequest.readystatechange,
     IXMLHttpRequest.ontimeout,
   ]) {
-    eventHandler.setter.onBeforeCallArgsMapperAdd(function (this, args: [any]) {
+    eventHandler.setter.onBeforeCallMapperAdd(function (this, args: [any]) {
       const func = args[0];
       args[0] = flowletManager.wrap(func, eventHandler.name, void 0, getTriggerFlowletFromEvent);
       return args;
     });
   }
 
-  IEventTarget.addEventListener.onBeforeCallArgsMapperAdd(args => {
+  IEventTarget.addEventListener.onBeforeCallMapperAdd(args => {
     args[1] = flowletManager.wrap(args[1], `${IEventTarget.addEventListener.name}(${args[0]})`, void 0, getTriggerFlowletFromEvent);
     return args;
   });
-  IEventTarget.removeEventListener.onBeforeCallArgsMapperAdd(args => {
+  IEventTarget.removeEventListener.onBeforeCallMapperAdd(args => {
     args[1] = flowletManager.getWrappedOrOriginal(args[1]);
     return args;
   });
@@ -171,7 +171,7 @@ export function initFlowletTrackers(flowletManager: FlowletManager) {
     IGlobalThis.setTimeout,
     IGlobalThis.setInterval
   ]) {
-    fi.onBeforeCallArgsMapperAdd(args => {
+    fi.onBeforeCallMapperAdd(args => {
       let handler = args[0];
       if (typeof handler === "string") {
         handler = new Function(handler);
@@ -186,7 +186,7 @@ export function initFlowletTrackers(flowletManager: FlowletManager) {
     IPromise.resolve,
     IPromise.reject
   ]) {
-    fi.onAfterReturnValueObserverAdd(value => {
+    fi.onAfterCallObserverAdd(value => {
       if (!getTriggerFlowlet(value)) {
         const triggerFlowlet = flowletManager.top()?.data.triggerFlowlet;
         if (triggerFlowlet) {
@@ -202,7 +202,7 @@ export function initFlowletTrackers(flowletManager: FlowletManager) {
     IPromise.any,
     IPromise.race
   ]) {
-    fi.onBeforeCallArgsAndAfterReturnValueMapperAdd(args => {
+    fi.onBeforeAndAfterCallMapperAdd(args => {
       const iterable = args[0];
       return value => {
         const topTriggerFlowlet = getTriggerFlowlet(value) ?? flowletManager.top()?.data.triggerFlowlet;
@@ -232,7 +232,7 @@ export function initFlowletTrackers(flowletManager: FlowletManager) {
   }
 
 
-  IPromise.then.onBeforeCallArgsAndAfterReturnValueMapperAdd(function (this, args) {
+  IPromise.then.onBeforeAndAfterCallMapperAdd(function (this, args) {
     const triggerFlowlet = getTriggerFlowlet(this);
     args[0] = flowletManager.wrap(args[0], IPromise.then.name, void 0, () => triggerFlowlet);
     args[1] = flowletManager.wrap(args[1], IPromise.then.name, void 0, () => triggerFlowlet);
@@ -247,7 +247,7 @@ export function initFlowletTrackers(flowletManager: FlowletManager) {
     };
   });
 
-  IPromise.Catch.onBeforeCallArgsAndAfterReturnValueMapperAdd(function (this, args) {
+  IPromise.Catch.onBeforeAndAfterCallMapperAdd(function (this, args) {
     const triggerFlowlet = getTriggerFlowlet(this);
     args[0] = flowletManager.wrap(args[0], IPromise.then.name, void 0, () => triggerFlowlet);
     return value => {

--- a/packages/hyperion-react/src/IReactComponent.ts
+++ b/packages/hyperion-react/src/IReactComponent.ts
@@ -317,7 +317,7 @@ export function init(options: InitOptions): void {
     }
     : */ interceptArgs;
 
-  const handler = IJsxRuntimeModule.jsx.onBeforeCallArgsMapperAdd(args => {
+  const handler = IJsxRuntimeModule.jsx.onBeforeCallMapperAdd(args => {
     /**
      * TODO: T132536682 remove this guard later to speed things up
      * NOTE: tried using ErrorGuard.guard, and ErrorGuard.applyWithGuard but
@@ -339,8 +339,8 @@ export function init(options: InitOptions): void {
     return args;
   });
   if (IJsxRuntimeModule.jsxs !== IJsxRuntimeModule.jsx) {
-    IJsxRuntimeModule.jsxs.onBeforeCallArgsMapperAdd(handler);
+    IJsxRuntimeModule.jsxs.onBeforeCallMapperAdd(handler);
   }
-  IJsxRuntimeModule.jsxDEV.onBeforeCallArgsMapperAdd(handler);
-  IReactModule.createElement.onBeforeCallArgsMapperAdd(handler);
+  IJsxRuntimeModule.jsxDEV.onBeforeCallMapperAdd(handler);
+  IReactModule.createElement.onBeforeCallMapperAdd(handler);
 }

--- a/packages/hyperion-react/src/IReactComponent.ts
+++ b/packages/hyperion-react/src/IReactComponent.ts
@@ -317,7 +317,7 @@ export function init(options: InitOptions): void {
     }
     : */ interceptArgs;
 
-  const handler = IJsxRuntimeModule.jsx.onArgsMapperAdd(args => {
+  const handler = IJsxRuntimeModule.jsx.onBeforeCallArgsMapperAdd(args => {
     /**
      * TODO: T132536682 remove this guard later to speed things up
      * NOTE: tried using ErrorGuard.guard, and ErrorGuard.applyWithGuard but
@@ -339,8 +339,8 @@ export function init(options: InitOptions): void {
     return args;
   });
   if (IJsxRuntimeModule.jsxs !== IJsxRuntimeModule.jsx) {
-    IJsxRuntimeModule.jsxs.onArgsMapperAdd(handler);
+    IJsxRuntimeModule.jsxs.onBeforeCallArgsMapperAdd(handler);
   }
-  IJsxRuntimeModule.jsxDEV.onArgsMapperAdd(handler);
-  IReactModule.createElement.onArgsMapperAdd(handler);
+  IJsxRuntimeModule.jsxDEV.onBeforeCallArgsMapperAdd(handler);
+  IReactModule.createElement.onBeforeCallArgsMapperAdd(handler);
 }

--- a/packages/hyperion-react/src/IReactFlowlet.ts
+++ b/packages/hyperion-react/src/IReactFlowlet.ts
@@ -111,7 +111,7 @@ export function init<
        * the body of the method has access to flowlet.
        * We will expand these methods to other lifecycle methods later.
        */
-      method.onArgsAndValueMapperAdd(function (this: ComponentWithFlowlet) {
+      method.onBeforeCallArgsAndAfterReturnValueMapperAdd(function (this: ComponentWithFlowlet) {
         const activeFlowlet = flowletPusher(this.props);
         return (value) => {
           if (activeFlowlet) {
@@ -129,7 +129,7 @@ export function init<
       if (fi.testAndSet(IS_FLOWLET_SETUP_PROP)) {
         return;
       }
-      fi.onArgsAndValueMapperAdd(([props]) => {
+      fi.onBeforeCallArgsAndAfterReturnValueMapperAdd(([props]) => {
         const activeFlowlet = flowletPusher(props);
         return (value) => {
           if (activeFlowlet) {

--- a/packages/hyperion-react/src/IReactFlowlet.ts
+++ b/packages/hyperion-react/src/IReactFlowlet.ts
@@ -111,7 +111,7 @@ export function init<
        * the body of the method has access to flowlet.
        * We will expand these methods to other lifecycle methods later.
        */
-      method.onBeforeCallArgsAndAfterReturnValueMapperAdd(function (this: ComponentWithFlowlet) {
+      method.onBeforeAndAfterCallMapperAdd(function (this: ComponentWithFlowlet) {
         const activeFlowlet = flowletPusher(this.props);
         return (value) => {
           if (activeFlowlet) {
@@ -129,7 +129,7 @@ export function init<
       if (fi.testAndSet(IS_FLOWLET_SETUP_PROP)) {
         return;
       }
-      fi.onBeforeCallArgsAndAfterReturnValueMapperAdd(([props]) => {
+      fi.onBeforeAndAfterCallMapperAdd(([props]) => {
         const activeFlowlet = flowletPusher(props);
         return (value) => {
           if (activeFlowlet) {

--- a/packages/hyperion-util/src/SyncMutationObserver.ts
+++ b/packages/hyperion-util/src/SyncMutationObserver.ts
@@ -16,7 +16,7 @@ export type MutationEvent = MutationAction<"added"> | MutationAction<"removed">;
 
 export const onDOMMutation = new Hook<(mutationEvent: MutationEvent) => void>();
 
-INode.appendChild.onBeforeCallArgsObserverAdd(function (this, value) {
+INode.appendChild.onBeforeCallObserverAdd(function (this, value) {
   onDOMMutation.call({
     action: "added",
     target: this,
@@ -24,7 +24,7 @@ INode.appendChild.onBeforeCallArgsObserverAdd(function (this, value) {
   });
 });
 
-INode.insertBefore.onBeforeCallArgsObserverAdd(function (this, newNode, _referenceNode) {
+INode.insertBefore.onBeforeCallObserverAdd(function (this, newNode, _referenceNode) {
   onDOMMutation.call({
     action: "added",
     target: this,
@@ -32,7 +32,7 @@ INode.insertBefore.onBeforeCallArgsObserverAdd(function (this, newNode, _referen
   });
 });
 
-INode.removeChild.onBeforeCallArgsObserverAdd(function (this, node) {
+INode.removeChild.onBeforeCallObserverAdd(function (this, node) {
   onDOMMutation.call({
     action: "removed",
     target: this,
@@ -40,7 +40,7 @@ INode.removeChild.onBeforeCallArgsObserverAdd(function (this, node) {
   });
 });
 
-INode.replaceChild.onBeforeCallArgsObserverAdd(function (this, newChild, oldChild) {
+INode.replaceChild.onBeforeCallObserverAdd(function (this, newChild, oldChild) {
   onDOMMutation.call({
     action: "removed",
     target: this,
@@ -53,7 +53,7 @@ INode.replaceChild.onBeforeCallArgsObserverAdd(function (this, newChild, oldChil
   });
 });
 
-IElement.innerHTML.setter.onBeforeCallArgsObserverAdd(function (this, _value) {
+IElement.innerHTML.setter.onBeforeCallObserverAdd(function (this, _value) {
   // Happens before actual call, so current children will be removed
   onDOMMutation.call({
     action: "removed",
@@ -61,7 +61,7 @@ IElement.innerHTML.setter.onBeforeCallArgsObserverAdd(function (this, _value) {
     nodes: Array.from(this.childNodes),
   });
 });
-IElement.innerHTML.setter.onAfterReturnValueObserverAdd(function (this) {
+IElement.innerHTML.setter.onAfterCallObserverAdd(function (this) {
   // Happens after actual call, so current children will are the ones added
   onDOMMutation.call({
     action: "added",
@@ -70,7 +70,7 @@ IElement.innerHTML.setter.onAfterReturnValueObserverAdd(function (this) {
   });
 });
 
-IElement.insertAdjacentElement.onBeforeCallArgsObserverAdd(function (this, where, element) {
+IElement.insertAdjacentElement.onBeforeCallObserverAdd(function (this, where, element) {
   const target = where === "afterbegin" || where === "beforeend" ? this : this.parentNode;
   if (target) {
     onDOMMutation.call({

--- a/packages/hyperion-util/src/SyncMutationObserver.ts
+++ b/packages/hyperion-util/src/SyncMutationObserver.ts
@@ -16,7 +16,7 @@ export type MutationEvent = MutationAction<"added"> | MutationAction<"removed">;
 
 export const onDOMMutation = new Hook<(mutationEvent: MutationEvent) => void>();
 
-INode.appendChild.onArgsObserverAdd(function (this, value) {
+INode.appendChild.onBeforeCallArgsObserverAdd(function (this, value) {
   onDOMMutation.call({
     action: "added",
     target: this,
@@ -24,7 +24,7 @@ INode.appendChild.onArgsObserverAdd(function (this, value) {
   });
 });
 
-INode.insertBefore.onArgsObserverAdd(function (this, newNode, _referenceNode) {
+INode.insertBefore.onBeforeCallArgsObserverAdd(function (this, newNode, _referenceNode) {
   onDOMMutation.call({
     action: "added",
     target: this,
@@ -32,7 +32,7 @@ INode.insertBefore.onArgsObserverAdd(function (this, newNode, _referenceNode) {
   });
 });
 
-INode.removeChild.onArgsObserverAdd(function (this, node) {
+INode.removeChild.onBeforeCallArgsObserverAdd(function (this, node) {
   onDOMMutation.call({
     action: "removed",
     target: this,
@@ -40,7 +40,7 @@ INode.removeChild.onArgsObserverAdd(function (this, node) {
   });
 });
 
-INode.replaceChild.onArgsObserverAdd(function (this, newChild, oldChild) {
+INode.replaceChild.onBeforeCallArgsObserverAdd(function (this, newChild, oldChild) {
   onDOMMutation.call({
     action: "removed",
     target: this,
@@ -53,7 +53,7 @@ INode.replaceChild.onArgsObserverAdd(function (this, newChild, oldChild) {
   });
 });
 
-IElement.innerHTML.setter.onArgsObserverAdd(function (this, _value) {
+IElement.innerHTML.setter.onBeforeCallArgsObserverAdd(function (this, _value) {
   // Happens before actual call, so current children will be removed
   onDOMMutation.call({
     action: "removed",
@@ -61,7 +61,7 @@ IElement.innerHTML.setter.onArgsObserverAdd(function (this, _value) {
     nodes: Array.from(this.childNodes),
   });
 });
-IElement.innerHTML.setter.onValueObserverAdd(function (this) {
+IElement.innerHTML.setter.onAfterReturnValueObserverAdd(function (this) {
   // Happens after actual call, so current children will are the ones added
   onDOMMutation.call({
     action: "added",
@@ -70,7 +70,7 @@ IElement.innerHTML.setter.onValueObserverAdd(function (this) {
   });
 });
 
-IElement.insertAdjacentElement.onArgsObserverAdd(function (this, where, element) {
+IElement.insertAdjacentElement.onBeforeCallArgsObserverAdd(function (this, where, element) {
   const target = where === "afterbegin" || where === "beforeend" ? this : this.parentNode;
   if (target) {
     onDOMMutation.call({

--- a/packages/hyperion-util/src/trackElementsWithAttributes.ts
+++ b/packages/hyperion-util/src/trackElementsWithAttributes.ts
@@ -14,7 +14,7 @@ export function trackElementsWithAttributes(attributeNames: string[]): ResultHoo
   for (let i = 0, len = attributeNames.length; i < len; ++i) {
     const attr = attributeNames[i];
     const vattr = interceptElementAttribute(attr, IElementtPrototype);
-    vattr.raw.setter.onArgsObserverAdd(function (this, value) {
+    vattr.raw.setter.onBeforeCallArgsObserverAdd(function (this, value) {
       hook.call(this, attr, value);
     });
   }

--- a/packages/hyperion-util/src/trackElementsWithAttributes.ts
+++ b/packages/hyperion-util/src/trackElementsWithAttributes.ts
@@ -14,7 +14,7 @@ export function trackElementsWithAttributes(attributeNames: string[]): ResultHoo
   for (let i = 0, len = attributeNames.length; i < len; ++i) {
     const attr = attributeNames[i];
     const vattr = interceptElementAttribute(attr, IElementtPrototype);
-    vattr.raw.setter.onBeforeCallArgsObserverAdd(function (this, value) {
+    vattr.raw.setter.onBeforeCallObserverAdd(function (this, value) {
       hook.call(this, attr, value);
     });
   }


### PR DESCRIPTION
I got several feedback that the original names are not very descriptive and would prefer something that more explicitly indicate the callbacks will before function call or after return value is ready. Hence the rename here.
This is a breaing change, but since we still don't have an official versioning and releasing process, we'd better make this change now!