### PR TITLE
Avoid background tasks until necessary.

### DIFF
--- a/packages/hyperion-util/src/SessionPersistentData.ts
+++ b/packages/hyperion-util/src/SessionPersistentData.ts
@@ -27,6 +27,10 @@ export class SessionPersistentData<T> {
   private static runner: TimedTrigger | null = null;
   private static pending = new Set<SessionPersistentData<any>>();
   private schedule() {
+    if (!this.isPersisted()) {
+      return; // Not much to do!
+    }
+
     if (!SessionPersistentData.runner) {
       SessionPersistentData.runner = new TimedTrigger(
         () => {


### PR DESCRIPTION
If we are not running in reall application (usually browser env.) we may not need some background tasks done.

This commit fixes two things:

* `SessionPersistentData` will only scheduling saving to disk if the feature is available (in browser). Otherwise, avoid unnecessary work.
* `FlowletManager` will only schedule cleanup when the stack size get bigger than a certain threshold. In normal cases, the pairs of push/pops should avoid this situation.