### PR TITLE
Add support for dynamic flowlet naming in `FlowletManager.mark`

### DIFF
--- a/packages/hyperion-flowlet/src/FlowletManager.ts
+++ b/packages/hyperion-flowlet/src/FlowletManager.ts
@@ -199,14 +199,12 @@ export class FlowletManager<T extends Flowlet = Flowlet> {
    * In case we wanted a function to push/pop a flowlet name on the stack, we can
    * use this helper function to create a wrapper that marks the desired flowlet
    * @param listener
-   * @param apiName
-   * @param customFlowlet
-   * @param getTriggerFlowlet
+   * @param getFlowletName
    * @returns
    */
   mark<F extends InterceptableFunction | undefined | null>(
     func: F,
-    flowletName: string,
+    getFlowletName: (...args: any) => string,
   ): F {
     if (!func) {
       return func;
@@ -220,6 +218,7 @@ export class FlowletManager<T extends Flowlet = Flowlet> {
       // Should we use onArgsAndValueMapper instead of setCustom, although this is safer with the finally call.
       funcInterceptor.setCustom(<any>function (this: any) {
         const handler: Function = funcInterceptor.getOriginal();
+        const flowletName = getFlowletName.apply(this, <any>arguments);
         const flowlet = new flowletManager.flowletCtor(flowletName, flowletManager.top());
         let res;
         try {

--- a/packages/hyperion-flowlet/test/FlowletManager.test.ts
+++ b/packages/hyperion-flowlet/test/FlowletManager.test.ts
@@ -201,10 +201,34 @@ describe("test FlowletManager", () => {
 
     const foo = () => {
       bar();
-    }
+    };
 
-    const markedFoo = manager.mark(foo, 'foo');
+    const markedFoo = manager.mark(foo, () => 'foo');
 
     markedFoo();
+  });
+
+  test("mark function with dynamic flowlet name", () => {
+    const manager = new FlowletManager(Flowlet);
+    const main = manager.push(new Flowlet("main"));
+
+    const bar = (param) => {
+      if (param === 'foo') {
+        expect(manager.top()?.getFullName()).toBe(`/main/foo`);
+      } else if (param === 'foobar') {
+        expect(manager.top()?.getFullName()).toBe(`/main/foobar`);
+      } else {
+        expect(false).toBeTruthy();
+      }
+    };
+    const foo = (param) => {
+      bar(param);
+    };
+
+    const getFlowletName = (param) => param;
+    const markedFoo = manager.mark(foo, getFlowletName);
+
+    markedFoo('foo');
+    markedFoo('foobar');
   });
 });

--- a/packages/hyperion-flowlet/test/FlowletManager.test.ts
+++ b/packages/hyperion-flowlet/test/FlowletManager.test.ts
@@ -212,20 +212,20 @@ describe("test FlowletManager", () => {
     const manager = new FlowletManager(Flowlet);
     const main = manager.push(new Flowlet("main"));
 
-    const bar = (param) => {
+    const bar = param => {
       if (param === 'foo') {
-        expect(manager.top()?.getFullName()).toBe(`/main/foo`);
+        expect(manager.top()?.getFullName()).toBe('/main/foo');
       } else if (param === 'foobar') {
-        expect(manager.top()?.getFullName()).toBe(`/main/foobar`);
+        expect(manager.top()?.getFullName()).toBe('/main/foobar');
       } else {
         expect(false).toBeTruthy();
       }
     };
-    const foo = (param) => {
+    const foo = param => {
       bar(param);
     };
 
-    const getFlowletName = (param) => param;
+    const getFlowletName = param => param;
     const markedFoo = manager.mark(foo, getFlowletName);
 
     markedFoo('foo');


### PR DESCRIPTION
Sometimes it's useful to name the flowlets created using `FlowletManager.mark` dynamically.