### PR TITLE
Fix type unsafe property access

### DIFF
--- a/packages/hyperion-flowlet/src/TriggerFlowlet.ts
+++ b/packages/hyperion-flowlet/src/TriggerFlowlet.ts
@@ -26,5 +26,5 @@ export function setTriggerFlowlet(obj: TriggerFlowletPayload, triggerFlowlet: Tr
 }
 
 export function getTriggerFlowlet(obj: TriggerFlowletPayload): TriggerFlowlet | null | undefined {
-  return obj.__ext_triggerFlowlet;
+  return obj?.__ext_triggerFlowlet;
 }


### PR DESCRIPTION
There are some cases on intern that are running into a null trigger flowlet payload object. Putting this up as a patch fix for now, while continuing to investigate why this is happening.