### PR TITLE
Surface config channel should use publisher provided channel

### DIFF
--- a/packages/hyperion-autologging/src/ALSurface.ts
+++ b/packages/hyperion-autologging/src/ALSurface.ts
@@ -73,7 +73,8 @@ export type InitOptions = Types.Options<
     IReactModule: IReact.IReactModuleExports;
     IJsxRuntimeModule: IReact.IJsxRuntimeModuleExports;
     domFlowletAttributeName?: string;
-    channel: ALChannel;
+    // Only used if ALSurfaceMutationPublisher is enabled as well.
+    channel?: ALChannel;
     disableReactDomPropsExtension?: boolean;
   }
 >;
@@ -204,7 +205,7 @@ export function init(options: InitOptions): ALSurfaceHOC {
       const { channel } = options;
       // Emit surface mutation events on mount/unmount
       ReactModule.useLayoutEffect(() => {
-        const metadata = props.metadata ?? {}; // Note that we want the same object to be shared between events to share the changes. 
+        const metadata = props.metadata ?? {}; // Note that we want the same object to be shared between events to share the changes.
         channel.emit('al_surface_mount', { surface: fullSurfaceString, metadata });
         return () => {
           channel.emit('al_surface_unmount', { surface: fullSurfaceString, metadata });

--- a/packages/hyperion-autologging/src/AutoLogging.ts
+++ b/packages/hyperion-autologging/src/AutoLogging.ts
@@ -38,8 +38,8 @@ export type InitOptions = Types.Options<
   {
     componentNameValidator?: ComponentNameValidator;
     flowletPublisher?: PublicInitOptions<ALFlowletPublisher.InitOptions> | null;
-    surface: PublicInitOptions<ALSurface.InitOptions>;
     elementText?: ALInteractableDOMElement.ALElementTextOptions | null;
+    surface: Omit<PublicInitOptions<ALSurface.InitOptions>, "channel">;
     uiEventPublisher?: PublicInitOptions<ALUIEventPublisher.InitOptions> | null;
     heartbeat?: ALHeartbeat.InitOptions | null;
     surfaceMutationPublisher?: PublicInitOptions<ALSurfaceMutationPublisher.InitOptions> | null;
@@ -110,7 +110,8 @@ export function init(options: InitOptions): boolean {
   cachedResults = {
     surfaceRenderer: ALSurface.init({
       ...sharedOptions,
-      ...options.surface
+      ...options.surface,
+      channel: options.surfaceMutationPublisher?.channel,
     }),
   };
 

--- a/packages/hyperion-react-testapp/src/AutoLoggingWrapper.ts
+++ b/packages/hyperion-react-testapp/src/AutoLoggingWrapper.ts
@@ -77,7 +77,6 @@ export function init() {
       IReactDOMModule,
       IReactModule,
       IJsxRuntimeModule,
-      channel,
     },
     elementText: {
       updateText(elementText: ExtendedElementText, domSource) {


### PR DESCRIPTION
- Since the channel provided is _currently_ only relevant when publishing mutations,  utilize the one provided when configuring the publisher
	- This way there's no way to misconfigure the channels when different ones are provided, since there's an interdependency between the two to enable the publisher

Validated both when publisher config is provided and not provided that things seem to function as expected.

Mutation events:
<img width="1278" alt="image" src="https://github.com/facebook/hyperion/assets/6064408/61db9e47-bf10-4b89-80ec-863621a898e4">

Validated with publisher config omitted surfaces are still present and no mutation events are emitted.
