### PR TITLE
Use targetElement for resolving React info

### DIFF
--- a/packages/hyperion-react-testapp/src/App.tsx
+++ b/packages/hyperion-react-testapp/src/App.tsx
@@ -11,6 +11,7 @@ import NestedComponent from './component/NestedComponent';
 import { PortalBodyContainerComponent } from './component/PortalComponent';
 import DynamicSvgComponent from './component/DynamicSvgComponent';
 import ElementNameComponent from './component/ElementNameComponent';
+import TextComponent from './component/TextComponent';
 
 function InitComp() {
   const [count, setCount] = React.useState(0);
@@ -50,6 +51,7 @@ function App() {
         <ElementNameComponent />
       </div>
       <DynamicSvgComponent></DynamicSvgComponent>
+      <TextComponent />
     </div>
   );
 }

--- a/packages/hyperion-react-testapp/src/component/TextComponent.tsx
+++ b/packages/hyperion-react-testapp/src/component/TextComponent.tsx
@@ -1,0 +1,7 @@
+export default function TextComponent() {
+  return (
+    <div onClick={(_) => null}>
+      <span>Text Span (Clicking Text Should Resolve to reactComponentName:TextComponent, while interactable element:div)</span>
+    </div>
+  );
+}


### PR DESCRIPTION
- With the change to use interactable element as source for better text extraction we seem to now run into cases where the interactable element does not have fiber information and may be installed by react itself, and may only contain the prop `_reactListening*` and no `_reactFiber` available.
- This change just keeps a ref to targetElement and uses it for resolving react information, leaving the other uses of the resolved interactableElement as is.