### PR TITLE
Add ref props to surface

### DIFF
--- a/packages/hyperion-autologging/src/ALIReactFlowlet.ts
+++ b/packages/hyperion-autologging/src/ALIReactFlowlet.ts
@@ -12,7 +12,7 @@ import * as IReactComponent from "@hyperion/hyperion-react/src/IReactComponent";
 import { ALFlowlet, ALFlowletManager } from "./ALFlowletManager";
 import { ALSurfaceContext, useALSurfaceContext } from "./ALSurfaceContext";
 
-export type InitOptions = Types.Options<
+export type InitOptions<> = Types.Options<
   {
     react: IReactComponent.InitOptions & {
       ReactModule: {

--- a/packages/hyperion-autologging/src/ALIReactFlowlet.ts
+++ b/packages/hyperion-autologging/src/ALIReactFlowlet.ts
@@ -12,7 +12,7 @@ import * as IReactComponent from "@hyperion/hyperion-react/src/IReactComponent";
 import { ALFlowlet, ALFlowletManager } from "./ALFlowletManager";
 import { ALSurfaceContext, useALSurfaceContext } from "./ALSurfaceContext";
 
-export type InitOptions<> = Types.Options<
+export type InitOptions = Types.Options<
   {
     react: IReactComponent.InitOptions & {
       ReactModule: {
@@ -55,7 +55,7 @@ export function init(options: InitOptions) {
   });
 
   /**
- * The following interceptor methods (onArgsObserver/onValueObserver) run immediately 
+ * The following interceptor methods (onArgsObserver/onValueObserver) run immediately
  * before & after intercepted method. So, we can push before and pop after so that
  * the body of the method has access to flowlet.
  * For class components, we store the flowlet in the `this` object.
@@ -143,5 +143,3 @@ export function init(options: InitOptions) {
   );
 
 }
-
-

--- a/packages/hyperion-autologging/src/ALSurface.ts
+++ b/packages/hyperion-autologging/src/ALSurface.ts
@@ -315,7 +315,7 @@ export function init(options: InitOptions): ALSurfaceHOC {
           "span",
           {
             "data-surface-wrapper": "1",
-            style: { display: 'contents', backgroundColor: 'pink' },
+            style: { display: 'contents', },
           },
           props.children
         );
@@ -326,7 +326,7 @@ export function init(options: InitOptions): ALSurfaceHOC {
         "span",
         {
           "data-surface-wrapper": "1",
-          style: { display: 'contents', backgroundColor: 'pink' },
+          style: { display: 'contents', },
           [domAttributeName]: domAttributeValue,
         },
         props.children

--- a/packages/hyperion-autologging/src/ALSurface.ts
+++ b/packages/hyperion-autologging/src/ALSurface.ts
@@ -32,7 +32,7 @@ export enum ALSurfaceCapability {
   TrackInteraction = 1 << 0, // Mark all interaction events with this surface
   TrackMutation = 1 << 1, // report mount/unmount of this surface
   // TrackVisibility = 1 << 2, // track when mounted surface's visibility changes
-  // TrackBoundingRect = 1 << 3, // Report the size of the bounding rect of the surface on the screen.  
+  // TrackBoundingRect = 1 << 3, // Report the size of the bounding rect of the surface on the screen.
 }
 
 const AllSurfaceCapabilityValues = [
@@ -51,7 +51,8 @@ function surfaceCapabilityToString(capability?: ALSurfaceCapability): string {
 export type ALSurfaceProps = Readonly<{
   surface: string;
   metadata?: ALMetadataEvent['metadata'];
-  capability?: ALSurfaceCapability, // a one-hot encoding what the surface can do. 
+  capability?: ALSurfaceCapability, // a one-hot encoding what the surface can do.
+  nodeRef?: React.MutableRefObject<HTMLElement | null | undefined>,
 }>;
 
 export type ALSurfaceRenderer = (node: React.ReactNode) => React.ReactElement;
@@ -236,7 +237,7 @@ export function init(options: InitOptions): ALSurfaceHOC {
     if (!proxiedContext) {
       const surface = flowlet.name;
       nonInteractiveSurfacePath = (parentNonInteractiveSurface ?? '') + SURFACE_SEPARATOR + surface;
-      const trackInteraction = props.capability == null || (props.capability & ALSurfaceCapability.TrackInteraction); // empty .capability field is default, means all enabled! 
+      const trackInteraction = props.capability == null || (props.capability & ALSurfaceCapability.TrackInteraction); // empty .capability field is default, means all enabled!
       if (!trackInteraction) {
         surfacePath = parentSurface ?? SURFACE_SEPARATOR;
         domAttributeName = domNonInteractiveSurfaceAttributeName;
@@ -280,6 +281,21 @@ export function init(options: InitOptions): ALSurfaceHOC {
           channel.emit('al_surface_unmount', event);
         }
       }, [domAttributeName, domAttributeValue]);
+    }
+
+    ReactModule.useLayoutEffect(() => {
+      nodeRef && console.log('danika in useEffect', {nodeRef, current: nodeRef.current})
+      nodeRef && nodeRef.current?.setAttribute(domAttributeName, domAttributeValue);
+      console.log('danika in useEffect after', {nodeRef, x: nodeRef?.current?.getAttributeNames()});
+      // ref.current is only not null after subsequent render. This is because ref.current will only get initialized when the <div/> has mounted. I think the Surface wrapper mounts first.
+      });
+
+      const {nodeRef} = props;
+    nodeRef && console.log('danika', {nodeRef, current: nodeRef.current})
+    if(nodeRef?.current != null){
+      // we never hit here
+      nodeRef.current?.setAttribute(domAttributeName, domAttributeValue);
+      console.log('danika after', {nodeRef, x: nodeRef.current.getAttributeNames()});
     }
 
     flowlet.data.surface = surfacePath;

--- a/packages/hyperion-autologging/src/ALSurface.ts
+++ b/packages/hyperion-autologging/src/ALSurface.ts
@@ -284,19 +284,14 @@ export function init(options: InitOptions): ALSurfaceHOC {
     }
 
     ReactModule.useLayoutEffect(() => {
-      nodeRef && console.log('danika in useEffect', {nodeRef, current: nodeRef.current})
-      nodeRef && nodeRef.current?.setAttribute(domAttributeName, domAttributeValue);
-      console.log('danika in useEffect after', {nodeRef, x: nodeRef?.current?.getAttributeNames()});
-      // ref.current is only not null after subsequent render. This is because ref.current will only get initialized when the <div/> has mounted. I think the Surface wrapper mounts first.
-      });
+      const nodeRefCurrent = props.nodeRef?.current;
 
-      const {nodeRef} = props;
-    nodeRef && console.log('danika', {nodeRef, current: nodeRef.current})
-    if(nodeRef?.current != null){
-      // we never hit here
-      nodeRef.current?.setAttribute(domAttributeName, domAttributeValue);
-      console.log('danika after', {nodeRef, x: nodeRef.current.getAttributeNames()});
-    }
+      if (nodeRefCurrent == null) {
+        return;
+      }
+      nodeRefCurrent.setAttribute(domAttributeName, domAttributeValue);
+    }, [props.nodeRef]);
+
 
     flowlet.data.surface = surfacePath;
     let children = props.children;
@@ -304,7 +299,7 @@ export function init(options: InitOptions): ALSurfaceHOC {
     if (!options.disableReactDomPropsExtension) {
       const foundDomElement = propagateFlowletDown(props.children, surfaceData);
 
-      if (foundDomElement !== true) {
+      if (foundDomElement !== true && props.nodeRef == null) {
         /**
          * We could not find a dom node to safely add the attribute to it.
          *
@@ -320,18 +315,18 @@ export function init(options: InitOptions): ALSurfaceHOC {
           "span",
           {
             "data-surface-wrapper": "1",
-            style: { display: 'contents' }
+            style: { display: 'contents', backgroundColor: 'pink' },
           },
           props.children
         );
         propagateFlowletDown(children, surfaceData);
       }
-    } else {
+    } else if (props.nodeRef == null) {
       children = ReactModule.createElement(
         "span",
         {
           "data-surface-wrapper": "1",
-          style: { display: 'contents' },
+          style: { display: 'contents', backgroundColor: 'pink' },
           [domAttributeName]: domAttributeValue,
         },
         props.children

--- a/packages/hyperion-autologging/src/ALSurface.ts
+++ b/packages/hyperion-autologging/src/ALSurface.ts
@@ -313,7 +313,7 @@ export function init(options: InitOptions): ALSurfaceHOC {
             "span",
             {
               "data-surface-wrapper": "1",
-              style: { display: 'contents', },
+              style: { display: 'contents'},
             },
             props.children
           );
@@ -324,7 +324,7 @@ export function init(options: InitOptions): ALSurfaceHOC {
           "span",
           {
             "data-surface-wrapper": "1",
-            style: { display: 'contents', },
+            style: { display: 'contents'},
             [domAttributeName]: domAttributeValue,
           },
           props.children

--- a/packages/hyperion-react-testapp/src/AutoLoggingWrapper.ts
+++ b/packages/hyperion-react-testapp/src/AutoLoggingWrapper.ts
@@ -87,7 +87,7 @@ export function init() {
       IJsxRuntimeModule,
     },
     surface: {
-      channel,
+      channel
     },
     elementText: {
       updateText(elementText: ExtendedElementText, domSource) {

--- a/packages/hyperion-react-testapp/src/AutoLoggingWrapper.ts
+++ b/packages/hyperion-react-testapp/src/AutoLoggingWrapper.ts
@@ -88,7 +88,6 @@ export function init() {
     },
     surface: {
       channel,
-      disableReactDomPropsExtension: true // repro what's happening in ads manager. This is always true unless user pass am_al_react_extend_dom_props
     },
     elementText: {
       updateText(elementText: ExtendedElementText, domSource) {

--- a/packages/hyperion-react-testapp/src/AutoLoggingWrapper.ts
+++ b/packages/hyperion-react-testapp/src/AutoLoggingWrapper.ts
@@ -87,7 +87,8 @@ export function init() {
       IJsxRuntimeModule,
     },
     surface: {
-      channel
+      channel,
+      disableReactDomPropsExtension: true // repro what's happening in ads manager. This is always true unless user pass am_al_react_extend_dom_props
     },
     elementText: {
       updateText(elementText: ExtendedElementText, domSource) {

--- a/packages/hyperion-react-testapp/src/component/NonInteractiveSurfaceComponent.tsx
+++ b/packages/hyperion-react-testapp/src/component/NonInteractiveSurfaceComponent.tsx
@@ -17,7 +17,7 @@ export default function (_props: {}): React.ReactElement {
     <SurfaceComp surface='S1'>
       <div>S1</div>
       <SurfaceComp surface='R1' capability={ALSurfaceCapability.TrackMutation} nodeRef={EMPTY_REF}>
-        <div>R1</div>
+        <div>R1 (will not be tracked)</div>
         <SurfaceComp surface='S2'>
           <div>/S1/S2</div>
           <SurfaceComp surface='R2' capability={ALSurfaceCapability.TrackMutation} nodeRef={refR2}>

--- a/packages/hyperion-react-testapp/src/component/NonInteractiveSurfaceComponent.tsx
+++ b/packages/hyperion-react-testapp/src/component/NonInteractiveSurfaceComponent.tsx
@@ -4,12 +4,13 @@
 
 import { ALSurfaceCapability } from "@hyperion/hyperion-autologging/src/ALSurface";
 import * as React from 'react';
-import { useState } from 'react';
+import { useState, useRef } from 'react';
 import { SurfaceComp } from './Surface';
 
 export default function (_props: {}): React.ReactElement {
   console.log('Root render');
   const [count, setCount] = useState(0);
+  const refR2 = useRef(null)
   return (
     <SurfaceComp surface='S1'>
       <div>S1</div>
@@ -17,8 +18,8 @@ export default function (_props: {}): React.ReactElement {
         <div>R1</div>
         <SurfaceComp surface='S2'>
           <div>/S1/S2</div>
-          <SurfaceComp surface='R2' capability={ALSurfaceCapability.TrackMutation}>
-            <div>/S1/R1/S2/R2</div>
+          <SurfaceComp surface='R2' capability={ALSurfaceCapability.TrackMutation} nodeRef={refR2}>
+            <div ref={refR2}>/S1/R1/S2/R2</div>
           </SurfaceComp>
         </SurfaceComp>
       </SurfaceComp>

--- a/packages/hyperion-react-testapp/src/component/NonInteractiveSurfaceComponent.tsx
+++ b/packages/hyperion-react-testapp/src/component/NonInteractiveSurfaceComponent.tsx
@@ -11,10 +11,12 @@ export default function (_props: {}): React.ReactElement {
   console.log('Root render');
   const [count, setCount] = useState(0);
   const refR2 = useRef(null)
+  const EMPTY_REF = {current: null};
+
   return (
     <SurfaceComp surface='S1'>
       <div>S1</div>
-      <SurfaceComp surface='R1' capability={ALSurfaceCapability.TrackMutation}>
+      <SurfaceComp surface='R1' capability={ALSurfaceCapability.TrackMutation} nodeRef={EMPTY_REF}>
         <div>R1</div>
         <SurfaceComp surface='S2'>
           <div>/S1/S2</div>


### PR DESCRIPTION
Adding an optional nodeRef prop to hyperion surface so we can track mutations with that ref instead of wrapping it with an additional span. This is because wrapping it with an additional span can obstruct/interfere with browser visibility logic. 

## Tests
<img width="1748" alt="Screenshot 2023-10-10 at 8 46 13 AM" src="https://github.com/facebook/hyperion/assets/32248809/6c5c9784-b1c8-4c97-af36-2ec9bc9f3aa5">

Build and run all tests pass: https://www.internalfb.com/phabricator/paste/view/P850540839
