### PR TITLE
Add default .metadata to all events

### DIFF
--- a/packages/hyperion-autologging/src/ALElementInfo.ts
+++ b/packages/hyperion-autologging/src/ALElementInfo.ts
@@ -6,7 +6,8 @@
 
 import { getReactComponentData_THIS_CAN_BREAK } from './ALReactUtils';
 import type { ReactComponentData } from './ALReactUtils';
-import { getVirtualPropertyValue, setVirtualPropertyValue } from '@hyperion/hyperion-core/src/intercept';
+import { getVirtualPropertyValue, intercept, setVirtualPropertyValue } from '@hyperion/hyperion-core/src/intercept';
+import * as IElement from "@hyperion/hyperion-dom/src/IElement";
 
 const AL_ELEMENT_INFO_PROPNAME = '__alInfo';
 const AUTO_LOGGING_COMPONENT_TYPE = 'data-auto-logging-component-type';
@@ -20,6 +21,7 @@ export default class ALElementInfo {
     element: Element
   ) {
     this.element = element;
+    intercept(element, IElement.IElementtPrototype); // This also ensures that proper interception is setup. 
     setVirtualPropertyValue(
       element,
       AL_ELEMENT_INFO_PROPNAME,

--- a/packages/hyperion-autologging/src/ALFlowletPublisher.ts
+++ b/packages/hyperion-autologging/src/ALFlowletPublisher.ts
@@ -9,30 +9,27 @@ import * as Types from "@hyperion/hyperion-util/src/Types";
 
 import * as Flowlet from "@hyperion/hyperion-flowlet/src/Flowlet";
 import { ALFlowlet } from "./ALFlowletManager";
+import { ALMetadataEvent } from "./ALType";
 
-export type ALFlowletEventData = Readonly<
-  {
-    flowlet: ALFlowlet;
-  }
->;
+export type ALFlowletEventData = ALMetadataEvent & Readonly<{
+  flowlet: ALFlowlet;
+}>;
 
 export type ALChannelFlowletEvent = Readonly<{
   al_flowlet_event: [ALFlowletEventData],
-}
->;
+}>;
 
 export type ALFlowletChannel = Channel<ALChannelFlowletEvent>;
 
-export type InitOptions = Types.Options<
-  {
-    channel: ALFlowletChannel;
-  }
->;
+export type InitOptions = Types.Options<{
+  channel: ALFlowletChannel;
+}>;
 
 export function publish(options: InitOptions): void {
   Flowlet.onFlowletInit.add(flowlet => {
     options.channel.emit('al_flowlet_event', {
       flowlet,
+      metadata: {},
     });
   });
 }

--- a/packages/hyperion-autologging/src/ALHeartbeat.ts
+++ b/packages/hyperion-autologging/src/ALHeartbeat.ts
@@ -126,6 +126,7 @@ function _logHeartbeat(heartbeatType: ALHeartbeatType): void {
       eventTimestamp: timestamp,
       // flowlet: AdsALFlowletManager.top(),
       heartbeatType,
+      metadata: {},
     });
     _lastHeartbeatTime = timestamp;
   }

--- a/packages/hyperion-autologging/src/ALNetworkPublisher.ts
+++ b/packages/hyperion-autologging/src/ALNetworkPublisher.ts
@@ -161,6 +161,7 @@ function captureFetch(options: InitOptions): void {
         flowlet,
         alFlowlet: flowlet?.data.alFlowlet,
         ...request,
+        metadata: {},
       });
     } else {
       ephemeralRequestEvent = null;
@@ -191,6 +192,7 @@ function captureFetch(options: InitOptions): void {
           alFlowlet: flowlet?.data.alFlowlet,
           requestEvent,
           response,
+          metadata: {},
         });
       });
     }
@@ -249,7 +251,8 @@ function captureXHR(options: InitOptions): void {
         eventIndex: ALEventIndex.getNextEventIndex(),
         flowlet,
         alFlowlet,
-        ...request // assert already ensures request is not undefined
+        ...request, // assert already ensures request is not undefined
+        metadata: {},
       });
 
       this.addEventListener(
@@ -266,7 +269,8 @@ function captureXHR(options: InitOptions): void {
             alFlowlet,
             requestEvent,
             response: this,
-          })
+            metadata: {},
+          });
         },
         { once: true }
       );

--- a/packages/hyperion-autologging/src/ALSurfaceMutationPublisher.ts
+++ b/packages/hyperion-autologging/src/ALSurfaceMutationPublisher.ts
@@ -167,6 +167,7 @@ export function publish(options: InitOptions): void {
           autoLoggingID: ALID.getOrSetAutoLoggingID(element),
           flowlet,
           alFlowlet: flowlet?.data.alFlowlet,
+          metadata: {},
         });
         break;
       }
@@ -183,6 +184,7 @@ export function publish(options: InitOptions): void {
           flowlet,
           alFlowlet: flowlet?.data.alFlowlet,
           mountEvent,
+          metadata: {},
         });
         break;
       }

--- a/packages/hyperion-autologging/src/ALType.ts
+++ b/packages/hyperion-autologging/src/ALType.ts
@@ -17,7 +17,15 @@ export type ALOptionalFlowletEvent = Omit<ALFlowletEvent, 'flowlet'> & Readonly<
 }>;
 
 export type ALTimedEvent = Readonly<{
-  eventTimestamp: number,
+  eventTimestamp: number;
+}>;
+
+export type Metadata = {
+  [Key: string]: string;
+};
+
+export type ALMetadataEvent = Readonly<{
+  metadata: Metadata;
 }>;
 
 /**
@@ -31,13 +39,13 @@ export type ALTimedEvent = Readonly<{
  * for their events to signal to the subscribers that they need to add extra
  * information as needed.
  */
-export type ALLoggableEvent = ALTimedEvent & Readonly<{
-  eventIndex: number,
+export type ALLoggableEvent = ALTimedEvent & ALMetadataEvent & Readonly<{
+  eventIndex: number;
 }>;
 
 export type ALReactElementEvent = Readonly<{
-  reactComponentName?: string | null,
-  reactComponentStack?: string[] | null,
+  reactComponentName?: string | null;
+  reactComponentStack?: string[] | null;
 }>;
 
 export type ALSharedInitOptions = Types.Options<{

--- a/packages/hyperion-autologging/test/ALInteractableDOMElement.test.ts
+++ b/packages/hyperion-autologging/test/ALInteractableDOMElement.test.ts
@@ -7,16 +7,10 @@
 import "jest";
 
 import * as ALInteractableDOMElement from "../src/ALInteractableDOMElement";
+import * as DomFragment from "./DomFragment";
 
-function html(text: string): HTMLElement {
-  const element = document.createElement("div");
-  element.innerHTML = text;
-  document.body.appendChild(element); // To ensure query functions of document works
-  return element;
-}
-
-function createTestDom(): HTMLElement {
-  return html(`
+function createTestDom(): DomFragment.DomFragment {
+  return DomFragment.html(`
   <span id='1' aria-label="test1"></span>
   <span id='2' aria-description="test2"></span>
   <span id='3'>test3</span>
@@ -37,7 +31,7 @@ function getText(id: string): string | null {
 
 describe("Text various element text options", () => {
   test("element with simple text", () => {
-    createTestDom();
+    const dom = createTestDom();
 
     expect(getText(`1`)).toBe("test1");
     expect(getText(`2`)).toBe("test2");
@@ -49,6 +43,8 @@ describe("Text various element text options", () => {
     expect(getText(`8`)).toBe("test8");
     expect(getText(`9`)).toBe("test9");
     expect(getText(`10`)).toBe("test10");
+
+    dom.cleanup();
   });
 
   test("element text callbacks", () => {
@@ -84,9 +80,10 @@ describe("Text various element text options", () => {
         });
       }
     });
-    const text = ALInteractableDOMElement.getElementTextEvent(dom, null);
+    const text = ALInteractableDOMElement.getElementTextEvent(dom.root, null);
     expect(text.elementName).toBe("  test1  test2  test3  test3  test3  test3test*  test7  test*  test*  test10  ");
     console.log(text);
 
+    dom.cleanup();
   });
 });

--- a/packages/hyperion-autologging/test/ALUIEventPublisher.test.ts
+++ b/packages/hyperion-autologging/test/ALUIEventPublisher.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved.
+ *
+ * @jest-environment jsdom
+ */
+
+import "jest";
+
+import { Channel } from "@hyperion/hook/src/Channel";
+import { ALFlowletManager } from "../src/ALFlowletManager";
+import { AUTO_LOGGING_SURFACE } from "../src/ALSurfaceConsts";
+import * as ALUIEventPublisher from "../src/ALUIEventPublisher";
+import * as DomFragment from "./DomFragment";
+
+describe("UI event publisher", () => {
+  test("meta data transfer between capture and bubble", (done) => {
+    const flowletManager = new ALFlowletManager();
+
+    const channel = new Channel<ALUIEventPublisher.ALChannelUIEvent>();
+
+    ALUIEventPublisher.publish({
+      flowletManager,
+      domSurfaceAttributeName: AUTO_LOGGING_SURFACE,
+      channel,
+      uiEvents: [
+        {
+          cacheElementReactInfo: true,
+          eventName: 'click',
+        }
+      ]
+    });
+
+    channel.addListener('al_ui_event_capture', event => {
+      event.metadata.m1 = "m1";
+    });
+
+    channel.addListener('al_ui_event_bubble', event => {
+      event.metadata.m2 = "m2";
+    });
+
+    channel.addListener('al_ui_event', event => {
+      expect(event.metadata.m1).toBe("m1");
+      expect(event.metadata.m2).toBe("m2");
+      done();
+    });
+
+    const dom = DomFragment.html(`
+  <div id='1' onclick="void 0;">
+    <span id='2'>"test2"</span>
+  </div>
+`);
+
+    const event = new MouseEvent('click', { bubbles: true });
+    document.getElementById("2")?.dispatchEvent(event);
+
+  });
+});

--- a/packages/hyperion-autologging/test/DomFragment.ts
+++ b/packages/hyperion-autologging/test/DomFragment.ts
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved.
+ *
+ * @jest-environment jsdom
+ */
+
+export interface DomFragment {
+  root: HTMLElement;
+  cleanup(): void;
+}
+
+export function html(text: string): DomFragment {
+  const element = document.createElement("div");
+  element.innerHTML = text;
+  document.body.appendChild(element); // To ensure query functions of document works
+  return {
+    root: element,
+    cleanup() {
+      document.body.removeChild(element);
+    },
+  };
+}

--- a/packages/hyperion-react-testapp/src/component/ClassComponent.tsx
+++ b/packages/hyperion-react-testapp/src/component/ClassComponent.tsx
@@ -8,7 +8,7 @@ import { Props, Surface } from "./Surface";
 
 export default class ClassComponent extends React.Component<Props> {
   render() {
-    return Surface({ surface: `ClassComp: ${this.props.message}` })(
+    return Surface({ surface: `ClassComp: ${this.props.message}`, metadata: { type: 'class component' } })(
       <ul data-comptype="class">
         <li>The class component</li>
         <li>{this.props.message}</li>


### PR DESCRIPTION
Often application code might want to extend the standard AL events and add data to be logged.

Although a recomended way would be to extend the event types themselves, but in some simple cases, it is easier to just add the new data to a default `.metadata` object that is later logged along with the rest of data.

This commit adds this feature, along with some tests. Specially for ui events, the metadata of the capture and bubble events is eventually merged into one and passed to the actual `al_ui_event`.

Later we will properly add supporting metadata for surfaces as well.