### PR TITLE
Handle long chaning of flowlets

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -4,6 +4,15 @@
 		{
 			"type": "npm",
 			"script": "build",
+			"path": "./",
+			"group": "build",
+			"problemMatcher": [],
+			"label": "npm: build all",
+			"detail": "tsc"
+		},
+		{
+			"type": "npm",
+			"script": "build",
 			"path": "packages/hyperion-core/",
 			"group": "build",
 			"problemMatcher": [],

--- a/packages/hyperion-flowlet/src/FlowletManager.ts
+++ b/packages/hyperion-flowlet/src/FlowletManager.ts
@@ -195,11 +195,11 @@ export class FlowletManager<T extends Flowlet = Flowlet> {
   /**
    * In case we wanted a function to push/pop a flowlet name on the stack, we can
    * use this helper function to create a wrapper that marks the desired flowlet
-   * @param listener 
-   * @param apiName 
-   * @param customFlowlet 
-   * @param getTriggerFlowlet 
-   * @returns 
+   * @param listener
+   * @param apiName
+   * @param customFlowlet
+   * @param getTriggerFlowlet
+   * @returns
    */
   mark<F extends InterceptableFunction | undefined | null>(
     func: F,

--- a/packages/hyperion-flowlet/test/Flowlet.test.ts
+++ b/packages/hyperion-flowlet/test/Flowlet.test.ts
@@ -8,6 +8,7 @@ import { Flowlet } from "../src/Flowlet";
 describe("test Flowlet", () => {
   test("test Flowlet methods", () => {
     const f1 = new Flowlet<{
+      triggerFlowlet: any,
       i?: number;
     }>("f1");
 
@@ -21,6 +22,17 @@ describe("test Flowlet", () => {
     f2.data.i = 20;
     expect(f2.data.i).toBe(20);
 
+  });
+
+  test("long flowlet chain", () => {
+    let flowlet = new Flowlet<{}>('f1');
+    for (let i = 0; i < 100000; ++i) {
+      flowlet = flowlet.fork('f');
+    }
+
+    const name = flowlet.getFullName();
+    expect(name.length).toBeGreaterThan(1000);
+    expect(name).toMatch(/[.][.][.](?:[/]f)+/);
   });
 
 });


### PR DESCRIPTION
In some cases, we might have a very long chain of flowlets (e.g. recursive setTimeout calls).

When we calculate the fullName of such cases, we might run into stack overflow.

This commit changes the algorithm to limit the length of the chain that we walk.