### PR TITLE
Add flowlet ids

### DIFF
--- a/packages/hyperion-flowlet/src/Flowlet.ts
+++ b/packages/hyperion-flowlet/src/Flowlet.ts
@@ -2,14 +2,23 @@
  * Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved.
  */
 
+import { Hook } from "@hyperion/hook";
+
+export const onFlowletInit = new Hook<(flowlet: Flowlet) => void>();
+
+let flowletID: number = 0;
+
 export class Flowlet<T extends {} = {}> {
   readonly data: T;
+  private _id: number = flowletID++;
   private _fullName: string | null = null;
+
   constructor(
     public readonly name: string,
     public readonly parent?: Flowlet<T> | null
   ) {
     this.data = Object.create(parent?.data ?? null);
+    onFlowletInit.call(this);
   }
 
   getFullName(): string {
@@ -17,6 +26,10 @@ export class Flowlet<T extends {} = {}> {
       this._fullName = `${this.parent?.getFullName() ?? ""}/${this.name}`;
     }
     return this._fullName;
+  }
+
+  getID(): number {
+    return this._id;
   }
 
   fork(name: string): Flowlet<T> {

--- a/packages/hyperion-flowlet/src/Flowlet.ts
+++ b/packages/hyperion-flowlet/src/Flowlet.ts
@@ -4,13 +4,13 @@
 
 import { Hook } from "@hyperion/hook";
 
-export const onFlowletInit = new Hook<(flowlet: Flowlet) => void>();
+export const onFlowletInit = new Hook<<T extends {} = {}>(flowlet: Flowlet<T>) => void>();
 
 let flowletID: number = 0;
 
 export class Flowlet<T extends {} = {}> {
   readonly data: T;
-  private _id: number = flowletID++;
+  readonly id: number = flowletID++;
   private _fullName: string | null = null;
 
   constructor(
@@ -18,7 +18,7 @@ export class Flowlet<T extends {} = {}> {
     public readonly parent?: Flowlet<T> | null
   ) {
     this.data = Object.create(parent?.data ?? null);
-    onFlowletInit.call(this);
+    onFlowletInit.call<T>(this);
   }
 
   getFullName(): string {
@@ -26,10 +26,6 @@ export class Flowlet<T extends {} = {}> {
       this._fullName = `${this.parent?.getFullName() ?? ""}/${this.name}`;
     }
     return this._fullName;
-  }
-
-  getID(): number {
-    return this._id;
   }
 
   fork(name: string): Flowlet<T> {

--- a/packages/hyperion-react/src/IReactFlowlet.ts
+++ b/packages/hyperion-react/src/IReactFlowlet.ts
@@ -17,12 +17,10 @@ export interface FlowletDataType {
 };
 
 
-let _globalExtId = 0;
 export class PropsExtension<
   DataType extends FlowletDataType,
   FlowletType extends Flowlet<DataType>
 > {
-  readonly id: number = _globalExtId++; // Useful for debugging
   flowlet: FlowletType;
 
   constructor(flowlet: FlowletType) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,7 +38,7 @@ export { default as TestAndSet } from "@hyperion/hyperion-util/src/TestAndSet";
 export { TimedTrigger } from "@hyperion/hyperion-util/src/TimedTrigger";
 
 // hyperionFlowletCore
-export { Flowlet } from "@hyperion/hyperion-flowlet/src/Flowlet";
+export { Flowlet, onFlowletInit } from "@hyperion/hyperion-flowlet/src/Flowlet";
 export { FlowletManager } from "@hyperion/hyperion-flowlet/src/FlowletManager";
 
 // hyperionFlowlet


### PR DESCRIPTION
Changes made:
- Added a simple id setter (on initialization) and getter for the base Flowlet class. This is a starting point for being able to pass around and identify flowlets without having to rely on the full name string.
- Added an `onFlowletInit` hook to be able to track when new flowlet instances/ids are created