### PR TITLE
Fixclasscompreactflowlet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,8 +3,8 @@
 node_modules
 coverage
 package-lock.json
-test/**/*.js
 dist/
+packages/*/src/**/*.js
+packages/*/src/**/*.jsx
 src/**/*.js
-packages/**/src/*.js
-packages/**/src/*.jsx
+test/**/*.js

--- a/packages/hyperion-core/src/ConstructorInterceptor.ts
+++ b/packages/hyperion-core/src/ConstructorInterceptor.ts
@@ -27,7 +27,7 @@ function createCtorInterceptor<
       default: throw "Unsupported case!";
     }
     return result;
-  }
+  };
   copyOwnProperties(ctorFunc, ctorInterceptor, true);
   return ctorInterceptor;
 }
@@ -36,7 +36,7 @@ class ConstructorInterceptor<
   BaseType extends InterceptableObjectType,
   Name extends string,
   FuncType extends { new(...args: any): BaseType; } = { new(...args: ConstructorParameters<BaseType[Name]>): BaseType; }
-  > extends FunctionInterceptor<BaseType, Name, FuncType> {
+> extends FunctionInterceptor<BaseType, Name, FuncType> {
   private ctorInterceptor: FuncType | null = null;
   constructor(name: Name, originalCtor: FuncType) {
     super(name, originalCtor, true); //If we intercept constructor, that means we want the output to be intercepted
@@ -62,7 +62,7 @@ class ConstructorMethodInterceptor<
   Name extends string,
   T extends InterceptableObjectType,
   FuncType extends { new(...args: any): any; } = { new(...args: ConstructorParameters<T[Name]>): T; }
-  > extends MethodInterceptor<Name, T, FuncType> {
+> extends MethodInterceptor<Name, T, FuncType> {
   private ctorInterceptor: FuncType | null = null;
   constructor(name: Name, shadowPrototype: ShadowPrototype<T>, desc?: ExtendedPropertyDescriptor) {
     super(name, shadowPrototype, true, desc); //If we intercept constructor, that means we want the output to be intercepted
@@ -75,16 +75,6 @@ class ConstructorMethodInterceptor<
 }
 
 export function interceptConstructorMethod<
-  Name extends string,
-  BaseType extends InterceptableObjectType,
-  FuncType extends { new(...args: any): any; } = { new(...args: ConstructorParameters<BaseType[Name]>): BaseType; }
->(name: Name,
-  shadowPrototype: ShadowPrototype<BaseType>,
-): FunctionInterceptor<BaseType, Name, FuncType> {
-
-  return new ConstructorMethodInterceptor<Name, BaseType, FuncType>(name, shadowPrototype);
-}
-export function interceptConstrucorMethod<
   Name extends string,
   BaseType extends InterceptableObjectType,
   FuncType extends { new(...args: any): any; } = { new(...args: ConstructorParameters<BaseType[Name]>): BaseType; }

--- a/packages/hyperion-core/src/MethodInterceptor.ts
+++ b/packages/hyperion-core/src/MethodInterceptor.ts
@@ -11,7 +11,7 @@ export class MethodInterceptor<
   Name extends string,
   T extends InterceptableObjectType,
   FuncType extends InterceptableFunction = (this: T, ...args: Parameters<T[Name]>) => ReturnType<T[Name]>
-  >
+>
   extends FunctionInterceptor<T, Name, FuncType>  {
 
   constructor(name: Name, shadowPrototype: ShadowPrototype<T>, interceptOutput: boolean = false, desc?: ExtendedPropertyDescriptor) {
@@ -112,9 +112,9 @@ export function getMethodInterceptor<
   Name extends string,
   BaseType extends InterceptableObjectType,
   FuncType extends InterceptableFunction = (this: BaseType, ...args: Parameters<BaseType[Name]>) => ReturnType<BaseType[Name]>,
-  >(
-    name: Name,
-    shadowPrototype: ShadowPrototype<BaseType>,
+>(
+  name: Name,
+  shadowPrototype: ShadowPrototype<BaseType>,
 ): ExtendedPropertyDescriptor<FunctionInterceptor<BaseType, Name, FuncType>> | undefined {
   type FuncInterceptorType = FunctionInterceptor<BaseType, Name, FuncType>;
 
@@ -145,8 +145,9 @@ export function interceptMethod<
 >(
   name: Name,
   shadowPrototype: ShadowPrototype<BaseType>,
-  interceptOutput: boolean = false
+  interceptOutput: boolean = false,
+  miCtor?: null | (new (name: string, shadowPrototype: ShadowPrototype<BaseType>, interceptOutput?: boolean, desc?: ExtendedPropertyDescriptor) => MethodInterceptor<Name, BaseType, FuncType>),
 ): FunctionInterceptor<BaseType, Name, FuncType> {
   const desc = getMethodInterceptor<Name, BaseType, FuncType>(name, shadowPrototype);
-  return desc?.interceptor ?? new MethodInterceptor(name, shadowPrototype, interceptOutput, desc);
+  return desc?.interceptor ?? new (miCtor ?? MethodInterceptor)(name, shadowPrototype, interceptOutput, desc);
 }

--- a/packages/hyperion-react-testapp/package.json
+++ b/packages/hyperion-react-testapp/package.json
@@ -36,7 +36,8 @@
   "scripts": {
     "start": "vite",
     "build": "tsc && vite build",
-    "serve": "vite preview"
+    "serve": "vite preview",
+    "test": ""
   },
   "eslintConfig": {
     "extends": [

--- a/packages/hyperion-react-testapp/src/component/ClassComponent.tsx
+++ b/packages/hyperion-react-testapp/src/component/ClassComponent.tsx
@@ -19,7 +19,7 @@ class ClassCompWithSurface extends React.Component<{}>{
   }
   render(): React.ReactNode {
     if (ALSurfaceContext) {
-      const outterFlowlet = FlowletManager.top();
+      const outerFlowlet = FlowletManager.top();
       return <ALSurfaceContext.Consumer>
         {value => {
           const surface = value.surface;
@@ -30,7 +30,7 @@ class ClassCompWithSurface extends React.Component<{}>{
             <tr><th>Surface</th><td>{surface}</td></tr>
             <tr><th>Surface Flowlet: </th><td>{surfaceFlowlet?.getFullName()}</td></tr>
             <tr><th>Inner Render Flowlet: </th><td>{flowlet?.getFullName()}</td></tr>
-            <tr><th>Outter Render Flowlet: </th><td>{outterFlowlet?.getFullName()}</td></tr>
+            <tr><th>Outer Render Flowlet: </th><td>{outerFlowlet?.getFullName()}</td></tr>
           </tbody></table>;
           this.foo();
           FlowletManager.pop(newFlowlet);

--- a/packages/hyperion-react-testapp/src/component/ClassComponent.tsx
+++ b/packages/hyperion-react-testapp/src/component/ClassComponent.tsx
@@ -5,18 +5,56 @@
 import React from "react";
 import FuncComponent from "./FuncComponent";
 import { Props, Surface } from "./Surface";
+import { ALSurfaceContext } from "@hyperion/hyperion-autologging/src/ALSurfaceContext";
+import { FlowletManager } from "../FlowletManager";
 
+class ClassCompWithSurface extends React.Component<{}>{
+  private foo() {
+    const flowlet = FlowletManager.top();
+    if (flowlet?.name !== "In Render") {
+      console.error("Invalid flowlet in this method", flowlet?.getFullName());
+    } else {
+      console.log("Recieved correct flowlet", flowlet.getFullName());
+    }
+  }
+  render(): React.ReactNode {
+    if (ALSurfaceContext) {
+      const outterFlowlet = FlowletManager.top();
+      return <ALSurfaceContext.Consumer>
+        {value => {
+          const surface = value.surface;
+          const surfaceFlowlet = value.flowlet;
+          const flowlet = FlowletManager.top();
+          const newFlowlet = FlowletManager.push(new FlowletManager.flowletCtor("In Render", surfaceFlowlet));
+          const result = <table border={1} ><tbody>
+            <tr><th>Surface</th><td>{surface}</td></tr>
+            <tr><th>Surface Flowlet: </th><td>{surfaceFlowlet?.getFullName()}</td></tr>
+            <tr><th>Inner Render Flowlet: </th><td>{flowlet?.getFullName()}</td></tr>
+            <tr><th>Outter Render Flowlet: </th><td>{outterFlowlet?.getFullName()}</td></tr>
+          </tbody></table>;
+          this.foo();
+          FlowletManager.pop(newFlowlet);
+          return result;
+        }
+        }
+      </ALSurfaceContext.Consumer>
+    }
+  }
+}
 export default class ClassComponent extends React.Component<Props> {
   render() {
     return Surface({ surface: `ClassComp: ${this.props.message}`, metadata: { type: 'class component' } })(
-      <ul data-comptype="class">
-        <li>The class component</li>
-        <li>{this.props.message}</li>
-        <li>
-          <FuncComponent message="func comp inside class compo" />
-          {this.props.children}
-        </li>
-      </ul>,
+      <>
+        <ul data-comptype="class">
+          <li>The class component</li>
+          <li>{this.props.message}</li>
+          <li>
+            <FuncComponent message="func comp inside class compo" />
+            {this.props.children}
+          </li>
+        </ul>
+        <ClassCompWithSurface></ClassCompWithSurface>
+      </>,
     );
   }
 }


### PR DESCRIPTION
Added React Class Component constructor interception and then used that to properly set the surface flowlet value of a component for all of its lifecycle methods. 