### PR TITLE
Add API for allowing disabling/enabling of UIPublisher handlers by event

### DIFF
--- a/packages/hyperion-autologging/src/ALInteractableDOMElement.ts
+++ b/packages/hyperion-autologging/src/ALInteractableDOMElement.ts
@@ -7,7 +7,7 @@ import * as IEventTarget from "@hyperion/hyperion-dom/src/IEventTarget";
 import { ReactComponentObjectProps } from "@hyperion/hyperion-react/src/IReact";
 import * as IReactComponent from "@hyperion/hyperion-react/src/IReactComponent";
 import type * as Types from "@hyperion/hyperion-util/src/Types";
-import { UIEventConfig } from "./ALUIEventPublisher";
+import type { UIEventConfig } from "./ALUIEventPublisher";
 
 'use strict';
 
@@ -103,13 +103,13 @@ export function disableUIEventHandlers(eventName: UIEventConfig['eventName']): v
   }
 }
 
-export function enableUIEventHandlers(eventName: UIEventConfig['eventName'], eventHandlerConfig?: TrackEventHandlerConfig | undefined): void {
-  let handlerConfig = UIEventHandlers.get(eventName) ?? eventHandlerConfig;
+export function enableUIEventHandlers(eventName: UIEventConfig['eventName'], eventHandlerConfig?: Omit<TrackEventHandlerConfig, "active"> | undefined): void {
+  let handlerConfig = UIEventHandlers.get(eventName);
   // Incoming config
   if (eventHandlerConfig != null) {
     // Disable the existing handlers if present, before installing the new ones
     disableUIEventHandlers(eventName);
-    handlerConfig = eventHandlerConfig;
+    handlerConfig = { ...eventHandlerConfig, active: false };
   }
   if (handlerConfig?.active === false) {
     // Install interactable attribute handlers

--- a/packages/hyperion-autologging/src/ALUIEventPublisher.ts
+++ b/packages/hyperion-autologging/src/ALUIEventPublisher.ts
@@ -14,7 +14,7 @@ import performanceAbsoluteNow from "@hyperion/hyperion-util/src/performanceAbsol
 import ALElementInfo from './ALElementInfo';
 import { ALFlowletManager, IALFlowlet } from "./ALFlowletManager";
 import { ALID, getOrSetAutoLoggingID } from "./ALID";
-import { ALElementTextEvent, getElementTextEvent, getInteractable, isTrackedEvent, UIEventHandlers, enableUIEventHandlers } from "./ALInteractableDOMElement";
+import { ALElementTextEvent, getElementTextEvent, getInteractable, isTrackedEvent, enableUIEventHandlers, TrackEventHandlerConfig } from "./ALInteractableDOMElement";
 import { ReactComponentData } from "./ALReactUtils";
 import { getSurfacePath } from "./ALSurfaceUtils";
 import { ALFlowletEvent, ALMetadataEvent, ALReactElementEvent, ALSharedInitOptions, ALTimedEvent } from "./ALType";
@@ -102,6 +102,12 @@ type CommonEventData = (ALUIEvent & ALTimedEvent) & {
   // The event.target element,  as opposed to element which represents the interactableElement
   targetElement: HTMLElement | null,
 };
+
+// Entrypoint to set up tracking and enable handlers
+export function trackAndEnableUIEventHandlers(eventName: UIEventConfig['eventName'], eventHandlerConfig: Omit<TrackEventHandlerConfig, 'active'>): void {
+  const config = { active: false, ...eventHandlerConfig };
+  enableUIEventHandlers(eventName, config);
+}
 
 /**
  *
@@ -277,15 +283,11 @@ export function publish(options: InitOptions): void {
       }
     };
 
-    // Set our handlers to register
-    UIEventHandlers.set(eventName, {
+    // Enable the events handlers as well as interactable tracking
+    trackAndEnableUIEventHandlers(eventName, {
       captureHandler,
       bubbleHandler,
-      active: false,
     });
-
-    // Enable the events handlers as well as interactable tracking
-    enableUIEventHandlers(eventName);
   }));
 
   function updateLastUIEvent(eventData: ALUIEventCaptureData) {

--- a/packages/hyperion-autologging/src/ALUIEventPublisher.ts
+++ b/packages/hyperion-autologging/src/ALUIEventPublisher.ts
@@ -105,8 +105,7 @@ type CommonEventData = (ALUIEvent & ALTimedEvent) & {
 
 // Entrypoint to set up tracking and enable handlers
 export function trackAndEnableUIEventHandlers(eventName: UIEventConfig['eventName'], eventHandlerConfig: Omit<TrackEventHandlerConfig, 'active'>): void {
-  const config = { active: false, ...eventHandlerConfig };
-  enableUIEventHandlers(eventName, config);
+  enableUIEventHandlers(eventName, eventHandlerConfig);
 }
 
 /**

--- a/packages/hyperion-autologging/test/ALInteractableDOMElement.test.ts
+++ b/packages/hyperion-autologging/test/ALInteractableDOMElement.test.ts
@@ -258,7 +258,14 @@ describe("Text various element text options", () => {
       <div id="addEventListener"></div>
     `);
 
-    ALInteractableDOMElement.trackInteractable("click");
+    ALInteractableDOMElement.UIEventHandlers.set(
+      'click', {
+      captureHandler: () => { },
+      bubbleHandler: () => { },
+      active: false
+    }
+    );
+    ALInteractableDOMElement.enableUIEventHandlers('click');
 
     let node = document.getElementById("attribute");
     expect(node).not.toBeNull();
@@ -275,6 +282,22 @@ describe("Text various element text options", () => {
     if (node) {
       node.addEventListener("click", () => { });
       expect(node.getAttribute("data-clickable")).toBe("1");
+    }
+
+    ALInteractableDOMElement.UIEventHandlers.set(
+      'mouseover', {
+      captureHandler: () => { },
+      bubbleHandler: () => { },
+      active: false
+    }
+    );
+    ALInteractableDOMElement.enableUIEventHandlers('mouseover');
+
+    node = document.getElementById("addEventListener");
+    expect(node).not.toBeNull();
+    if (node) {
+      node.addEventListener("mouseover", () => { });
+      expect(node.getAttribute("data-mouseoverable")).toBe("1");
     }
   });
 });

--- a/packages/hyperion-autologging/test/ALInteractableDOMElement.test.ts
+++ b/packages/hyperion-autologging/test/ALInteractableDOMElement.test.ts
@@ -8,6 +8,7 @@ import "jest";
 
 import * as ALInteractableDOMElement from "../src/ALInteractableDOMElement";
 import * as DomFragment from "./DomFragment";
+import { UIEventConfig, trackAndEnableUIEventHandlers } from "../src/ALUIEventPublisher";
 
 function createTestDom(): DomFragment.DomFragment {
   return DomFragment.html(`
@@ -64,7 +65,7 @@ function getText(id: string): string | null {
 }
 
 describe("Test interactable detection algorithm", () => {
-  function interactable(node: HTMLElement | null, eventName: string, interactableOnly: boolean = true): HTMLElement | null {
+  function interactable(node: HTMLElement | null, eventName: UIEventConfig['eventName'], interactableOnly: boolean = true): HTMLElement | null {
     return ALInteractableDOMElement.getInteractable(node, eventName, interactableOnly);
   }
 
@@ -258,14 +259,10 @@ describe("Text various element text options", () => {
       <div id="addEventListener"></div>
     `);
 
-    ALInteractableDOMElement.UIEventHandlers.set(
-      'click', {
+    trackAndEnableUIEventHandlers('click', {
       captureHandler: () => { },
       bubbleHandler: () => { },
-      active: false
-    }
-    );
-    ALInteractableDOMElement.enableUIEventHandlers('click');
+    });
 
     let node = document.getElementById("attribute");
     expect(node).not.toBeNull();
@@ -284,14 +281,10 @@ describe("Text various element text options", () => {
       expect(node.getAttribute("data-clickable")).toBe("1");
     }
 
-    ALInteractableDOMElement.UIEventHandlers.set(
-      'mouseover', {
+    trackAndEnableUIEventHandlers('mouseover', {
       captureHandler: () => { },
       bubbleHandler: () => { },
-      active: false
-    }
-    );
-    ALInteractableDOMElement.enableUIEventHandlers('mouseover');
+    });
 
     node = document.getElementById("addEventListener");
     expect(node).not.toBeNull();

--- a/src/index.ts
+++ b/src/index.ts
@@ -62,4 +62,3 @@ export * as AutoLogging from "@hyperion/hyperion-autologging/src/AutoLogging";
 export { ALSurfaceCapability } from "@hyperion/hyperion-autologging/src/ALSurface";
 export * as ALSurfaceUtils from "@hyperion/hyperion-autologging/src/ALSurfaceUtils";
 export * as ALCustomEvent from '@hyperion/hyperion-autologging/src/ALCustomEvent';
-export { enableEventHandlers, disableEventHandlers } from "@hyperion/hyperion-autologging/src/ALUIEventPublisher";

--- a/src/index.ts
+++ b/src/index.ts
@@ -62,3 +62,4 @@ export * as AutoLogging from "@hyperion/hyperion-autologging/src/AutoLogging";
 export { ALSurfaceCapability } from "@hyperion/hyperion-autologging/src/ALSurface";
 export * as ALSurfaceUtils from "@hyperion/hyperion-autologging/src/ALSurfaceUtils";
 export * as ALCustomEvent from '@hyperion/hyperion-autologging/src/ALCustomEvent';
+export { enableEventHandlers, disableEventHandlers } from "@hyperion/hyperion-autologging/src/ALUIEventPublisher";


### PR DESCRIPTION
Use a map to maintain handlers as they are added,  and for reference when re-enabling the handlers.

The two exported functions are very similar,  I'm not opposed to combining them into a single call if there's any suggestions.

Tested that the APIs work as expected in www
https://pxl.cl/4vGxg