### PR TITLE
When wrapping a Portal'd SVG element, wrap in `<g>` not `<span>`

### DIFF
--- a/packages/hyperion-autologging/src/ALSurface.ts
+++ b/packages/hyperion-autologging/src/ALSurface.ts
@@ -327,6 +327,9 @@ export function init(options: InitOptions): ALSurfaceHOC {
 
     // flowlet.data.surface = surfacePath;
     let children = props.children;
+
+    const wrapperElementType = proxiedContext?.container instanceof SVGElement ? "g" : "span";
+
     if (addSurfaceWrapper) {
       if (!options.disableReactDomPropsExtension) {
         const foundDomElement = propagateFlowletDown(props.children, surfaceData);
@@ -344,7 +347,7 @@ export function init(options: InitOptions): ALSurfaceHOC {
            *
            */
           children = ReactModule.createElement(
-            "span",
+            wrapperElementType,
             {
               "data-surface-wrapper": "1",
               style: { display: 'contents' },
@@ -355,7 +358,7 @@ export function init(options: InitOptions): ALSurfaceHOC {
         }
       } else {
         children = ReactModule.createElement(
-          "span",
+          wrapperElementType,
           {
             "data-surface-wrapper": "1",
             style: { display: 'contents' },


### PR DESCRIPTION
When using autologger and a React portal, the element ends up getting wrapped with a `<span>`. If this is an SVG element, however, this will break the SVG as a `<span>` is not a valid element in the SVG namespace. 

This PR detects if the element that is being wrapped is an SVG element and changes the wrapping element to a `<g>` 