### PR TITLE
Change global window check,  Window not available in server

### DIFF
--- a/packages/hyperion-autologging/src/AutoLogging.ts
+++ b/packages/hyperion-autologging/src/AutoLogging.ts
@@ -71,7 +71,7 @@ export function init(options: InitOptions): boolean {
     setComponentNameValidator(options.componentNameValidator);
   }
 
-  if (global instanceof Window && global?.document.createElement != null) {
+  if (typeof global !== 'undefined' && (global as Window)?.document?.createElement != null) {
     initFlowletTrackers(options.flowletManager);
   }
 


### PR DESCRIPTION
`instanceof Window` can't be executed in server env as `Window` doesn't exist.

Tested with this and seems to work as expected.