### PR TITLE
Rename flowlets to always include ID in the name.

### DIFF
--- a/packages/hyperion-autologging/src/ALNetworkPublisher.ts
+++ b/packages/hyperion-autologging/src/ALNetworkPublisher.ts
@@ -182,7 +182,7 @@ function captureFetch(options: InitOptions): void {
     }
 
     const parentTriggerFlowlet = flowletManager.top()?.data.triggerFlowlet;
-    const triggerFlowlet = new flowletManager.flowletCtor(`fetch(method:${request.method}&url:${request.uri.pathname})`, parentTriggerFlowlet);
+    const triggerFlowlet = new flowletManager.flowletCtor(`fetch(method=${request.method}&url=${request.uri.pathname})`, parentTriggerFlowlet);
 
     return value => {
       setTriggerFlowlet(value, triggerFlowlet); // This will be picked by the wrappers of Promis.* callbacks.
@@ -266,7 +266,7 @@ function captureXHR(options: InitOptions): void {
     );
 
     const parentTriggerFlowlet = flowletManager.top()?.data.triggerFlowlet;
-    const triggerFlowlet = new flowletManager.flowletCtor(`xhr(method:${method}&url:${request.uri.pathname})`, parentTriggerFlowlet);
+    const triggerFlowlet = new flowletManager.flowletCtor(`xhr(method=${method}&url=${request.uri.pathname})`, parentTriggerFlowlet);
     setTriggerFlowlet(this, triggerFlowlet);
   });
 

--- a/packages/hyperion-autologging/src/ALNetworkPublisher.ts
+++ b/packages/hyperion-autologging/src/ALNetworkPublisher.ts
@@ -182,7 +182,7 @@ function captureFetch(options: InitOptions): void {
     }
 
     const parentTriggerFlowlet = flowletManager.top()?.data.triggerFlowlet;
-    const triggerFlowlet = new flowletManager.flowletCtor(`fetch(method:${request.method},url:${request.uri.pathname})`, parentTriggerFlowlet);
+    const triggerFlowlet = new flowletManager.flowletCtor(`fetch(method:${request.method}&url:${request.uri.pathname})`, parentTriggerFlowlet);
 
     return value => {
       setTriggerFlowlet(value, triggerFlowlet); // This will be picked by the wrappers of Promis.* callbacks.
@@ -266,7 +266,7 @@ function captureXHR(options: InitOptions): void {
     );
 
     const parentTriggerFlowlet = flowletManager.top()?.data.triggerFlowlet;
-    const triggerFlowlet = new flowletManager.flowletCtor(`xhr(method:${method},url:${request.uri.pathname})`, parentTriggerFlowlet);
+    const triggerFlowlet = new flowletManager.flowletCtor(`xhr(method:${method}&url:${request.uri.pathname})`, parentTriggerFlowlet);
     setTriggerFlowlet(this, triggerFlowlet);
   });
 

--- a/packages/hyperion-autologging/src/ALTriggerFlowlet.ts
+++ b/packages/hyperion-autologging/src/ALTriggerFlowlet.ts
@@ -134,7 +134,7 @@ export function init(options: InitOptions) {
           if (!getTriggerFlowlet(event)) {
             const parentTriggerFlowlet = ALUIEventGroupPublishers.getGroupRootFlowlet(event);
             const triggerFlowlet = new flowletManager.flowletCtor(
-              `${eventType}(ts:${performanceAbsoluteNow()})`,
+              `${eventType}(ts=${performanceAbsoluteNow()})`,
               parentTriggerFlowlet
             );
             setTriggerFlowlet(event, triggerFlowlet);

--- a/packages/hyperion-autologging/src/ALUIEventGroupPublisher.ts
+++ b/packages/hyperion-autologging/src/ALUIEventGroupPublisher.ts
@@ -4,7 +4,6 @@
 
 'use strict';
 import * as Types from "@hyperion/hyperion-util/src/Types";
-import performanceAbsoluteNow from "@hyperion/hyperion-util/src/performanceAbsoluteNow";
 import { IALFlowlet } from "./ALFlowletManager";
 import { ALSharedInitOptions } from "./ALType";
 import TestAndSet from "@hyperion/hyperion-util/src/TestAndSet";
@@ -93,7 +92,7 @@ export function getGroupRootFlowlet(event: Event): IALFlowlet | null | undefined
      * we use a common parent for all ui events to avoid tracking each ui event's
      * flowlet individually.
      */
-    const groupFlowlet = new _options.flowletManager.flowletCtor(`${type}(ts:${performanceAbsoluteNow()})`, _options.flowletManager.root);
+    const groupFlowlet = new _options.flowletManager.flowletCtor(type, _options.flowletManager.root);
     groupRootFlowlet = {
       groupFlowlet,
       type,

--- a/packages/hyperion-autologging/src/ALUIEventPublisher.ts
+++ b/packages/hyperion-autologging/src/ALUIEventPublisher.ts
@@ -169,7 +169,6 @@ export function publish(options: InitOptions): void {
   const { uiEvents, flowletManager, channel, domSurfaceAttributeName } = options;
 
   let lastUIEvent: CurrentUIEvent | null;
-  const defaultTopFlowlet = new flowletManager.flowletCtor("/");
 
   uiEvents.forEach((eventConfig => {
     const { eventName, cacheElementReactInfo = false } = eventConfig;
@@ -186,26 +185,26 @@ export function publish(options: InitOptions): void {
       if (!uiEventData) {
         return;
       }
-      const { element, targetElement, autoLoggingID, eventTimestamp } = uiEventData;
+      const { element, targetElement, autoLoggingID } = uiEventData;
 
       const surface = getSurfacePath(targetElement, domSurfaceAttributeName);
       /**
        * Regardless of element, we want to set the flowlet on this event.
        * If we do have an element, we include its id in the flowlet.
        * Since it is possible to interact with the same exact element multiple times,
-       * we need yet another distinguishing fact, for which we use timestamp
+       * we need yet another distinguishing fact, for which we rely on flowlet id to be part of the name
        */
-      const topFlowlet = flowletManager.top();
-      let flowlet = topFlowlet ?? defaultTopFlowlet; // We want to ensure flowlet is always assigned
-      let flowletName = eventName + `(ts:${eventTimestamp}`;
-      if (autoLoggingID) {
-        flowletName += `,element:${autoLoggingID}`;
-      }
+      let flowletName = eventName + `(`;
+      let separator = '';
       if (surface) {
-        flowletName += `,surface:${surface}`;
+        flowletName += `${separator}surface=${surface}`;
+        separator = '&';
+      }
+      if (autoLoggingID) {
+        flowletName += `${separator}element=${autoLoggingID}`;
       }
       flowletName += ')';
-      flowlet = new flowletManager.flowletCtor(flowletName, ALUIEventGroupPublisher.getGroupRootFlowlet(event));
+      let flowlet = new flowletManager.flowletCtor(flowletName, ALUIEventGroupPublisher.getGroupRootFlowlet(event));
       if (shouldPushPopFlowlet(event)) {
         uiEventFlowletManager.push(flowlet);
         flowlet = flowletManager.push(flowlet);

--- a/packages/hyperion-autologging/test/ALFlowletPublisher.test.ts
+++ b/packages/hyperion-autologging/test/ALFlowletPublisher.test.ts
@@ -8,6 +8,7 @@
 import { Channel } from "@hyperion/hook/src/Channel";
 import { ALFlowletManager } from "../src/ALFlowletManager";
 import * as ALFlowletPublisher from "../src/ALFlowletPublisher";
+import { getFullNamePattern } from "@hyperion/hyperion-flowlet/test/FlowletTestUtil";
 
 describe('ALFlowletPublisher', () => {
 
@@ -24,8 +25,8 @@ describe('ALFlowletPublisher', () => {
     const f3 = flowletManager.push(f2, "f3");
 
     expect(fn).toBeCalledTimes(3);
-    expect(fn.mock.calls[0][0].flowlet.getFullName()).toBe("/f1");
-    expect(fn.mock.calls[1][0].flowlet.getFullName()).toBe("/f1/f2");
-    expect(fn.mock.calls[2][0].flowlet.getFullName()).toBe("/f1/f2/f3");
+    expect(fn.mock.calls[0][0].flowlet.getFullName()).toMatch(getFullNamePattern("/f1"));
+    expect(fn.mock.calls[1][0].flowlet.getFullName()).toMatch(getFullNamePattern("/f1/f2"));
+    expect(fn.mock.calls[2][0].flowlet.getFullName()).toMatch(getFullNamePattern("/f1/f2/f3"));
   });
 });

--- a/packages/hyperion-flowlet/src/Flowlet.ts
+++ b/packages/hyperion-flowlet/src/Flowlet.ts
@@ -28,7 +28,7 @@ export class Flowlet<T extends FlowletDataType = FlowletDataType> {
     onFlowletInit.call<T>(this);
   }
 
-  getFullName(includeId:boolean = false): string {
+  getFullName(): string {
     if (!this._fullName) {
       // The following is easiest approach, but does not work for very long chains!
       // this._fullName = `${this.parent?.getFullName() ?? ""}/${this.name}`;
@@ -46,10 +46,7 @@ export class Flowlet<T extends FlowletDataType = FlowletDataType> {
       let prefix: string = f ? (f._fullName ?? '...') : '';
       for (let j = rawFlowlets.length-1; j>=0; --j){
         let flowlet = rawFlowlets[j];
-        flowlet._fullName = prefix = prefix + "/" + flowlet.name;
-        if (includeId){
-          flowlet._fullName += ":" + flowlet.id;
-        }
+        flowlet._fullName = prefix = prefix + "/" + flowlet.name + ":" + flowlet.id;
       }
     }
     if (__DEV__){

--- a/packages/hyperion-flowlet/src/FlowletManager.ts
+++ b/packages/hyperion-flowlet/src/FlowletManager.ts
@@ -31,7 +31,7 @@ export class FlowletManager<T extends Flowlet = Flowlet> {
 
   public readonly root: T;
   constructor(public flowletCtor: new (flowletName: string, parent?: T | null) => T) {
-    this.root = new flowletCtor("");
+    this.root = new flowletCtor("/");
 
     if (__DEV__) {
       this.onPush.add(flowlet => {

--- a/packages/hyperion-flowlet/src/FlowletWrappers.ts
+++ b/packages/hyperion-flowlet/src/FlowletWrappers.ts
@@ -159,7 +159,7 @@ export function initFlowletTrackers(flowletManager: FlowletManager) {
   }
 
   IEventTarget.addEventListener.onArgsMapperAdd(args => {
-    args[1] = flowletManager.wrap(args[1], `${IEventTarget.addEventListener.name}:${args[0]}`, void 0, getTriggerFlowletFromEvent);
+    args[1] = flowletManager.wrap(args[1], `${IEventTarget.addEventListener.name}(${args[0]})`, void 0, getTriggerFlowletFromEvent);
     return args;
   });
   IEventTarget.removeEventListener.onArgsMapperAdd(args => {
@@ -218,7 +218,7 @@ export function initFlowletTrackers(flowletManager: FlowletManager) {
         }
 
         if (triggerFlowlets.length > 0) {
-          const flowletName = `Promise.${fi.name}(${triggerFlowlets.map(f => f.id).join(",")})`;
+          const flowletName = `Promise.${fi.name}(${triggerFlowlets.map(f => f.id).join("&")})`;
           const triggerFlowlet = new flowletManager.flowletCtor(flowletName, topTriggerFlowlet);
           setTriggerFlowlet(value, triggerFlowlet);
         } else if (topTriggerFlowlet) {

--- a/packages/hyperion-flowlet/test/Flowlet.test.ts
+++ b/packages/hyperion-flowlet/test/Flowlet.test.ts
@@ -4,8 +4,15 @@
 
 import "jest";
 import { Flowlet } from "../src/Flowlet";
+import { getFullNamePattern } from "./FlowletTestUtil";
 
 describe("test Flowlet", () => {
+  test("include id in the flowlet name", () => {
+    let flowlet = new Flowlet<{}>('f1');
+    expect(flowlet.getFullName()).toMatch(/f1:\d+/);
+    expect(flowlet.getFullName()).toMatch(getFullNamePattern("/f1"));
+  });
+
   test("test Flowlet methods", () => {
     const f1 = new Flowlet<{
       triggerFlowlet: any,
@@ -15,8 +22,8 @@ describe("test Flowlet", () => {
     const f2 = f1.fork("f2");
 
     expect(f2.parent).toStrictEqual(f1);
-    expect(f1.getFullName()).toBe("/f1");
-    expect(f2.getFullName()).toBe("/f1/f2");
+    expect(f1.getFullName()).toMatch(getFullNamePattern("/f1"));
+    expect(f2.getFullName()).toMatch(getFullNamePattern("/f1/f2"));
     f1.data.i = 10;
     expect(f2.data.i).toBe(10);
     f2.data.i = 20;
@@ -35,8 +42,4 @@ describe("test Flowlet", () => {
     expect(name).toMatch(/[.][.][.](?:[/]f)+/);
   });
 
-  test("include id in the flowlet name", () => {
-    let flowlet = new Flowlet<{}>('f1');
-    expect(flowlet.getFullName(true)).toMatch(/f1:\d+/);
-  });
 });

--- a/packages/hyperion-flowlet/test/FlowletManager.test.ts
+++ b/packages/hyperion-flowlet/test/FlowletManager.test.ts
@@ -6,6 +6,7 @@ import "jest";
 import { Flowlet } from "../src/Flowlet";
 
 import { FlowletManager } from "../src/FlowletManager";
+import { getFullNamePattern } from "./FlowletTestUtil";
 
 describe("test FlowletManager", () => {
   jest.useFakeTimers();
@@ -25,7 +26,7 @@ describe("test FlowletManager", () => {
     const p1 = manager.pop(f2);
     const f1_1 = manager.push(f1.fork("f1.1"));
 
-    expect(f1_1.getFullName()).toBe("/main/f1/f1.1");
+    expect(f1_1.getFullName()).toMatch(getFullNamePattern("/main/f1/f1.1"));
 
     expect(manager.top()).toStrictEqual(f1_1);
     expect(manager.pop(f1_1)).toStrictEqual(f1_1);
@@ -89,12 +90,12 @@ describe("test FlowletManager", () => {
 
     const f1 = manager.push(new Flowlet("f1"));
     batchRunner.schedule(() => {
-      expect(manager.top()?.parent).toStrictEqual(f1);
+      expect(manager.top().parent).toStrictEqual(f1);
     });
 
     const f2 = manager.push(f1.fork("f2"));
     batchRunner.schedule(() => {
-      expect(manager.top()?.parent).toStrictEqual(f2);
+      expect(manager.top().parent).toStrictEqual(f2);
     });
 
     manager.pop(f2);
@@ -123,7 +124,7 @@ describe("test FlowletManager", () => {
     const f1 = manager.push(new Flowlet("f1"));
     const ExceptionText = "Test Exception";
     const func = () => {
-      expect(manager.top() === f1 || manager.top()?.parent === f1).toBe(true);
+      expect(manager.top() === f1 || manager.top().parent === f1).toBe(true);
       throw ExceptionText;
     }
     const wrapped = manager.wrap(func, 'test error');
@@ -196,7 +197,7 @@ describe("test FlowletManager", () => {
     const main = manager.push(new Flowlet("main"));
 
     const bar = () => {
-      expect(manager.top()?.getFullName()).toBe('/main/foo');
+      expect(manager.top().getFullName()).toMatch(getFullNamePattern('/main/foo'));
     };
 
     const foo = () => {
@@ -214,9 +215,9 @@ describe("test FlowletManager", () => {
 
     const bar = param => {
       if (param === 'foo') {
-        expect(manager.top()?.getFullName()).toBe('/main/foo');
+        expect(manager.top().getFullName()).toMatch(getFullNamePattern('/main/foo'));
       } else if (param === 'foobar') {
-        expect(manager.top()?.getFullName()).toBe('/main/foobar');
+        expect(manager.top().getFullName()).toMatch(getFullNamePattern('/main/foobar'));
       } else {
         expect(false).toBeTruthy();
       }

--- a/packages/hyperion-flowlet/test/FlowletTestUtil.ts
+++ b/packages/hyperion-flowlet/test/FlowletTestUtil.ts
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved.
+ */
+
+import "jest";
+
+export function getFullNamePattern(simpleName: string): RegExp {
+  const parts = simpleName.split('/');
+  if (parts[0] == '') {
+    /**
+     * We expect names in the form of '/f1/f2/f3', i.e. each flowletname
+     * preceded by a /.
+     * So, dropping the first empty item to have the following work well.
+     */
+    parts.shift();
+  }
+  const pattern = parts.map(p => `[/]${p}:\\d+`).join('');
+  return new RegExp(pattern);
+}

--- a/packages/hyperion-flowlet/test/FlowletWrapper.test.ts
+++ b/packages/hyperion-flowlet/test/FlowletWrapper.test.ts
@@ -138,10 +138,10 @@ describe("test flow of flowlets", () => {
     expect(getTriggerFlowlet(p1)).toBe(tf);
 
     const all = Promise.all([p0, p1]);
-    expect(getTriggerFlowlet(all)?.getFullName()).toMatch(/Promise.all\(\d+,\d+\)/);
+    expect(getTriggerFlowlet(all)?.getFullName()).toMatch(/Promise.all\(\d+&\d+\)/);
 
     const race = Promise.race([p0, p1]);
-    expect(getTriggerFlowlet(race)?.getFullName()).toMatch(/Promise.race\(\d+,\d+\)/);
+    expect(getTriggerFlowlet(race)?.getFullName()).toMatch(/Promise.race\(\d+&\d+\)/);
 
     let p2;
     try { // Need try/catch to handle reject
@@ -151,6 +151,6 @@ describe("test flow of flowlets", () => {
       expect(getTriggerFlowlet(p2)).toBe(tf);
     }
     const allSettled = Promise.allSettled([p0, p1, p2]);
-    expect(getTriggerFlowlet(allSettled)?.getFullName()).toMatch(/Promise.allSettled\(\d+,\d+,\d+\)/);
+    expect(getTriggerFlowlet(allSettled)?.getFullName()).toMatch(/Promise.allSettled\(\d+&\d+&\d+\)/);
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ export { PipeableEmitter, Channel } from "@hyperion/hook/src/Channel";
 // hyperionCore
 export { setAssertLoggerOptions } from "@hyperion/global/src/assert";
 export { intercept, getVirtualPropertyValue, setVirtualPropertyValue, getOwnShadowPrototypeOf, registerShadowPrototype } from "@hyperion/hyperion-core/src/intercept";
-export { interceptFunction } from "@hyperion/hyperion-core/src/FunctionInterceptor";
+export { interceptFunction, getFunctionInterceptor } from "@hyperion/hyperion-core/src/FunctionInterceptor";
 export { interceptMethod } from "@hyperion/hyperion-core/src/MethodInterceptor";
 export { interceptConstructor, interceptConstructorMethod } from "@hyperion/hyperion-core/src/ConstructorInterceptor";
 export * as IRequire from "@hyperion/hyperion-core/src/IRequire";


### PR DESCRIPTION
In many cases, we do need to distinguish between instances of the flowlets. So, now the inclusion of id in the name is by default enabled.

We can now remove timestamp from the flowlet names and end up with shorter names.

Also, replaced use of `,` in the names with `&`, and explicitly renamed the root flowlet to `/`. This way, the flowlet will look like a URI and is easier to copy/paste in other tools.

Consumers of the flowlet can also add a `schema` before the name before logging to embed the meaning the name, e.g.
`trigger://:1/mounse:2/click:3/`.