### PR TITLE
Added testAndSet to FunctionInterceptor for conenience.

### DIFF
--- a/packages/hyperion-core/src/FunctionInterceptor.ts
+++ b/packages/hyperion-core/src/FunctionInterceptor.ts
@@ -427,6 +427,13 @@ export class FunctionInterceptor<
     }
     this.data[dataPropName] = value;
   }
+  public testAndSet(dataPropName: string): boolean {
+    const currValue = this.getData<boolean>(dataPropName) || false;
+    if (!currValue) {
+      this.setData<boolean>(dataPropName, true);
+    }
+    return currValue;
+  }
 }
 
 type ExtendedFuncType<FuncType extends InterceptableFunction> =

--- a/packages/hyperion-core/test/FunctionInterceptor.test.ts
+++ b/packages/hyperion-core/test/FunctionInterceptor.test.ts
@@ -82,6 +82,11 @@ describe("test modern classes", () => {
     const testPropName = 'randomProp';
     fi.setData(testPropName, true);
     expect(fi.getData(testPropName)).toBe(true);
+
+    fi.setData(testPropName, false);
+    expect(fi.getData(testPropName)).toBe(false);
+    expect(fi.testAndSet(testPropName)).toBe(false);
+    expect(fi.getData(testPropName)).toBe(true);
   });
 
   test("Ensure props are carried over", () => {

--- a/packages/hyperion-react/src/IReactComponent.ts
+++ b/packages/hyperion-react/src/IReactComponent.ts
@@ -156,15 +156,12 @@ export function init(options: InitOptions): void {
      * So, we don't need to use the interceptionInfo map here.
      */
 
-    const fi = __DEV__
-      ? interceptFunction<TReactFunctionComponent>(
-        functionComponent,
-        false,
-        null,
-        (functionComponent.displayName ?? functionComponent.name) || void 0, // void 0 will force default for empty string
-      )
-      : interceptFunction<TReactFunctionComponent>(functionComponent);
-
+    const fi = interceptFunction<TReactFunctionComponent>(
+      functionComponent,
+      false,
+      null,
+      (functionComponent.displayName ?? functionComponent.name) || void 0, // void 0 will force default for empty string
+    );
     onReactFunctionComponentIntercept.call(fi);
 
     return fi.interceptor;


### PR DESCRIPTION
In many cases, we check the data value once and then set it. This helper method makes it more concise.

Also removed __DEV__ for function component name.