### PR TITLE
Ensure react interception is enabled for tracking interactable elements

### DIFF
--- a/packages/hyperion-autologging/src/ALFlowletPublisher.ts
+++ b/packages/hyperion-autologging/src/ALFlowletPublisher.ts
@@ -21,9 +21,11 @@ export type ALChannelFlowletEvent = Readonly<{
 
 export type ALFlowletChannel = Channel<ALChannelFlowletEvent>;
 
-export type InitOptions = Types.Options<{
-  channel: ALFlowletChannel;
-}>;
+export type InitOptions = Types.Options<
+  {
+    channel: ALFlowletChannel;
+  }
+>;
 
 export function publish(options: InitOptions): void {
   Flowlet.onFlowletInit.add(flowlet => {

--- a/packages/hyperion-autologging/src/ALHeartbeat.ts
+++ b/packages/hyperion-autologging/src/ALHeartbeat.ts
@@ -31,11 +31,13 @@ export type ALChannelHeartbeatEvent = Readonly<{
 
 export type ALHeartbeatChannel = Channel<ALChannelHeartbeatEvent & ALChannelUIEvent>;
 
-export type InitOptions = Types.Options<{
-  channel: ALHeartbeatChannel;
-  heartbeatInterval?: number;
-  maxUserInactivityDuration?: number;
-}>;
+export type InitOptions = Types.Options<
+  {
+    channel: ALHeartbeatChannel;
+    heartbeatInterval?: number;
+    maxUserInactivityDuration?: number;
+  }
+>;
 
 const HEARTBEAT_INTERVAL = 30 * 1000 /* DateConsts.MS_PER_SEC */;
 const MAX_USER_INACTIVITY_DURATION = 4 * HEARTBEAT_INTERVAL;

--- a/packages/hyperion-autologging/src/ALIReactFlowlet.ts
+++ b/packages/hyperion-autologging/src/ALIReactFlowlet.ts
@@ -14,12 +14,13 @@ import { ALFlowlet, ALFlowletManager } from "./ALFlowletManager";
 import { ALSurfaceContext } from "./ALSurfaceContext";
 
 export type InitOptions<> = Types.Options<
-  IReactComponent.InitOptions &
   {
-    ReactModule: {
-      useRef: <T>(initialValue: T) => React.MutableRefObject<T>;
-    }
-    IReactModule: IReact.IReactModuleExports;
+    react: IReactComponent.InitOptions & {
+      ReactModule: {
+        useRef: <T>(initialValue: T) => React.MutableRefObject<T>;
+      }
+      IReactModule: IReact.IReactModuleExports;
+    };
     flowletManager: ALFlowletManager;
     disableReactFlowlet?: boolean;
   }
@@ -31,9 +32,10 @@ export function init(options: InitOptions) {
     return;
   }
 
-  IReactComponent.init(options);
+  IReactComponent.init(options.react);
 
-  const { flowletManager, IReactModule, ReactModule } = options;
+  const { flowletManager } = options;
+  const { IReactModule, ReactModule } = options.react;
 
   [
     IReactModule.useCallback,

--- a/packages/hyperion-autologging/src/ALInteractableDOMElement.ts
+++ b/packages/hyperion-autologging/src/ALInteractableDOMElement.ts
@@ -292,7 +292,6 @@ export type ALDOMTextSource = {
 }
 
 export type ALElementTextOptions = Types.Options<
-  IReactComponent.InitOptions &
   {
     maxDepth?: number;
     updateText?: <T extends ALElementText>(elementText: T, domSource: ALDOMTextSource) => void;
@@ -305,9 +304,6 @@ let MaxDepth = 20;
 export function init(options: ALElementTextOptions) {
   _options = options;
   MaxDepth = _options.maxDepth ?? MaxDepth;
-
-  // We need this to ensure interactivity tracking works well.
-  IReactComponent.init(options);
 }
 
 function callExternalTextProcessor(

--- a/packages/hyperion-autologging/src/ALInteractableDOMElement.ts
+++ b/packages/hyperion-autologging/src/ALInteractableDOMElement.ts
@@ -3,9 +3,10 @@
  */
 
 import * as IEventTarget from "@hyperion/hyperion-dom/src/IEventTarget";
-import { ReactComponentObjectProps } from "@hyperion/hyperion-react/src/IReact";
-import { onReactDOMElement } from "@hyperion/hyperion-react/src/IReactComponent";
 // import * as IGlobalEventHandlers from "@hyperion/hyperion-dom/src/IGlobalEventHandlers";
+import { ReactComponentObjectProps } from "@hyperion/hyperion-react/src/IReact";
+import * as IReactComponent from "@hyperion/hyperion-react/src/IReactComponent";
+import type * as Types from "@hyperion/hyperion-util/src/Types";
 
 'use strict';
 
@@ -108,7 +109,7 @@ let installHandlers = () => {
     }
   });
 
-  onReactDOMElement.add((_component, props: ReactComponentObjectProps) => {
+  IReactComponent.onReactDOMElement.add((_component, props: ReactComponentObjectProps) => {
     if (props != null) {
       TrackedEvents.forEach(event => {
         if (props[SYNTHETIC_EVENT_HANDLER_MAP[event]] != null) {
@@ -290,17 +291,23 @@ export type ALDOMTextSource = {
   element: HTMLElement;
 }
 
-export type ALElementTextOptions = Readonly<{
-  maxDepth?: number;
-  updateText?: <T extends ALElementText>(elementText: T, domSource: ALDOMTextSource) => void;
-  getText?: <T extends ALElementText>(elementTexts: T[]) => ALElementText;
-}>;
+export type ALElementTextOptions = Types.Options<
+  IReactComponent.InitOptions &
+  {
+    maxDepth?: number;
+    updateText?: <T extends ALElementText>(elementText: T, domSource: ALDOMTextSource) => void;
+    getText?: <T extends ALElementText>(elementTexts: T[]) => ALElementText;
+  }
+>;
 
 let _options: ALElementTextOptions | null = null;
 let MaxDepth = 20;
 export function init(options: ALElementTextOptions) {
   _options = options;
   MaxDepth = _options.maxDepth ?? MaxDepth;
+
+  // We need this to ensure interactivity tracking works well.
+  IReactComponent.init(options);
 }
 
 function callExternalTextProcessor(

--- a/packages/hyperion-autologging/src/ALSurface.ts
+++ b/packages/hyperion-autologging/src/ALSurface.ts
@@ -66,12 +66,14 @@ export type InitOptions = Types.Options<
   ALSurfaceContext.InitOptions &
   SurfaceProxy.InitOptions &
   {
-    ReactModule: {
-      createElement: typeof React.createElement;
-      useLayoutEffect: typeof React.useLayoutEffect;
+    react: {
+      ReactModule: {
+        createElement: typeof React.createElement;
+        useLayoutEffect: typeof React.useLayoutEffect;
+      };
+      IReactModule: IReact.IReactModuleExports;
+      IJsxRuntimeModule: IReact.IJsxRuntimeModuleExports;
     };
-    IReactModule: IReact.IReactModuleExports;
-    IJsxRuntimeModule: IReact.IJsxRuntimeModuleExports;
     domFlowletAttributeName?: string;
     channel: ALChannel;
     disableReactDomPropsExtension?: boolean;
@@ -100,7 +102,7 @@ function setupDomElementSurfaceAttribute(options: InitOptions): void {
   }
 
   // We should make sure the following enabled for our particular usage in this function.
-  IReactComponent.init(options);
+  IReactComponent.init(options.react);
 
   const { flowletManager, domSurfaceAttributeName = AUTO_LOGGING_SURFACE, domFlowletAttributeName } = options;
   /**
@@ -178,7 +180,8 @@ function setupDomElementSurfaceAttribute(options: InitOptions): void {
 
 
 export function init(options: InitOptions): ALSurfaceHOC {
-  const { ReactModule, flowletManager, domSurfaceAttributeName = AUTO_LOGGING_SURFACE } = options;
+  const { flowletManager, domSurfaceAttributeName = AUTO_LOGGING_SURFACE } = options;
+  const { ReactModule } = options.react;
 
   ALIReactFlowlet.init(options);
 

--- a/packages/hyperion-autologging/src/ALSurfaceContext.ts
+++ b/packages/hyperion-autologging/src/ALSurfaceContext.ts
@@ -11,9 +11,11 @@ import * as Types from "@hyperion/hyperion-util/src/Types";
 
 
 export type InitOptions = Types.Options<{
-  ReactModule: {
-    createContext: typeof React.createContext;
-    useContext: typeof React.useContext;
+  react: {
+    ReactModule: {
+      createContext: typeof React.createContext;
+      useContext: typeof React.useContext;
+    }
   }
 }>;
 
@@ -33,12 +35,12 @@ const DefaultSurfaceContext: ALSurfaceContextValue = {
 export let ALSurfaceContext: React.Context<ALSurfaceContextValue> | null = null;
 
 
-let ReactModule: InitOptions['ReactModule'] | null = null;
+let ReactModule: InitOptions['react']['ReactModule'] | null = null;
 
 export function init(options: InitOptions): React.Context<ALSurfaceContextValue> {
   assert(!ReactModule && !ALSurfaceContext, "Already initilized");
 
-  ReactModule = options.ReactModule;
+  ReactModule = options.react.ReactModule;
   ALSurfaceContext = ReactModule.createContext(
     DefaultSurfaceContext,
   );

--- a/packages/hyperion-autologging/src/ALSurfaceMutationPublisher.ts
+++ b/packages/hyperion-autologging/src/ALSurfaceMutationPublisher.ts
@@ -63,7 +63,8 @@ type SurfaceInfo = ALReactElementEvent & ALElementTextEvent & ALMetadataEvent & 
 const activeSurfaces = new Map<string, SurfaceInfo>();
 
 export type InitOptions = Types.Options<
-  ALSharedInitOptions & {
+  ALSharedInitOptions &
+  {
     channel: ALSurfaceMutationChannel;
     cacheElementReactInfo: boolean;
   }

--- a/packages/hyperion-autologging/src/ALSurfaceProxy.ts
+++ b/packages/hyperion-autologging/src/ALSurfaceProxy.ts
@@ -15,8 +15,10 @@ import * as Types from "@hyperion/hyperion-util/src/Types";
 
 
 export type InitOptions = Types.Options<{
-  ReactModule: { createElement: typeof React.createElement, Fragment: typeof React.Fragment };
-  IReactDOMModule: IReactDOM.IReactDOMModuleExports;
+  react: {
+    ReactModule: { createElement: typeof React.createElement, Fragment: typeof React.Fragment };
+    IReactDOMModule: IReactDOM.IReactDOMModuleExports;
+  };
   flowletManager: ALFlowletManager;
 }>;
 
@@ -36,7 +38,8 @@ type ProxyInitOptions =
  * like the following:
  */
 function SurfaceProxy(props: React.PropsWithChildren<ProxyInitOptions>): React.ReactElement {
-  const { ReactModule, surfaceComponent, flowletManager, children } = props;
+  const { surfaceComponent, flowletManager, children } = props;
+  const { ReactModule, } = props.react;
   const { surface, flowlet } = useALSurfaceContext();
   if (surface != null && flowlet != null) {
     return ReactModule.createElement(
@@ -55,7 +58,7 @@ function SurfaceProxy(props: React.PropsWithChildren<ProxyInitOptions>): React.R
 }
 
 export function init(options: ProxyInitOptions): void {
-  const { IReactDOMModule, ReactModule } = options;
+  const { IReactDOMModule, ReactModule } = options.react;
   /**
    * When createPortal is called, the react components will be added to a
    * separate container DOM node and shown in place later.

--- a/packages/hyperion-autologging/test/ALInteractableDOMElement.test.ts
+++ b/packages/hyperion-autologging/test/ALInteractableDOMElement.test.ts
@@ -276,7 +276,5 @@ describe("Text various element text options", () => {
       node.addEventListener("click", () => { });
       expect(node.getAttribute("data-clickable")).toBe("1");
     }
-
-
   });
 });

--- a/packages/hyperion-react-testapp/src/AutoLoggingWrapper.ts
+++ b/packages/hyperion-react-testapp/src/AutoLoggingWrapper.ts
@@ -72,12 +72,14 @@ export function init() {
     flowletPublisher: {
       channel
     },
-    surface: {
+    react: {
       ReactModule: React as any,
       IReactDOMModule,
       IReactModule,
       IJsxRuntimeModule,
-      channel,
+    },
+    surface: {
+      channel
     },
     elementText: {
       updateText(elementText: ExtendedElementText, domSource) {


### PR DESCRIPTION
In order to track custom events on DOM elements, we should make sure that `IReactComponent.init()` is already called.
This commit fixes that.
In the past, if `disableReactDomPropsExtension` was false, the `ALSurface` would have initialized `IReactComponent` by itself. But the code was not resilient enough to work independently.