### PR TITLE
Expose Surface utils for apps to directly use it

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -60,6 +60,7 @@ export default defineConfig({
         "@hyperion/hyperion-autologging/src/ALFlowletManager",
         "@hyperion/hyperion-autologging/src/ALSurface",
         "@hyperion/hyperion-autologging/src/ALSurfaceContext",
+        "@hyperion/hyperion-autologging/src/ALSurfaceUtils",
         "@hyperion/hyperion-autologging/src/ALEventIndex",
         "@hyperion/hyperion-autologging/src/ALElementInfo",
         "@hyperion/hyperion-autologging/src/ALInteractableDOMElement",

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,3 +57,4 @@ export * as ALEventIndex from "@hyperion/hyperion-autologging/src/ALEventIndex";
 export { default as ALElementInfo } from "@hyperion/hyperion-autologging/src/ALElementInfo";
 export * as ALInteractableDOMElement from "@hyperion/hyperion-autologging/src/ALInteractableDOMElement";
 export * as AutoLogging from "@hyperion/hyperion-autologging/src/AutoLogging";
+export * as ALSurfaceUtils from "@hyperion/hyperion-autologging/src/ALSurfaceUtils";


### PR DESCRIPTION
As title, a simpel change to avoid duplicate code in the app.