### PR TITLE
Fix UI event flowlets being set incorrectly

### DIFF
--- a/packages/hyperion-autologging/src/ALUIEventPublisher.ts
+++ b/packages/hyperion-autologging/src/ALUIEventPublisher.ts
@@ -318,7 +318,7 @@ export function publish(options: InitOptions): void {
    */
   flowletManager.onPush.add((flowlet, _reason) => {
     const uiEventFlowlet = uiEventFlowletManager.top();
-    if (uiEventFlowlet && flowlet.data.uiEventFlowlet !== uiEventFlowlet) {
+    if (uiEventFlowletManager.stackSize() > 0 && flowlet.data.uiEventFlowlet !== uiEventFlowlet) {
       flowlet.data.uiEventFlowlet = uiEventFlowlet;
       if (flowlet.name === "useState" && flowlet.parent) {
         /**


### PR DESCRIPTION
https://github.com/facebook/hyperion/commit/57922df49982500a0101ba7ae99a52427f0e0bce added a root flowlet in the `FlowletManager` class, which changed the `top()` implemention to always return a non-null flowlet.

The original logic for setting UI event flowlets first checked if `uiEventFlowletManager.top()` is null, which is now always false, so UI event flowlets were getting set when they should not have been. This resulted in `flowlet.data.uiEventFlowlet` getting set as the root UI event flowlet.

This PR changes the logic to check if `uiEventFlowletManager` is empty before setting UI event flowlets, to make sure that we are not setting `flowlet.data.uiEventFlowlet` as the root UI event flowlet anywhere.