### PR TITLE
Update list of React symbols based on recent changes.

### DIFF
--- a/packages/hyperion-react/src/IReactConsts.ts
+++ b/packages/hyperion-react/src/IReactConsts.ts
@@ -38,6 +38,7 @@ export const REACT_FRAGMENT_TYPE: Sym = SymbolFor(0xeacb, 'react.fragment');
 export const REACT_STRICT_MODE_TYPE: Sym = SymbolFor(0xeacc, 'react.strict_mode');
 export const REACT_PROFILER_TYPE: Sym = SymbolFor(0xead2, 'react.profiler');
 export const REACT_PROVIDER_TYPE: Sym = SymbolFor(0xeacd, 'react.provider');
+export const REACT_CONSUMER_TYPE: Sym = SymbolFor(0xeace, 'react.consumer'); // same as context
 export const REACT_CONTEXT_TYPE: Sym = SymbolFor(0xeace, 'react.context');
 export const REACT_FORWARD_REF_TYPE: Sym = SymbolFor(0xead0, 'react.forward_ref');
 export const REACT_SUSPENSE_LIST_TYPE: Sym = SymbolFor(0xead8, 'react.suspense_list');

--- a/packages/hyperion-react/src/IReactElementVisitor.ts
+++ b/packages/hyperion-react/src/IReactElementVisitor.ts
@@ -174,6 +174,7 @@ function optimizeVisitors<
     [IReactConsts.REACT_FORWARD_REF_TYPE]: ctor('forwardRef'),
     [IReactConsts.REACT_MEMO_TYPE]: ctor('memo'),
     [IReactConsts.REACT_PROVIDER_TYPE]: ctor('provider'),
+    [IReactConsts.REACT_CONSUMER_TYPE]: ctor('context'), // this is same as 'context'
     [IReactConsts.REACT_CONTEXT_TYPE]: ctor('context'),
     [IReactConsts.REACT_FRAGMENT_TYPE]: ctor('fragment'),
     [IReactConsts.REACT_SUSPENSE_TYPE]: ctor(),
@@ -263,6 +264,7 @@ function getVisitor<
           case IReactConsts.REACT_PROVIDER_TYPE:
             visitor = visitors.provider;
             break;
+          case IReactConsts.REACT_CONSUMER_TYPE:
           case IReactConsts.REACT_CONTEXT_TYPE:
             visitor = visitors.context;
             break;


### PR DESCRIPTION
Recently React added one more symbol for handling Context.Consumer. That started to trigger one of the asserts in the code in the dev mode. This diff integrates that new changes.