### PR TITLE
Use the more concise testAndSet api whenever possible.

### DIFF
--- a/packages/hyperion-autologging/src/ALIReactFlowlet.ts
+++ b/packages/hyperion-autologging/src/ALIReactFlowlet.ts
@@ -117,10 +117,9 @@ export function init(options: InitOptions) {
 
 
     methods.forEach(method => {
-      if (method.getData<boolean>(IS_FLOWLET_SETUP_PROP)) {
+      if (method.testAndSet(IS_FLOWLET_SETUP_PROP)) {
         return;
       }
-      method.setData(IS_FLOWLET_SETUP_PROP, true);
 
       if (method === shadowComponent.render) {
         method.onArgsObserverAdd(function (this: ComponentWithFlowlet) {
@@ -146,8 +145,7 @@ export function init(options: InitOptions) {
 
   IReactComponent.onReactFunctionComponentIntercept.add(
     fi => {
-      if (!fi.getData<boolean>(IS_FLOWLET_SETUP_PROP)) {
-        fi.setData(IS_FLOWLET_SETUP_PROP, true);
+      if (!fi.testAndSet(IS_FLOWLET_SETUP_PROP)) {
 
         let activeFlowlet: ALFlowlet | undefined | null;
         fi.onArgsObserverAdd(_props => {

--- a/packages/hyperion-flowlet/src/FlowletManager.ts
+++ b/packages/hyperion-flowlet/src/FlowletManager.ts
@@ -73,8 +73,7 @@ export class FlowletManager<T extends Flowlet = Flowlet> {
 
     const flowlet = customFlowlet ?? new this.flowletCtor(apiName, this.top());
     const funcInterceptor = interceptEventListener(listener);
-    if (funcInterceptor && !funcInterceptor.getData(IS_FLOWLET_SETUP_PROP_NAME)) {
-      funcInterceptor.setData(IS_FLOWLET_SETUP_PROP_NAME, true);
+    if (funcInterceptor && !funcInterceptor.testAndSet(IS_FLOWLET_SETUP_PROP_NAME)) {
       // funcInterceptor.onArgsObserverAdd(() => {
       //   this.push(currentFLowlet);
       // });

--- a/packages/hyperion-react/src/IReactFlowlet.ts
+++ b/packages/hyperion-react/src/IReactFlowlet.ts
@@ -101,10 +101,9 @@ export function init<
     ];
 
     methods.forEach(method => {
-      if (method.getData<boolean>(IS_FLOWLET_SETUP_PROP)) {
+      if (method.testAndSet(IS_FLOWLET_SETUP_PROP)) {
         return;
       }
-      method.setData(IS_FLOWLET_SETUP_PROP, true);
 
       /**
        * The following interceptor methods run immediately before & after
@@ -126,8 +125,7 @@ export function init<
 
   IReactComponent.onReactFunctionComponentIntercept.add(
     fi => {
-      if (!fi.getData<boolean>(IS_FLOWLET_SETUP_PROP)) {
-        fi.setData(IS_FLOWLET_SETUP_PROP, true);
+      if (!fi.testAndSet(IS_FLOWLET_SETUP_PROP)) {
 
         let activeFlowlet: FlowletType | undefined | null;
         fi.onArgsObserverAdd(props => {


### PR DESCRIPTION
Simple cleanup change to use the simpler `testAndSet` api instead of the the `getData / setData` pairs.