### PR TITLE
Simplify DOM surface attribute name options

### DIFF
--- a/packages/hyperion-autologging-visualizer/src/index.ts
+++ b/packages/hyperion-autologging-visualizer/src/index.ts
@@ -9,7 +9,7 @@ import { Channel } from "@hyperion/hook/src/Channel";
 import * as ElementTextTooltip from "./component/ElementTextTooltip.react";
 
 export type InitOptions = Types.Options<
-  Pick<AutoLogging.InitOptions, 'flowletManager' | 'domSurfaceAttributeName'> &
+  Pick<AutoLogging.InitOptions, 'flowletManager'> &
   {
     channel: Channel<AutoLogging.ALChannelEvent>
   }

--- a/packages/hyperion-autologging/src/ALSurface.ts
+++ b/packages/hyperion-autologging/src/ALSurface.ts
@@ -100,7 +100,6 @@ export type InitOptions = Types.Options<
       IJsxRuntimeModule: IReact.IJsxRuntimeModuleExports;
     };
     domFlowletAttributeName?: string;
-    domNonInteractiveSurfaceAttributeName?: string;
     channel: ALChannel;
     enableReactDomPropsExtension?: boolean;
   }
@@ -131,7 +130,7 @@ function setupDomElementSurfaceAttribute(options: InitOptions): void {
   // We should make sure the following enabled for our particular usage in this function.
   IReactComponent.init(options.react);
 
-  const { flowletManager, domSurfaceAttributeName = AUTO_LOGGING_SURFACE, domFlowletAttributeName, domNonInteractiveSurfaceAttributeName = AUTO_LOGGING_NON_INTERACTIVE_SURFACE } = options;
+  const { flowletManager, domFlowletAttributeName } = options;
   /**
   * if flowlets are disabled, but we still want to extend the props, we use
   * the following placeholder flowlet to let the rest of the logic work.
@@ -159,8 +158,8 @@ function setupDomElementSurfaceAttribute(options: InitOptions): void {
      * its own tree. The null surface attributes will be filtered later.
      */
     if (allowedTags.has(component)) {
-      props[domSurfaceAttributeName] = new SurfaceDOMString(flowlet);
-      props[domNonInteractiveSurfaceAttributeName] = new SurfaceDOMString(flowlet);
+      props[AUTO_LOGGING_SURFACE] = new SurfaceDOMString(flowlet);
+      props[AUTO_LOGGING_NON_INTERACTIVE_SURFACE] = new SurfaceDOMString(flowlet);
 
       if (__DEV__) {
         if (domFlowletAttributeName) {
@@ -193,8 +192,8 @@ function setupDomElementSurfaceAttribute(options: InitOptions): void {
     attrValue: any,
   ) {
     switch (attrName) {
-      case domSurfaceAttributeName:
-      case domNonInteractiveSurfaceAttributeName:
+      case AUTO_LOGGING_SURFACE:
+      case AUTO_LOGGING_NON_INTERACTIVE_SURFACE:
         if (
           attrValue === '' ||
           attrValue === 'null' ||
@@ -214,7 +213,7 @@ function setupDomElementSurfaceAttribute(options: InitOptions): void {
         if (
           this.nodeName === 'SPAN' && (
             this.hasAttribute(SURFACE_WRAPPER_ATTRIBUTE_NAME) ||
-            this.hasAttribute(domSurfaceAttributeName)
+            this.hasAttribute(AUTO_LOGGING_SURFACE)
           )
         ) {
           return true;
@@ -227,7 +226,7 @@ function setupDomElementSurfaceAttribute(options: InitOptions): void {
 
 
 export function init(options: InitOptions): ALSurfaceHOC {
-  const { flowletManager, domSurfaceAttributeName = AUTO_LOGGING_SURFACE, domNonInteractiveSurfaceAttributeName = AUTO_LOGGING_NON_INTERACTIVE_SURFACE } = options;
+  const { flowletManager} = options;
   const { ReactModule } = options.react;
 
   setupDomElementSurfaceAttribute(options);
@@ -261,17 +260,17 @@ export function init(options: InitOptions): ALSurfaceHOC {
       const trackInteraction = props.capability == null || (props.capability & ALSurfaceCapability.TrackInteraction); // empty .capability field is default, means all enabled!
       if (!trackInteraction) {
         surfacePath = parentSurface ?? SURFACE_SEPARATOR;
-        domAttributeName = domNonInteractiveSurfaceAttributeName;
+        domAttributeName = AUTO_LOGGING_NON_INTERACTIVE_SURFACE;
         domAttributeValue = nonInteractiveSurfacePath;
       } else {
         surfacePath = (parentSurface ?? '') + SURFACE_SEPARATOR + surface;
-        domAttributeName = domSurfaceAttributeName;
+        domAttributeName = AUTO_LOGGING_SURFACE;
         domAttributeValue = surfacePath;
       }
     } else {
       surfacePath = proxiedContext.surface;
       nonInteractiveSurfacePath = proxiedContext.nonInteractiveSurface;
-      domAttributeName = domSurfaceAttributeName
+      domAttributeName = AUTO_LOGGING_SURFACE
       domAttributeValue = surfacePath;
       if (proxiedContext.container instanceof Element) {
         const container = proxiedContext.container;

--- a/packages/hyperion-autologging/src/ALSurfaceUtils.ts
+++ b/packages/hyperion-autologging/src/ALSurfaceUtils.ts
@@ -4,11 +4,20 @@
 
 'use strict';
 
-export function getSurfacePath(node: HTMLElement | null, domSurfaceAttributeName: string): string| null {
-  const domSurfaceSelector = `[${domSurfaceAttributeName}]`;
-  return getAncestralSurfaceNode(node, domSurfaceSelector)?.getAttribute(domSurfaceAttributeName) ?? null;
+import { AUTO_LOGGING_SURFACE } from "./ALSurfaceConsts";
+
+export function getSurfacePath(node: HTMLElement | null): string| null {
+  return getAncestralSurfaceNode(node)?.getAttribute(AUTO_LOGGING_SURFACE) ?? null;
 }
 
-export function getAncestralSurfaceNode(node: Element | null, domSurfaceSelector: string): Element| null {
-  return node?.closest(domSurfaceSelector) ?? null;
+export function getAncestralSurfaceNode(node: Element | null): Element| null {
+  return node?.closest(`[${AUTO_LOGGING_SURFACE}]`) ?? null;
+}
+
+export function getElementSurface(node: Element | null): string| null {
+  return node?.getAttribute(AUTO_LOGGING_SURFACE) ?? null;
+}
+
+export function getElementsWithSurfaces(): NodeListOf<Element> {
+  return document.querySelectorAll(`[${AUTO_LOGGING_SURFACE}]`);
 }

--- a/packages/hyperion-autologging/src/ALType.ts
+++ b/packages/hyperion-autologging/src/ALType.ts
@@ -50,5 +50,4 @@ export type ALReactElementEvent = Readonly<{
 
 export type ALSharedInitOptions = Types.Options<{
   flowletManager: ALFlowletManager;
-  domSurfaceAttributeName: string;
 }>;

--- a/packages/hyperion-autologging/src/ALUIEventPublisher.ts
+++ b/packages/hyperion-autologging/src/ALUIEventPublisher.ts
@@ -19,6 +19,7 @@ import { ReactComponentData } from "./ALReactUtils";
 import { getSurfacePath } from "./ALSurfaceUtils";
 import { ALFlowletEvent, ALMetadataEvent, ALReactElementEvent, ALSharedInitOptions, ALTimedEvent } from "./ALType";
 import * as ALUIEventGroupPublisher from "./ALUIEventGroupPublisher";
+import { AUTO_LOGGING_SURFACE } from "./ALSurfaceConsts";
 
 /**
  * Generates a union type of all handler event and domEvent permutations.
@@ -166,7 +167,7 @@ function getCommonEventData<T extends keyof DocumentEventMap>(eventConfig: UIEve
  * and filtering of events is configured via {@link UIEventConfig}.
  */
 export function publish(options: InitOptions): void {
-  const { uiEvents, flowletManager, channel, domSurfaceAttributeName } = options;
+  const { uiEvents, flowletManager, channel } = options;
 
   let lastUIEvent: CurrentUIEvent | null;
 
@@ -187,7 +188,7 @@ export function publish(options: InitOptions): void {
       }
       const { element, targetElement, autoLoggingID } = uiEventData;
 
-      const surface = getSurfacePath(targetElement, domSurfaceAttributeName);
+      const surface = getSurfacePath(targetElement, AUTO_LOGGING_SURFACE);
       /**
        * Regardless of element, we want to set the flowlet on this event.
        * If we do have an element, we include its id in the flowlet.

--- a/packages/hyperion-autologging/src/ALUIEventPublisher.ts
+++ b/packages/hyperion-autologging/src/ALUIEventPublisher.ts
@@ -19,7 +19,6 @@ import { ReactComponentData } from "./ALReactUtils";
 import { getSurfacePath } from "./ALSurfaceUtils";
 import { ALFlowletEvent, ALMetadataEvent, ALReactElementEvent, ALSharedInitOptions, ALTimedEvent } from "./ALType";
 import * as ALUIEventGroupPublisher from "./ALUIEventGroupPublisher";
-import { AUTO_LOGGING_SURFACE } from "./ALSurfaceConsts";
 
 /**
  * Generates a union type of all handler event and domEvent permutations.
@@ -188,7 +187,7 @@ export function publish(options: InitOptions): void {
       }
       const { element, targetElement, autoLoggingID } = uiEventData;
 
-      const surface = getSurfacePath(targetElement, AUTO_LOGGING_SURFACE);
+      const surface = getSurfacePath(targetElement);
       /**
        * Regardless of element, we want to set the flowlet on this event.
        * If we do have an element, we include its id in the flowlet.

--- a/packages/hyperion-autologging/src/AutoLogging.ts
+++ b/packages/hyperion-autologging/src/AutoLogging.ts
@@ -78,7 +78,6 @@ export function init(options: InitOptions): boolean {
 
   const sharedOptions: ALSharedInitOptions = {
     flowletManager: options.flowletManager,
-    domSurfaceAttributeName: options.domSurfaceAttributeName,
   }
 
   if (typeof global !== 'undefined' && (global as Window)?.document?.createElement != null) {


### PR DESCRIPTION
Proposing to simplify setting the DOM surface attribute name by removing the ability to pass these fields through options, i.e. to use the `ALSurfaceConsts` values from Hyperion and not allow overwriting from WWW. One reason for this is to simplify initialization of AL code and make it easier to test specific pieces in WWW environments (e.g. D53191534).