### PR TITLE
Added a simple 'mark' api to FlowletManager

### DIFF
--- a/packages/hyperion-flowlet/test/FlowletManager.test.ts
+++ b/packages/hyperion-flowlet/test/FlowletManager.test.ts
@@ -190,4 +190,21 @@ describe("test FlowletManager", () => {
     expect(manager.stackSize()).toBe(0);
   });
 
+  test("mark function", () => {
+    const manager = new FlowletManager(Flowlet);
+
+    const main = manager.push(new Flowlet("main"));
+
+    const bar = () => {
+      expect(manager.top()?.getFullName()).toBe('/main/foo');
+    };
+
+    const foo = () => {
+      bar();
+    }
+
+    const markedFoo = manager.mark(foo, 'foo');
+
+    markedFoo();
+  });
 });


### PR DESCRIPTION
Sometimes, we want to make sure when a function is called, it 'forks' the top flow and marks its execution for the rest of the stack. In these case, we should not use the FlowletManager.wrap since it "preserves" the existing flowlet for a callback.
The `FlowletManager.mark` function will return a new function that automatically adds the markings.