### PR TITLE
Reuse portal container for adding attributes.

### DIFF
--- a/packages/hyperion-autologging/src/ALSurface.ts
+++ b/packages/hyperion-autologging/src/ALSurface.ts
@@ -51,7 +51,7 @@ export type ALSurfaceProps = Readonly<{
   surface: string;
   metadata?: ALMetadataEvent['metadata'];
   capability?: ALSurfaceCapability, // a one-hot encoding what the surface can do.
-  nodeRef?: React.MutableRefObject<HTMLElement | null | undefined>,
+  nodeRef?: React.MutableRefObject<Element | null | undefined>,
 }>;
 
 export type ALSurfaceRenderer = (node: React.ReactNode) => React.ReactElement;
@@ -249,6 +249,7 @@ export function init(options: InitOptions): ALSurfaceHOC {
       nonInteractiveSurfacePath = proxiedContext.nonInteractiveSurface;
       domAttributeName = domSurfaceAttributeName
       domAttributeValue = surfacePath;
+      props.nodeRef?.current?.setAttribute(domAttributeName, domAttributeValue);
     }
 
     const surfaceData: SurfaceData = {
@@ -270,7 +271,7 @@ export function init(options: InitOptions): ALSurfaceHOC {
       ReactModule.useLayoutEffect(() => {
         const nodeRef = props.nodeRef;
         const nodeRefCurrent = nodeRef?.current;
-        if(nodeRef != null && nodeRefCurrent == null){
+        if (nodeRef != null && nodeRefCurrent == null) {
           return;
         }
         nodeRefCurrent != null && nodeRefCurrent.setAttribute(domAttributeName, domAttributeValue);
@@ -299,7 +300,7 @@ export function init(options: InitOptions): ALSurfaceHOC {
 
     flowlet.data.surface = surfacePath;
     let children = props.children;
-    if (props.nodeRef == null){
+    if (props.nodeRef == null) {
       if (!options.disableReactDomPropsExtension) {
         const foundDomElement = propagateFlowletDown(props.children, surfaceData);
 
@@ -319,18 +320,18 @@ export function init(options: InitOptions): ALSurfaceHOC {
             "span",
             {
               "data-surface-wrapper": "1",
-              style: { display: 'contents'},
+              style: { display: 'contents' },
             },
             props.children
           );
           propagateFlowletDown(children, surfaceData);
         }
-      } else{
+      } else {
         children = ReactModule.createElement(
           "span",
           {
             "data-surface-wrapper": "1",
-            style: { display: 'contents'},
+            style: { display: 'contents' },
             [domAttributeName]: domAttributeValue,
           },
           props.children

--- a/packages/hyperion-autologging/src/ALSurfaceProxy.ts
+++ b/packages/hyperion-autologging/src/ALSurfaceProxy.ts
@@ -37,8 +37,8 @@ type ProxyInitOptions =
  * If we can find a way around this limitation, we can use a simpler logic
  * like the following:
  */
-function SurfaceProxy(props: React.PropsWithChildren<ProxyInitOptions>): React.ReactElement {
-  const { surfaceComponent, children } = props;
+function SurfaceProxy(props: React.PropsWithChildren<ProxyInitOptions & { container: Element | DocumentFragment }>): React.ReactNode {
+  const { surfaceComponent, children, container } = props;
   const { ReactModule, } = props.react;
   const surfaceContext = useALSurfaceContext();
   const { flowlet } = surfaceContext;
@@ -49,11 +49,13 @@ function SurfaceProxy(props: React.PropsWithChildren<ProxyInitOptions>): React.R
         __ext: new SurfacePropsExtension(flowlet),
         flowlet,
         proxiedContext: surfaceContext,
+        nodeRef: { current: container instanceof Element && container.childElementCount === 0 ? container : null }
       },
       children
     );
   } else {
-    return ReactModule.createElement(ReactModule.Fragment, {}, children);
+    // return ReactModule.createElement(ReactModule.Fragment, {}, children);
+    return children;
   }
 }
 
@@ -67,10 +69,10 @@ export function init(options: ProxyInitOptions): void {
    * with the same flowlet and surface from the original surface context.
    */
   IReactDOMModule.createPortal.onArgsMapperAdd(args => {
-    const [node, _container] = args;
+    const [node, container] = args;
 
     if (node != null) {
-      args[0] = ReactModule.createElement(SurfaceProxy, options, node);
+      args[0] = ReactModule.createElement(SurfaceProxy, { ...options, container }, node);
     }
     return args;
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ export { PipeableEmitter, Channel } from "@hyperion/hook/src/Channel";
 
 // hyperionCore
 export { setAssertLoggerOptions } from "@hyperion/global/src/assert";
-export { intercept, getVirtualPropertyValue, setVirtualPropertyValue, getOwnShadowPrototypeOf } from "@hyperion/hyperion-core/src/intercept";
+export { intercept, getVirtualPropertyValue, setVirtualPropertyValue, getOwnShadowPrototypeOf, registerShadowPrototype } from "@hyperion/hyperion-core/src/intercept";
 export { interceptFunction } from "@hyperion/hyperion-core/src/FunctionInterceptor";
 export { interceptMethod } from "@hyperion/hyperion-core/src/MethodInterceptor";
 export { interceptConstructor, interceptConstructorMethod } from "@hyperion/hyperion-core/src/ConstructorInterceptor";


### PR DESCRIPTION
In order to minimize the possibility of messing up the styles in the application, this change will try to reuse the portal container if it is an empty element.
That fixes a bug we see some internal app.