### PR TITLE
Create new root flowlets for UI events

### DIFF
--- a/packages/hyperion-autologging/src/ALUIEventPublisher.ts
+++ b/packages/hyperion-autologging/src/ALUIEventPublisher.ts
@@ -166,19 +166,21 @@ export function publish(options: InitOptions): void {
        * Since it is possible to interact with the same exact element multiple times,
        * we need yet another distinguishing fact, for which we use timestamp
        */
-      let flowlet = flowletManager.top() ?? defaultTopFlowlet; // We want to ensure flowlet is always assigned
+      const topFlowlet = flowletManager.top();
+      let flowlet = topFlowlet ?? defaultTopFlowlet; // We want to ensure flowlet is always assigned
       if (shouldPushPopFlowlet(event)) {
-        if (surface) {
-          flowlet = flowlet.fork(surface);
-        }
-        flowlet = flowlet.fork(eventName);
+        let flowletName = eventName + `(ts:${captureTimestamp}`;
         if (autoLoggingID) {
-          flowlet = flowlet.fork(autoLoggingID)
+          flowletName += `,element:${autoLoggingID}`;
         }
-        flowlet = flowlet.fork(`ts${captureTimestamp}`);
+        if (surface) {
+          flowletName += `,surface:${surface}`;
+        }
+        flowletName += ')';
+        flowlet = new flowletManager.flowletCtor(flowletName);
+        ALFlowletManagerInstance.push(flowlet);
         flowlet = flowletManager.push(flowlet);
         activeUIEventFlowlets.set(eventName, flowlet);
-        ALFlowletManagerInstance.push(flowlet);
       }
       let reactComponentData: ReactComponentData | null = null;
       if (element && cacheElementReactInfo) {


### PR DESCRIPTION
For UI events, proposing to always start a new flowlet, instead of forking from the current top flowlet. Often, whatever else is happening when the UI event occurs is irrelevant to the user action that triggered the UI event. 

Changes made:
- When there is a UI event, create a new flowlet without assigning the current top flowlet as the parent
- Set `ALFlowletManagerInstance.push(flowlet)` before `flowletManager.push(flowlet)`, so that `ALFlowletManagerInstance.top()` is up-to-date before the new UI event flowlet is pushed to `flowletManager`
- Changed the UI event flowlet name so that the flowlet created is a single flowlet. The exact naming pattern will likely change once we align on a more scalable/consistent flowlet naming pattern for all use cases. 