### PR TITLE
Trigger ui event even when propagation is stopped.

### DIFF
--- a/packages/hyperion-dom/src/IEvent.ts
+++ b/packages/hyperion-dom/src/IEvent.ts
@@ -1,0 +1,10 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved.
+ */
+
+import { interceptMethod } from "@hyperion/hyperion-core/src/MethodInterceptor";
+import { DOMShadowPrototype } from "./DOMShadowPrototype";
+
+export const IEventPrototype = new DOMShadowPrototype(Event, null, { sampleObject: new Event("tmp"), registerOnPrototype: true });
+
+export const stopPropagation = interceptMethod('stopPropagation', IEventPrototype);

--- a/packages/hyperion-dom/test/IEvent.test.ts
+++ b/packages/hyperion-dom/test/IEvent.test.ts
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved.
+ *
+ * @jest-environment jsdom
+ */
+
+import "jest";
+import * as IEvent from "../src/IEvent";
+import * as intercept from "@hyperion/hyperion-core/src/intercept";
+
+describe('test Event interception', () => {
+  test('test base Event', () => {
+    const stopPropagation = jest.fn();
+    IEvent.stopPropagation.onArgsObserverAdd(stopPropagation);
+
+    const eventIntercepted = jest.fn();
+    IEvent.IEventPrototype.onBeforInterceptObj.add(eventIntercepted);
+
+    const event = new Event('test');
+    expect(intercept.isIntercepted(event)).toBe(false);
+    expect(eventIntercepted).toBeCalledTimes(0);
+    intercept.intercept(event);
+    expect(intercept.isIntercepted(event)).toBe(true);
+    expect(eventIntercepted).toBeCalledTimes(1);
+
+    event.stopPropagation();
+    expect(stopPropagation).toBeCalledTimes(1);
+
+  });
+});

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -23,6 +23,7 @@ export default defineConfig({
         "@hyperion/hyperion-core/src/IGlobalThis",
       ],
       "hyperionDOM": [
+        "@hyperion/hyperion-dom/src/IEvent",
         "@hyperion/hyperion-dom/src/IEventTarget",
         "@hyperion/hyperion-dom/src/INode",
         "@hyperion/hyperion-dom/src/IElement_",

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ export * as IPromise from "@hyperion/hyperion-core/src/IPromise";
 export * as IGlobalThis from "@hyperion/hyperion-core/src/IGlobalThis";
 
 // hyperionDOM
+export * as IEvent from "@hyperion/hyperion-dom/src/IEvent";
 export * as IEventTarget from "@hyperion/hyperion-dom/src/IEventTarget";
 // export * as INode from "@hyperion/hyperion-dom/src/INode";
 export * as IElement from "@hyperion/hyperion-dom/src/IElement";


### PR DESCRIPTION
Ensuring that `al_ui_event` if fired in time so we can handle it before page unloads. 