### PR TITLE
Fix compiler error for latest version of TypeScript

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,11 +61,11 @@
   "dependencies": {
     "@hyperion/global": "*",
     "@hyperion/hook": "*",
+    "@hyperion/hyperion-autologging": "*",
     "@hyperion/hyperion-core": "*",
     "@hyperion/hyperion-dom": "*",
     "@hyperion/hyperion-flowlet": "*",
     "@hyperion/hyperion-react": "*",
-    "@hyperion/hyperion-autologging": "*",
     "@hyperion/hyperion-util": "*"
   },
   "devDependencies": {
@@ -83,6 +83,6 @@
     "rollup": "^3.7.4",
     "rollup-plugin-node-resolve": "^5.2.0",
     "tslib": "^2.4.0",
-    "typescript": "^5.0.3"
+    "typescript": "^5.1.3"
   }
 }

--- a/packages/hyperion-autologging/src/ALSurface.ts
+++ b/packages/hyperion-autologging/src/ALSurface.ts
@@ -264,7 +264,7 @@ export function init(options: InitOptions): ALSurfaceHOC {
     children: React.ReactNode,
     deep: boolean,
   ): boolean | undefined | null {
-    if (!ext || !(ext instanceof IReactFlowlet.PropsExtension<DataType, FlowletType>)) {
+    if (!ext || !(ext instanceof IReactFlowlet.PropsExtension/* <DataType, FlowletType> */)) {
       return;
     }
 


### PR DESCRIPTION
The latest version of TS is catching a small issue, but breaks the build and prevents CI job to finish.

This commit updates the TS version to latest and fixed the issue.