### PR TITLE
Fix arrow function component visitors during interception

### DIFF
--- a/packages/hyperion-react-testapp/src/AutoLoggingWrapper.ts
+++ b/packages/hyperion-react-testapp/src/AutoLoggingWrapper.ts
@@ -48,6 +48,7 @@ export function init() {
     isExtended?: boolean;
   }
 
+  const enableReactFlowlet = true;
   AutoLogging.init({
     flowletManager,
     domSurfaceAttributeName,
@@ -56,7 +57,7 @@ export function init() {
       channel
     },
     triggerFlowlet: {
-      disableReactFlowlet: true,
+      disableReactFlowlet: !enableReactFlowlet,
       channel,
     },
     react: {
@@ -64,6 +65,9 @@ export function init() {
       IReactDOMModule,
       IReactModule,
       IJsxRuntimeModule,
+      enableInterceptClassComponentMethods: true,
+      enableInterceptClassComponentConstructor: enableReactFlowlet,
+      enableInterceptFunctionComponentRender: enableReactFlowlet,
     },
     surface: {
       channel

--- a/packages/hyperion-react/src/IReactComponent.ts
+++ b/packages/hyperion-react/src/IReactComponent.ts
@@ -226,30 +226,28 @@ export function init(options: InitOptions): void {
              *  https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/prototype#:~:text=prototype%20property%2C%20by%20default
            */
 
-          // $FlowIgnore[prop-missing]
           const classComponentParentClass = component.prototype;
+          let classComponentParentClassParent;
 
           if (
-            classComponentParentClass instanceof ReactModule.Component ||
-            typeof classComponentParentClass?.render === 'function' || // possibly created via React.createClass
-            Object.getPrototypeOf(Object.getPrototypeOf(classComponentParentClass)) || // not a plain function, may be with some other lifecycle methods. 
-            classComponentParentClass === ReactModule.Component.prototype // in case buggy code didn't properly inherit from ReactModule.Component
+            classComponentParentClass && (
+              classComponentParentClass instanceof ReactModule.Component ||
+              typeof classComponentParentClass.render === 'function' || // possibly created via React.createClass
+              (
+                (classComponentParentClassParent = Object.getPrototypeOf(classComponentParentClass)) &&
+                Object.getPrototypeOf(classComponentParentClassParent)
+              ) || // not a plain function, may be with some other lifecycle methods. 
+              classComponentParentClass === ReactModule.Component.prototype // in case buggy code didn't properly inherit from ReactModule.Component
+            )
           ) {
-            // $FlowIgnore[incompatible-exact]
-            // $FlowIgnore[incompatible-type]
-            // $FlowIgnore[incompatible-type-arg]
             // @ts-ignore
             const classComponent: Class<TReactClassComponent> = component;
             interceptedComponent = processReactClassComponent(
               classComponent,
-              // $FlowIgnore[incompatible-exact]
-              // $FlowIgnore[incompatible-call]
               classComponentParentClass,
             );
             onReactClassComponentElement.call(classComponent, props);
           } else {
-            // $FlowIgnore[incompatible-use]
-            // $FlowIgnore[prop-missing]
             // @ts-ignore
             const functionalComponent: TReactFunctionComponent = component;
             interceptedComponent =


### PR DESCRIPTION
Function components that are created via arraow (=>) functions won't have `.prototype` value. The code already had a bug that was checking this value before trying to get its prototype! This would throw at runtime but someone react was always hiding this error!