### PR TITLE
Rename alFlowlet to uiEventFlowlet

### DIFF
--- a/packages/hyperion-autologging/src/ALFlowletManager.ts
+++ b/packages/hyperion-autologging/src/ALFlowletManager.ts
@@ -14,7 +14,7 @@ import { Flowlet } from "@hyperion/hyperion-flowlet/src/Flowlet";
  */
 export interface ALFlowletDataType {
   surface?: string;
-  alFlowlet?: ALFlowlet;
+  uiEventFlowlet?: ALFlowlet;
 };
 
 export class ALFlowlet<DataType extends ALFlowletDataType = ALFlowletDataType>
@@ -27,5 +27,3 @@ export class ALFlowletManager<DataType extends ALFlowletDataType = ALFlowletData
     super(ALFlowlet);
   }
 }
-
-export const ALFlowletManagerInstance = new ALFlowletManager();

--- a/packages/hyperion-autologging/src/ALNetworkPublisher.ts
+++ b/packages/hyperion-autologging/src/ALNetworkPublisher.ts
@@ -159,7 +159,6 @@ function captureFetch(options: InitOptions): void {
         eventTimestamp: performanceAbsoluteNow(),
         eventIndex: ALEventIndex.getNextEventIndex(),
         flowlet,
-        alFlowlet: flowlet?.data.alFlowlet,
         ...request,
         metadata: {},
       });
@@ -189,7 +188,6 @@ function captureFetch(options: InitOptions): void {
           eventTimestamp: performanceAbsoluteNow(),
           eventIndex: ALEventIndex.getNextEventIndex(),
           flowlet,
-          alFlowlet: flowlet?.data.alFlowlet,
           requestEvent,
           response,
           metadata: {},
@@ -240,7 +238,6 @@ function captureXHR(options: InitOptions): void {
 
 
     const flowlet = flowletManager.top(); // Before calling requestFilter and losing current top flowlet
-    const alFlowlet = flowlet?.data.alFlowlet;
     if (!options.requestFilter || options.requestFilter(request)) {
       let requestEvent: ALNetworkResponseEvent['requestEvent'];
 
@@ -250,7 +247,6 @@ function captureXHR(options: InitOptions): void {
         eventTimestamp: performanceAbsoluteNow(),
         eventIndex: ALEventIndex.getNextEventIndex(),
         flowlet,
-        alFlowlet,
         ...request, // assert already ensures request is not undefined
         metadata: {},
       });
@@ -266,7 +262,6 @@ function captureXHR(options: InitOptions): void {
             eventTimestamp: performanceAbsoluteNow(),
             eventIndex: ALEventIndex.getNextEventIndex(),
             flowlet, // should carry request flowlet forward
-            alFlowlet,
             requestEvent,
             response: this,
             metadata: {},

--- a/packages/hyperion-autologging/src/ALSurfaceMutationPublisher.ts
+++ b/packages/hyperion-autologging/src/ALSurfaceMutationPublisher.ts
@@ -175,7 +175,6 @@ export function publish(options: InitOptions): void {
           eventIndex: ALEventIndex.getNextEventIndex(),
           autoLoggingID: ALID.getOrSetAutoLoggingID(element),
           flowlet,
-          alFlowlet: flowlet?.data.alFlowlet,
         });
         break;
       }
@@ -190,7 +189,6 @@ export function publish(options: InitOptions): void {
           autoLoggingID: ALID.getOrSetAutoLoggingID(element),
           mountedDuration: (removeTime - surfaceInfo.addTime) / 1000,
           flowlet,
-          alFlowlet: flowlet?.data.alFlowlet,
           mountEvent,
         });
         break;

--- a/packages/hyperion-autologging/src/ALType.ts
+++ b/packages/hyperion-autologging/src/ALType.ts
@@ -9,7 +9,6 @@ import { ALFlowlet, ALFlowletManager } from './ALFlowletManager';
 
 export type ALFlowletEvent = Readonly<{
   flowlet: ALFlowlet;
-  alFlowlet: ALFlowlet | null | undefined; // we want to ensure the value is always passed, even with a null value
 }>;
 
 export type ALOptionalFlowletEvent = Omit<ALFlowletEvent, 'flowlet'> & Readonly<{


### PR DESCRIPTION
Changes made:
- Renamed `alFlowlet` to `uiEventFlowlet`, since these are flowlets that map directly to UI events and are used to link generic AL events with the triggering UI event
- Removed `alFlowlet` from channel events since it can be read directly from `flowlet`