### PR TITLE
Test fake timers with latest version of jest

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,30 +59,30 @@
     "./packages/hyperion-util"
   ],
   "dependencies": {
-    "@hyperion/global": "*",
-    "@hyperion/hook": "*",
-    "@hyperion/hyperion-autologging": "*",
-    "@hyperion/hyperion-core": "*",
-    "@hyperion/hyperion-dom": "*",
-    "@hyperion/hyperion-flowlet": "*",
-    "@hyperion/hyperion-react": "*",
-    "@hyperion/hyperion-util": "*"
+    "@hyperion/global": "^0.1.0",
+    "@hyperion/hook": "^0.1.0",
+    "@hyperion/hyperion-autologging": "^0.1.0",
+    "@hyperion/hyperion-core": "^0.1.0",
+    "@hyperion/hyperion-dom": "^0.1.0",
+    "@hyperion/hyperion-flowlet": "^0.1.0",
+    "@hyperion/hyperion-react": "^0.1.0",
+    "@hyperion/hyperion-util": "^0.1.0"
   },
   "devDependencies": {
-    "@babel/cli": "^7.18.10",
-    "@babel/core": "^7.18.13",
+    "@babel/cli": "^7.22.9",
+    "@babel/core": "^7.22.9",
     "@babel/plugin-proposal-class-properties": "^7.18.6",
-    "@babel/preset-env": "^7.18.10",
-    "@babel/preset-typescript": "^7.18.6",
-    "@types/jest": "^29.0.0",
-    "@types/node": "^18.11.15",
-    "babel-jest": "^29.0.2",
-    "jest": "^29.0.2",
-    "jest-environment-jsdom": "^29.0.2",
+    "@babel/preset-env": "^7.22.9",
+    "@babel/preset-typescript": "^7.22.5",
+    "@types/jest": "^29.5.3",
+    "@types/node": "^20.4.1",
+    "babel-jest": "^29.6.1",
+    "jest": "^29.6.1",
+    "jest-environment-jsdom": "^29.6.1",
     "md5": "^2.3.0",
-    "rollup": "^3.7.4",
+    "rollup": "^3.26.2",
     "rollup-plugin-node-resolve": "^5.2.0",
-    "tslib": "^2.4.0",
-    "typescript": "^5.1.3"
+    "tslib": "^2.6.0",
+    "typescript": "^5.1.6"
   }
 }

--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -17,6 +17,6 @@
     "test": "jest"
   },
   "devDependencies": {
-    "@types/jest": "^27.4.1"
+    "@types/jest": "^29.5.3"
   }
 }

--- a/packages/global/package.json
+++ b/packages/global/package.json
@@ -16,7 +16,7 @@
     "../devtools"
   ],
   "devDependencies": {
-    "@hyperion/devtools": "*",
+    "@hyperion/devtools": "^0.1.0",
     "@types/jest": "^27.4.1"
   }
 }

--- a/packages/hook/package.json
+++ b/packages/hook/package.json
@@ -21,7 +21,7 @@
     "../devtools"
   ],
   "devDependencies": {
-    "@hyperion/devtools": "*",
-    "@types/jest": "^27.4.1"
+    "@hyperion/devtools": "^0.1.0",
+    "@types/jest": "^29.5.3"
   }
 }

--- a/packages/hyperion-autologging/package.json
+++ b/packages/hyperion-autologging/package.json
@@ -19,18 +19,18 @@
     "../hyperion-react"
   ],
   "dependencies": {
-    "@hyperion/global": "*",
-    "@hyperion/hook": "*",
-    "@hyperion/hyperion-dom": "*",
-    "@hyperion/hyperion-react": "*"
+    "@hyperion/global": "^0.1.0",
+    "@hyperion/hook": "^0.1.0",
+    "@hyperion/hyperion-dom": "^0.1.0",
+    "@hyperion/hyperion-react": "^0.1.0"
   },
   "peerDependencies": {
-    "@types/react": "^18.2.7",
-    "@types/react-dom": "^18.2.4"
+    "@types/react": "^18.2.14",
+    "@types/react-dom": "^18.2.7"
   },
   "devDependencies": {
-    "@hyperion/devtools": "*",
-    "@types/jest": "^27.4.1"
+    "@hyperion/devtools": "^0.1.0",
+    "@types/jest": "^29.5.3"
   },
   "eslintConfig": {
     "extends": [

--- a/packages/hyperion-core/package.json
+++ b/packages/hyperion-core/package.json
@@ -16,11 +16,11 @@
     "../hook"
   ],
   "dependencies": {
-    "@hyperion/global": "*",
-    "@hyperion/hook": "*"
+    "@hyperion/global": "^0.1.0",
+    "@hyperion/hook": "^0.1.0"
   },
   "devDependencies": {
-    "@hyperion/devtools": "*",
-    "@types/jest": "^27.4.1"
+    "@hyperion/devtools": "^0.1.0",
+    "@types/jest": "^29.5.3"
   }
 }

--- a/packages/hyperion-core/test/Timers.test.ts
+++ b/packages/hyperion-core/test/Timers.test.ts
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved.
+ */
+
+import "jest";
+
+
+describe('test timers', () => {
+
+  test('Check the rendered components', async () => {
+    jest.useFakeTimers();
+
+    console.log('BEFORE FIRST');
+    jest.advanceTimersByTime(100);
+    console.log('AFTER FIRST');
+
+    /**
+     * We load the following here to test what happens if jest starts first
+     * and then we install the interceptors.
+     * Goal is to see everyting continue function correctly.
+     */
+    const x = require("../src/IGlobalThis");
+    x.setTimeout.onArgsObserverAdd(() => {
+      console.log("something");
+    });
+
+    console.log('BEFORE SECOND');
+    let y: number = 0;
+    setTimeout(() => {
+      y = 1;
+    }, 50);
+
+    jest.advanceTimersByTime(100);
+    console.log('AFTER SECOND');
+    expect(y).toBe(1);
+  });
+
+});

--- a/packages/hyperion-dom/package.json
+++ b/packages/hyperion-dom/package.json
@@ -17,14 +17,14 @@
     "../hyperion-core"
   ],
   "dependencies": {
-    "@hyperion/global": "*",
-    "@hyperion/hook": "*",
-    "@hyperion/hyperion-core": "*"
+    "@hyperion/global": "^0.1.0",
+    "@hyperion/hook": "^0.1.0",
+    "@hyperion/hyperion-core": "^0.1.0"
   },
   "devDependencies": {
-    "@hyperion/devtools": "*",
-    "@types/jest": "^27.4.1",
-    "cross-fetch": "^3.1.5",
+    "@hyperion/devtools": "^0.1.0",
+    "@types/jest": "^29.5.3",
+    "cross-fetch": "^4.0.0",
     "xhr-mock": "^2.5.1"
   }
 }

--- a/packages/hyperion-flowlet/package.json
+++ b/packages/hyperion-flowlet/package.json
@@ -17,12 +17,12 @@
     "../hyperion-dom"
   ],
   "dependencies": {
-    "@hyperion/global": "*",
-    "@hyperion/hook": "*",
-    "@hyperion/hyperion-dom": "*"
+    "@hyperion/global": "^0.1.0",
+    "@hyperion/hook": "^0.1.0",
+    "@hyperion/hyperion-dom": "^0.1.0"
   },
   "devDependencies": {
-    "@hyperion/devtools": "*",
-    "@types/jest": "^27.4.1"
+    "@hyperion/devtools": "^0.1.0",
+    "@types/jest": "^29.5.3"
   }
 }

--- a/packages/hyperion-react-testapp/package.json
+++ b/packages/hyperion-react-testapp/package.json
@@ -15,7 +15,7 @@
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
-    "@types/jest": "^27.5.2",
+    "@types/jest": "^29.5.3",
     "@types/node": "^16.18.9",
     "@types/react": "^18.0.26",
     "@types/react-dom": "^18.0.9",

--- a/packages/hyperion-react/package.json
+++ b/packages/hyperion-react/package.json
@@ -17,16 +17,16 @@
     "../hyperion-dom"
   ],
   "dependencies": {
-    "@hyperion/global": "*",
-    "@hyperion/hook": "*",
-    "@hyperion/hyperion-dom": "*",
-    "@types/react": "^18.0.26",
-    "@types/react-dom": "^18.0.9",
-    "@types/react-is": "^17.0.3",
+    "@hyperion/global": "^0.1.0",
+    "@hyperion/hook": "^0.1.0",
+    "@hyperion/hyperion-dom": "^0.1.0",
+    "@types/react": "^18.2.14",
+    "@types/react-dom": "^18.2.7",
+    "@types/react-is": "^17.0.4",
     "react-is": "^18.2.0"
   },
   "devDependencies": {
-    "@hyperion/devtools": "*",
-    "@types/jest": "^29.2.4"
+    "@hyperion/devtools": "^0.1.0",
+    "@types/jest": "^29.5.3"
   }
 }

--- a/packages/hyperion-util/package.json
+++ b/packages/hyperion-util/package.json
@@ -17,12 +17,12 @@
     "../hyperion-dom"
   ],
   "dependencies": {
-    "@hyperion/global": "*",
-    "@hyperion/hook": "*",
-    "@hyperion/hyperion-dom": "*"
+    "@hyperion/global": "^0.1.0",
+    "@hyperion/hook": "^0.1.0",
+    "@hyperion/hyperion-dom": "^0.1.0"
   },
   "devDependencies": {
-    "@hyperion/devtools": "*",
-    "@types/jest": "^27.4.1"
+    "@hyperion/devtools": "^0.1.0",
+    "@types/jest": "^29.5.3"
   }
 }


### PR DESCRIPTION
Upgraded jest (and other packages) and added a new test To ensure that fake timers work with latest version of jest and also hyperion core enabled, which intercepts `setTimeout`.

The test loads interception a bit late to test how jest will behave.