### PR TITLE
changed reduceText option to getText, updated interactive element list

### DIFF
--- a/packages/hyperion-autologging/test/ALInteractableDOMElement.test.ts
+++ b/packages/hyperion-autologging/test/ALInteractableDOMElement.test.ts
@@ -69,8 +69,19 @@ describe("Text various element text options", () => {
         }
         elementText.text = elementText.text.replace(/\r\n|\r|\n/, '');
       },
-      reduceText: (prev: ExtendedElementText, current: ExtendedElementText, next: ExtendedElementText) => {
-        next.modifiedText = (prev.modifiedText ?? "") + (current.modifiedText ?? "");
+      getText: (elementTexts: Readonly<ExtendedElementText[]>): ExtendedElementText => {
+        return elementTexts.reduce((prev, current) => {
+          return {
+            ...prev,
+            ...current,
+            text: prev.text + ALInteractableDOMElement.extractCleanText(current.text),
+            modifiedText: (prev.modifiedText ?? "") + (current.modifiedText ?? ""),
+          }
+        }, {
+          text: "",
+          source: 'innerText',
+          modifiedText: ""
+        });
       }
     });
     const text = ALInteractableDOMElement.getElementTextEvent(dom, null);


### PR DESCRIPTION
To allow external apps fully controll text generation, replaced the `reduceText` with `getText` that will be used instead of the default logic if provided.

Also updated the list of interactive elements according the standard.