### PR TITLE
Make sure pageload flowlet has a root

### DIFF
--- a/packages/hyperion-autologging/src/ALSurface.ts
+++ b/packages/hyperion-autologging/src/ALSurface.ts
@@ -52,7 +52,7 @@ export type ALSurfaceProps = Readonly<{
   surface: string;
   metadata?: ALMetadataEvent['metadata'];
   capability?: ALSurfaceCapability, // a one-hot encoding what the surface can do.
-  nodeRef?: React.MutableRefObject<Element | null | undefined>,
+  nodeRef?: React.RefObject<Element | null | undefined>,
 }>;
 
 export type ALSurfaceRenderer = (node: React.ReactNode) => React.ReactElement;

--- a/packages/hyperion-autologging/src/ALTriggerFlowlet.ts
+++ b/packages/hyperion-autologging/src/ALTriggerFlowlet.ts
@@ -52,7 +52,7 @@ export function init(options: InitOptions) {
 
   const { channel, flowletManager } = options;
 
-  let currTriggerFlowlet = new flowletManager.flowletCtor('pageload');
+  let currTriggerFlowlet = new flowletManager.flowletCtor('pageload', flowletManager.root);
   currTriggerFlowlet.data.triggerFlowlet = currTriggerFlowlet;
 
   const activeRootFlowlets = new class {

--- a/packages/hyperion-autologging/src/ALUIEventGroupPublisher.ts
+++ b/packages/hyperion-autologging/src/ALUIEventGroupPublisher.ts
@@ -107,7 +107,7 @@ export function getGroupRootFlowlet(event: Event): IALFlowlet | null | undefined
     GroupFlowlets.set(targetElement, groupRootFlowlet);
     return groupFlowlet;
   }
-  return null;
+  return _options?.flowletManager.root;
 }
 
 let initialized = new TestAndSet();


### PR DESCRIPTION
An assersion was firing a lot because the `pageload` trigger flowlet did not have root. Others do.

This fixes the issue.