### PR TITLE
Fixed interception of Promises for Network events.

### DIFF
--- a/packages/hyperion-autologging/src/ALNetworkPublisher.ts
+++ b/packages/hyperion-autologging/src/ALNetworkPublisher.ts
@@ -4,7 +4,7 @@
 
 import { assert } from "@hyperion/global";
 import { Channel } from "@hyperion/hook/src/Channel";
-import "@hyperion/hyperion-core/src/IPromise";
+import * as IPromise from "@hyperion/hyperion-core/src/IPromise";
 import * as intercept from "@hyperion/hyperion-core/src/intercept";
 import * as IWindow from "@hyperion/hyperion-dom/src/IWindow";
 import * as IXMLHttpRequest from "@hyperion/hyperion-dom/src/IXMLHttpRequest";
@@ -176,6 +176,7 @@ function captureFetch(options: InitOptions): void {
      */
 
     if (ephemeralRequestEvent) {
+      intercept.intercept(value, IPromise.IPromisePrototype); // Ensure we can setVirtualPropertyValue, and ensures Promise is intercepted.
       intercept.setVirtualPropertyValue<ALNetworkRequestEvent>(value, REQUEST_INFO_PROP_NAME, ephemeralRequestEvent);
       value.then(response => {
         const requestEvent = intercept.getVirtualPropertyValue<ALNetworkRequestEvent>(value, REQUEST_INFO_PROP_NAME);

--- a/packages/hyperion-autologging/src/AutoLogging.ts
+++ b/packages/hyperion-autologging/src/AutoLogging.ts
@@ -6,6 +6,7 @@
 
 import { assert } from "@hyperion/global";
 import { Channel } from "@hyperion/hook/src/Channel";
+import { initFlowletTrackers } from "@hyperion/hyperion-flowlet/src/Index";
 import * as Types from "@hyperion/hyperion-util/src/Types";
 import * as ALHeartbeat from "./ALHeartbeat";
 import * as ALNetworkPublisher from "./ALNetworkPublisher";
@@ -60,6 +61,8 @@ export function init(options: InitOptions): boolean {
   if (options.componentNameValidator) {
     setComponentNameValidator(options.componentNameValidator);
   }
+
+  initFlowletTrackers(options.flowletManager);
 
   const sharedOptions: ALSharedInitOptions = {
     flowletManager: options.flowletManager,

--- a/packages/hyperion-flowlet/src/Index.ts
+++ b/packages/hyperion-flowlet/src/Index.ts
@@ -9,9 +9,16 @@ import * as IEventTarget from "@hyperion/hyperion-dom/src/IEventTarget";
 // import * as IWindow from "@hyperion/hyperion-dom/src/IWindow";
 // import * as IWorker from "@hyperion/hyperion-dom/src/IWorker";
 import * as IXMLHttpRequest from "@hyperion/hyperion-dom/src/IXMLHttpRequest";
+import TestAndSet from "@hyperion/hyperion-util/src/TestAndSet";
 import { FlowletManager } from "./FlowletManager";
 
+const initialized = new TestAndSet();
+
 export function initFlowletTrackers(flowletManager: FlowletManager) {
+  if (initialized.testAndSet()) {
+    return;
+  }
+
   for (const eventHandler of [
     // IWindow.ondevicemotion,
     // IWindow.ondeviceorientation,

--- a/packages/hyperion-react-testapp/src/AutoLoggingWrapper.ts
+++ b/packages/hyperion-react-testapp/src/AutoLoggingWrapper.ts
@@ -4,7 +4,6 @@
 
 import { Channel } from "@hyperion/hook/src/Channel";
 import * as AutoLogging from "@hyperion/hyperion-autologging/src/AutoLogging";
-import { initFlowletTrackers } from "@hyperion/hyperion-flowlet/src/Index";
 import * as IReact from "@hyperion/hyperion-react/src/IReact";
 import * as IReactDOM from "@hyperion/hyperion-react/src/IReactDOM";
 import React from 'react';
@@ -30,11 +29,35 @@ export function init() {
 
   });
 
-  initFlowletTrackers(FlowletManager);
-
   const testCompValidator = (name: string) => !name.match(/(^Surface(Proxy)?)/);
 
   console.log('csid:', ClientSessionID);
+
+  // Better to first setup listeners before initializing AutoLogging so we don't miss any events (e.g. Heartbeat(START))
+  ([
+    'al_surface_mount',
+    'al_surface_unmount',
+    'al_heartbeat_event',
+    'al_ui_event_capture',
+    'al_ui_event_bubble',
+  ] as const).forEach(eventName => {
+    channel.on(eventName).add(ev => {
+      console.log(eventName, ev, performance.now());
+    });
+
+  });
+
+  ([
+    'al_ui_event',
+    'al_surface_mutation_event',
+    'al_network_request',
+    'al_network_response',
+    'al_network_response',
+  ] as const).forEach(eventName => {
+    channel.on(eventName).add(ev => {
+      console.log(eventName, ev, performance.now(), ev.flowlet?.getFullName());
+    });
+  });
 
   AutoLogging.init({
     flowletManager: FlowletManager,
@@ -89,28 +112,4 @@ export function init() {
     }
   });
 
-  ([
-    'al_surface_mount',
-    'al_surface_unmount',
-    'al_heartbeat_event',
-    'al_ui_event_capture',
-    'al_ui_event_bubble',
-  ] as const).forEach(eventName => {
-    channel.on(eventName).add(ev => {
-      console.log(eventName, ev, performance.now());
-    });
-
-  });
-
-  ([
-    'al_ui_event',
-    'al_surface_mutation_event',
-    'al_network_request',
-    'al_network_response',
-    'al_network_response',
-  ] as const).forEach(eventName => {
-    channel.on(eventName).add(ev => {
-      console.log(eventName, ev, performance.now(), ev.flowlet?.getFullName());
-    });
-  });
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -18,6 +18,8 @@ export default defineConfig({
         "@hyperion/hyperion-core/src/AttributeInterceptor",
         "@hyperion/hyperion-core/src/intercept",
         "@hyperion/hyperion-core/src/IRequire",
+        "@hyperion/hyperion-core/src/IPromise",
+        "@hyperion/hyperion-core/src/IGlobalThis",
       ],
       "hyperionDOM": [
         "@hyperion/hyperion-dom/src/IEventTarget",

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,8 @@ export { interceptFunction } from "@hyperion/hyperion-core/src/FunctionIntercept
 export { interceptMethod } from "@hyperion/hyperion-core/src/MethodInterceptor";
 export { interceptConstructor, interceptConstructorMethod } from "@hyperion/hyperion-core/src/ConstructorInterceptor";
 export * as IRequire from "@hyperion/hyperion-core/src/IRequire";
+export * as IPromise from "@hyperion/hyperion-core/src/IPromise";
+export * as IGlobalThis from "@hyperion/hyperion-core/src/IGlobalThis";
 
 // hyperionDOM
 export * as IEventTarget from "@hyperion/hyperion-dom/src/IEventTarget";


### PR DESCRIPTION
The al_network_* events assume Promise interception is already happened. We did have a empty call to `IPromise` to ensure that but it was removed during build time.

If we were calling `initFlowletTrackers` it would trigger Promise interception as a side effect. So, in some cases we were lukcy.

I noticed in some applications that we have console error for handling fetch. It turned out a) initFlowletTrackers was not called by default as part of AutoLogging, and b) call to require IPromise was dropped during build of bundles.

The code here fixes these issues and ensures we can handle `fetch` calls with our network events.