### PR TITLE
Expose ALElementInfo static method for resolving react component on d…

### DIFF
--- a/packages/hyperion-autologging/src/ALElementInfo.ts
+++ b/packages/hyperion-autologging/src/ALElementInfo.ts
@@ -11,6 +11,7 @@ import * as IElement from "@hyperion/hyperion-dom/src/IElement";
 
 const AL_ELEMENT_INFO_PROPNAME = '__alInfo';
 const AUTO_LOGGING_COMPONENT_TYPE = 'data-auto-logging-component-type';
+export type BailTraversalFunc = (foundReactComponent: boolean, depth: number) => boolean;
 
 export default class ALElementInfo {
   element: Element;
@@ -44,6 +45,10 @@ export default class ALElementInfo {
 
   static getOrCreate(element: Element): ALElementInfo {
     return ALElementInfo.get(element) ?? new ALElementInfo(element);
+  }
+
+  static getReactComponentData(element: Element, bailTraversalFunc?: BailTraversalFunc): ReactComponentData | null {
+    return getReactComponentData_THIS_CAN_BREAK(element, bailTraversalFunc);
   }
 
   getReactComponentData(): ReactComponentData | null {

--- a/packages/hyperion-autologging/src/ALElementInfo.ts
+++ b/packages/hyperion-autologging/src/ALElementInfo.ts
@@ -48,7 +48,7 @@ export default class ALElementInfo {
   }
 
   static getReactComponentData(element: Element, bailTraversalFunc?: BailTraversalFunc): ReactComponentData | null {
-    return getReactComponentData_THIS_CAN_BREAK(element, bailTraversalFunc);
+    return ALElementInfo.get(element)?.getReactComponentData() ?? getReactComponentData_THIS_CAN_BREAK(element, bailTraversalFunc);
   }
 
   getReactComponentData(): ReactComponentData | null {

--- a/packages/hyperion-autologging/src/ALReactUtils.ts
+++ b/packages/hyperion-autologging/src/ALReactUtils.ts
@@ -9,6 +9,7 @@ import { BailTraversalFunc } from "./ALElementInfo";
 export type ReactComponentData = Readonly<{
   name: string | null,
   stack: Array<string>,
+  isTruncated: boolean,
 }>;
 
 export type ComponentNameValidator = (name: string) => boolean;
@@ -76,9 +77,11 @@ export function getReactComponentData_THIS_CAN_BREAK(
     const stack: Array<string> = [];
     let fiber = getReactInternalFiber(element);
     let depth = 0;
+    let isTruncated = false;
     while (fiber) {
       if (bailTraversal != null && bailTraversal(name != null, depth++)) {
         stack.push('...');
+        isTruncated = true;
         break;
       }
       const fiberType = fiber.type;
@@ -98,7 +101,7 @@ export function getReactComponentData_THIS_CAN_BREAK(
       }
       fiber = fiber.return;
     }
-    return stack.length > 0 ? { name, stack } : null;
+    return stack.length > 0 ? { name, stack, isTruncated } : null;
   } catch (err) {
     if (__DEV__) {
       throw err;

--- a/packages/hyperion-autologging/src/ALReactUtils.ts
+++ b/packages/hyperion-autologging/src/ALReactUtils.ts
@@ -4,6 +4,8 @@
 
 'use strict';
 
+import { BailTraversalFunc } from "./ALElementInfo";
+
 export type ReactComponentData = Readonly<{
   name: string | null,
   stack: Array<string>,
@@ -62,6 +64,7 @@ const getReactComponentName = (
 
 export function getReactComponentData_THIS_CAN_BREAK(
   node: Element | null,
+  bailTraversal?: BailTraversalFunc
 ): ReactComponentData | null {
   if (node == null) {
     return null;
@@ -72,7 +75,12 @@ export function getReactComponentData_THIS_CAN_BREAK(
     let name: string | null = null;
     const stack: Array<string> = [];
     let fiber = getReactInternalFiber(element);
+    let depth = 0;
     while (fiber) {
+      if (bailTraversal != null && bailTraversal(name != null, depth++)) {
+        stack.push('...');
+        break;
+      }
       const fiberType = fiber.type;
       if (fiberType == null || typeof fiberType === 'string') {
         fiber = fiber.return;


### PR DESCRIPTION
…emand, including optional ability to stop fiber walking


This is a slightly different route than https://github.com/facebook/hyperion/pull/154
But a quicker alternative than trying to deal with the ElementInfo cache problem described in our meeting and witnessed in https://github.com/facebook/hyperion/compare/main...schwartzmx:hyperion:bail-traversal with trying to make this configurable per event.