### PR TITLE
Better detect class components

### DIFF
--- a/packages/hyperion-react/src/IReactComponent.ts
+++ b/packages/hyperion-react/src/IReactComponent.ts
@@ -205,7 +205,8 @@ export function init(options: InitOptions): void {
       if (
         classComponentParentClass instanceof ReactModule.Component ||
         typeof classComponentParentClass?.render === 'function' || // possibly created via React.createClass
-        Object.getPrototypeOf(Object.getPrototypeOf(classComponentParentClass)) // not a plane function, may be with some other lifecycle methods. 
+        Object.getPrototypeOf(Object.getPrototypeOf(classComponentParentClass)) || // not a plain function, may be with some other lifecycle methods. 
+        classComponentParentClass === ReactModule.Component.prototype // in case buggy code didn't properly inherit from ReactModule.Component
       ) {
         // $FlowIgnore[incompatible-exact]
         // $FlowIgnore[incompatible-type]


### PR DESCRIPTION
We had an internal SEV (S348357) that was caused because some old code was setting up a class component incorrectly by just copying the `React.Component.prototype`.
This fix addresses such situations to have more robust detection of function components in case such pattern exists in other places.