### PR TITLE
Fix proxy container usage for Surface during strict mode

### DIFF
--- a/packages/hyperion-autologging/src/ALSurfaceProxy.ts
+++ b/packages/hyperion-autologging/src/ALSurfaceProxy.ts
@@ -48,8 +48,7 @@ function SurfaceProxy(props: React.PropsWithChildren<ProxyInitOptions & { contai
       {
         __ext: new SurfacePropsExtension(flowlet),
         flowlet,
-        proxiedContext: surfaceContext,
-        nodeRef: { current: container instanceof Element && container.childElementCount === 0 ? container : null }
+        proxiedContext: { ...surfaceContext, container },
       },
       children
     );

--- a/packages/hyperion-autologging/src/ALTriggerFlowlet.ts
+++ b/packages/hyperion-autologging/src/ALTriggerFlowlet.ts
@@ -168,7 +168,7 @@ export function init(options: InitOptions) {
 
 
   /**
-  * The following interceptor methods (onArgsObserver/onValueObserver) run immediately 
+  * The following interceptor methods (onArgsObserver/onValueObserver) run immediately
   * before & after intercepted method. So, we can push before and pop after so that
   * the body of the method has access to flowlet.
   * For class components, we store the flowlet in the `this` object.


### PR DESCRIPTION
React in strict mode (dev time), renders components twice. That means portal containers my be empty the first round, and have some content the second round. We had a conditional usage of such container for Surface wrappers that would fail the second time.

This change allows us to check if the container is empty or has the same attribute as before, and hence avoid adding the Surface wrapper.