### PR TITLE
Add an option to collect default values under a surface

### DIFF
--- a/packages/hyperion-autologging/src/ALElementValuePublisher.ts
+++ b/packages/hyperion-autologging/src/ALElementValuePublisher.ts
@@ -57,7 +57,7 @@ export function publish(options: InitOptions): void {
     }
 
     const elementText = getElementTextEvent(element, surface);
-    const flowlet = options.flowletManager.top();
+    const callFlowlet = options.flowletManager.top();
 
     channel.emit('al_ui_event', {
       event: 'change',
@@ -67,8 +67,8 @@ export function publish(options: InitOptions): void {
       eventIndex: ALEventIndex.getNextEventIndex(),
       eventTimestamp: performanceAbsoluteNow(),
       autoLoggingID: ALID.getOrSetAutoLoggingID(element),
-      flowlet,
-      triggerFlowlet: flowlet.data.triggerFlowlet,
+      callFlowlet,
+      triggerFlowlet: callFlowlet.data.triggerFlowlet,
       ...elementText,
       reactComponentName: reactComponentData?.name,
       reactComponentStack: reactComponentData?.stack,

--- a/packages/hyperion-autologging/src/ALElementValuePublisher.ts
+++ b/packages/hyperion-autologging/src/ALElementValuePublisher.ts
@@ -6,15 +6,16 @@
 
 import type { Channel } from "@hyperion/hook/src/Channel";
 import * as Types from "@hyperion/hyperion-util/src/Types";
+import performanceAbsoluteNow from "@hyperion/hyperion-util/src/performanceAbsoluteNow";
+import ALElementInfo from "./ALElementInfo";
 import * as ALEventIndex from "./ALEventIndex";
 import * as ALID from './ALID';
 import { ALElementTextEvent, getElementTextEvent } from './ALInteractableDOMElement';
-import { ALChannelSurfaceMutationEvent } from "./ALSurfaceMutationPublisher";
+import { ReactComponentData } from "./ALReactUtils";
+import type { ALChannelSurfaceEvent } from "./ALSurface";
+import * as ALSurfaceMutationPublisher from "./ALSurfaceMutationPublisher";
 import { getAncestralSurfaceNode } from "./ALSurfaceUtils";
 import { ALElementEvent, ALFlowletEvent, ALLoggableEvent, ALMetadataEvent, ALReactElementEvent, ALSharedInitOptions } from "./ALType";
-import performanceAbsoluteNow from "@hyperion/hyperion-util/src/performanceAbsoluteNow";
-import { ReactComponentData } from "./ALReactUtils";
-import ALElementInfo from "./ALElementInfo";
 
 export type ALElementValueEventData = Readonly<
   ALLoggableEvent &
@@ -25,7 +26,7 @@ export type ALElementValueEventData = Readonly<
   ALElementEvent &
   {
     surface: string;
-    value: string | boolean;
+    value: string;
   }
 >;
 
@@ -34,7 +35,7 @@ export type ALChannelElementValueEvent = Readonly<{
 }
 >;
 
-export type ALElementValueChannel = Channel<ALChannelElementValueEvent & ALChannelSurfaceMutationEvent>;
+export type ALElementValueChannel = Channel<ALChannelElementValueEvent & ALChannelSurfaceEvent>;
 
 
 export type InitOptions = Types.Options<
@@ -48,13 +49,34 @@ export type InitOptions = Types.Options<
 export function publish(options: InitOptions): void {
   const { channel } = options;
 
-  channel.addListener('al_surface_mutation_event', surfaceEventData => {
-    const surfaceElement = surfaceEventData.element;
-    const surface = surfaceEventData.surface;
+  type PartialALEventValueEventData = Pick<ALElementValueEventData, "surface" | "element" | "value" | "metadata" | "relatedEventIndex">;
+  function emitEvent(elementValueEventData: PartialALEventValueEventData) {
+    const { element, surface } = elementValueEventData;
 
-    if (surfaceEventData.event !== 'mount_component' || !surface == null || !surfaceElement) {
-      return;
+    const elementText = getElementTextEvent(element, surface);
+
+    let reactComponentData: ReactComponentData | null = null;
+    if (options.cacheElementReactInfo) {
+      const elementInfo = ALElementInfo.getOrCreate(element);
+      reactComponentData = elementInfo.getReactComponentData();
     }
+
+    const flowlet = options.flowletManager.top();
+
+    channel.emit('al_element_value_event', {
+      ...elementValueEventData,
+      eventIndex: ALEventIndex.getNextEventIndex(),
+      eventTimestamp: performanceAbsoluteNow(),
+      autoLoggingID: ALID.getOrSetAutoLoggingID(element),
+      flowlet,
+      triggerFlowlet: flowlet.data.triggerFlowlet,
+      ...elementText,
+      reactComponentName: reactComponentData?.name,
+      reactComponentStack: reactComponentData?.stack,
+    });
+  }
+
+  function trackElementValues(surface: string, surfaceElement: Element) {
     // The following is expensive, so try to jam everything we are interested in to the selector
     const elements = surfaceElement.querySelectorAll<HTMLInputElement | HTMLSelectElement>('input[type=radio], input[type=checkbox], select');
 
@@ -63,69 +85,59 @@ export function publish(options: InitOptions): void {
       return;
     }
 
+    const relatedEventIndex = ALSurfaceMutationPublisher.getSurfaceMountInfo(surface)?.eventIndex;
+
     for (let i = 0; i < elements.length; ++i) {
       const element = elements[i];
       const parentSurfaceNode = getAncestralSurfaceNode(element);
       if (parentSurfaceNode === surfaceElement) {
         // We know value is part of this surface only
-        const elementText = getElementTextEvent(element, surface);
-        let elementValueEventData: Pick<ALElementValueEventData, "value" | "metadata"> | null = null;
 
         switch (element.nodeName) {
           case 'INPUT': {
             const input = element as HTMLInputElement;
             if (input.checked) {
-              elementValueEventData = {
-                value: input.checked,
+              emitEvent({
+                surface,
+                element,
+                relatedEventIndex,
+                value: 'true',
                 metadata: {
                   type: input.getAttribute('type') ?? '',
                 }
-              }
+              });
             }
             break;
           }
           case 'SELECT': {
             const select = element as HTMLSelectElement;
             if (select.selectedIndex > -1) {
-              elementValueEventData = {
+              emitEvent({
+                surface,
+                element,
+                relatedEventIndex,
                 value: select.value,
                 metadata: {
                   type: 'select',
                   text: select.options[select.selectedIndex].text
                 }
-              }
+              });
             }
             break;
           }
-
         }
-        if (elementValueEventData) {
-          let reactComponentData: ReactComponentData | null = null;
-          if (options.cacheElementReactInfo) {
-            const elementInfo = ALElementInfo.getOrCreate(element);
-            reactComponentData = elementInfo.getReactComponentData();
-          }
-
-          const flowlet = options.flowletManager.top();
-
-
-          channel.emit('al_element_value_event', {
-            eventIndex: ALEventIndex.getNextEventIndex(),
-            relatedEventIndex: surfaceEventData.eventIndex,
-            eventTimestamp: performanceAbsoluteNow(),
-            element,
-            autoLoggingID: ALID.getOrSetAutoLoggingID(element),
-            surface,
-            flowlet,
-            triggerFlowlet: flowlet.data.triggerFlowlet,
-            ...elementText,
-            ...elementValueEventData,
-            reactComponentName: reactComponentData?.name,
-            reactComponentStack: reactComponentData?.stack,
-          });
-        }
-
       }
     }
+  }
+
+  channel.addListener('al_surface_mount', surfaceEventData => {
+    const surfaceElement = surfaceEventData.element;
+    const surface = surfaceEventData.surface;
+
+    if (!surface == null || !surfaceElement) {
+      return;
+    }
+
+    trackElementValues(surface, surfaceElement);
   });
 }

--- a/packages/hyperion-autologging/src/ALElementValuePublisher.ts
+++ b/packages/hyperion-autologging/src/ALElementValuePublisher.ts
@@ -79,14 +79,34 @@ export function publish(options: InitOptions): void {
     });
   }
 
+  const QueryString = (function () {
+    /**
+     * Some engines (e.g. Jest) may not be able to handle the more advanced
+     * query selector (e.g. :has(...)).
+     * The following code gracefully degrade to match the capabilities.
+     */
+    function tryQuery(query: string): string | null {
+      try {
+        document.querySelectorAll(query);
+        return query;
+      } catch (e) {
+        console.error('Does not handle ', query);
+      }
+      return null;
+    }
+
+    return tryQuery(
+      'input[type=radio][checked], input[type=checkbox][checked], select:has(option[selected])'
+    ) ?? tryQuery(
+      'input[type=radio][checked], input[type=checkbox][checked], select'
+    ) ?? (
+        'input[type=radio], input[type=checkbox], select'
+      );
+  })();
+
   function trackElementValues(surface: string, surfaceElement: Element) {
     // The following is expensive, so try to jam everything we are interested in to the selector
-    const elements = surfaceElement.querySelectorAll<HTMLInputElement | HTMLSelectElement>(
-      'input[type=radio][checked], input[type=checkbox][checked], select:has(option[selected])'
-      // 'input[type=radio], input[type=checkbox], select'
-    );
-
-
+    const elements = surfaceElement.querySelectorAll<HTMLInputElement | HTMLSelectElement>(QueryString);
     if (!elements.length) {
       // Nothing to add
       return;

--- a/packages/hyperion-autologging/src/ALElementValuePublisher.ts
+++ b/packages/hyperion-autologging/src/ALElementValuePublisher.ts
@@ -1,0 +1,131 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved.
+ */
+
+'use strict';
+
+import type { Channel } from "@hyperion/hook/src/Channel";
+import * as Types from "@hyperion/hyperion-util/src/Types";
+import * as ALEventIndex from "./ALEventIndex";
+import * as ALID from './ALID';
+import { ALElementTextEvent, getElementTextEvent } from './ALInteractableDOMElement';
+import { ALChannelSurfaceMutationEvent } from "./ALSurfaceMutationPublisher";
+import { getAncestralSurfaceNode } from "./ALSurfaceUtils";
+import { ALElementEvent, ALFlowletEvent, ALLoggableEvent, ALMetadataEvent, ALReactElementEvent, ALSharedInitOptions } from "./ALType";
+import performanceAbsoluteNow from "@hyperion/hyperion-util/src/performanceAbsoluteNow";
+import { ReactComponentData } from "./ALReactUtils";
+import ALElementInfo from "./ALElementInfo";
+
+export type ALElementValueEventData = Readonly<
+  ALLoggableEvent &
+  ALFlowletEvent &
+  ALReactElementEvent &
+  ALElementTextEvent &
+  ALMetadataEvent &
+  ALElementEvent &
+  {
+    surface: string;
+    value: string | boolean;
+  }
+>;
+
+export type ALChannelElementValueEvent = Readonly<{
+  al_element_value_event: [ALElementValueEventData],
+}
+>;
+
+export type ALElementValueChannel = Channel<ALChannelElementValueEvent & ALChannelSurfaceMutationEvent>;
+
+
+export type InitOptions = Types.Options<
+  ALSharedInitOptions &
+  {
+    channel: ALElementValueChannel;
+    cacheElementReactInfo: boolean;
+  }
+>;
+
+export function publish(options: InitOptions): void {
+  const { channel } = options;
+
+  channel.addListener('al_surface_mutation_event', surfaceEventData => {
+    const surfaceElement = surfaceEventData.element;
+    const surface = surfaceEventData.surface;
+
+    if (surfaceEventData.event !== 'mount_component' || !surface == null || !surfaceElement) {
+      return;
+    }
+    // The following is expensive, so try to jam everything we are interested in to the selector
+    const elements = surfaceElement.querySelectorAll<HTMLInputElement | HTMLSelectElement>('input[type=radio], input[type=checkbox], select');
+
+    if (!elements.length) {
+      // Nothing to add
+      return;
+    }
+
+    for (let i = 0; i < elements.length; ++i) {
+      const element = elements[i];
+      const parentSurfaceNode = getAncestralSurfaceNode(element);
+      if (parentSurfaceNode === surfaceElement) {
+        // We know value is part of this surface only
+        const elementText = getElementTextEvent(element, surface);
+        let elementValueEventData: Pick<ALElementValueEventData, "value" | "metadata"> | null = null;
+
+        switch (element.nodeName) {
+          case 'INPUT': {
+            const input = element as HTMLInputElement;
+            if (input.checked) {
+              elementValueEventData = {
+                value: input.checked,
+                metadata: {
+                  type: input.getAttribute('type') ?? '',
+                }
+              }
+            }
+            break;
+          }
+          case 'SELECT': {
+            const select = element as HTMLSelectElement;
+            if (select.selectedIndex > -1) {
+              elementValueEventData = {
+                value: select.value,
+                metadata: {
+                  type: 'select',
+                  text: select.options[select.selectedIndex].text
+                }
+              }
+            }
+            break;
+          }
+
+        }
+        if (elementValueEventData) {
+          let reactComponentData: ReactComponentData | null = null;
+          if (options.cacheElementReactInfo) {
+            const elementInfo = ALElementInfo.getOrCreate(element);
+            reactComponentData = elementInfo.getReactComponentData();
+          }
+
+          const flowlet = options.flowletManager.top();
+
+
+          channel.emit('al_element_value_event', {
+            eventIndex: ALEventIndex.getNextEventIndex(),
+            relatedEventIndex: surfaceEventData.eventIndex,
+            eventTimestamp: performanceAbsoluteNow(),
+            element,
+            autoLoggingID: ALID.getOrSetAutoLoggingID(element),
+            surface,
+            flowlet,
+            triggerFlowlet: flowlet.data.triggerFlowlet,
+            ...elementText,
+            ...elementValueEventData,
+            reactComponentName: reactComponentData?.name,
+            reactComponentStack: reactComponentData?.stack,
+          });
+        }
+
+      }
+    }
+  });
+}

--- a/packages/hyperion-autologging/src/ALSurfaceMutationPublisher.ts
+++ b/packages/hyperion-autologging/src/ALSurfaceMutationPublisher.ts
@@ -58,6 +58,10 @@ type SurfaceInfo = ALSurfaceMutationEventData & Types.Writeable<ALElementEvent> 
 
 const activeSurfaces = new Map<string, SurfaceInfo>();
 
+export function getSurfaceMountInfo(surface: string): ALSurfaceMutationEventData | undefined {
+  return activeSurfaces.get(surface);
+}
+
 export type InitOptions = Types.Options<
   ALSharedInitOptions &
   {
@@ -163,10 +167,10 @@ export function publish(options: InitOptions): void {
   }
 
   channel.addListener('al_surface_mount', event => {
-    processNode(event, 'added');
+    !event.isProxy && processNode(event, 'added');
   });
 
   channel.addListener('al_surface_unmount', event => {
-    processNode(event, 'removed');
+    !event.isProxy && processNode(event, 'removed');
   });
 }

--- a/packages/hyperion-autologging/src/ALSurfaceMutationPublisher.ts
+++ b/packages/hyperion-autologging/src/ALSurfaceMutationPublisher.ts
@@ -8,6 +8,7 @@ import { assert } from "@hyperion/global/src/assert";
 import type { Channel } from "@hyperion/hook/src/Channel";
 import * as Types from "@hyperion/hyperion-util/src/Types";
 import performanceAbsoluteNow from '@hyperion/hyperion-util/src/performanceAbsoluteNow';
+import * as ALCustomEvent from "./ALCustomEvent";
 import ALElementInfo from './ALElementInfo';
 import * as ALEventIndex from './ALEventIndex';
 import * as ALID from './ALID';
@@ -46,7 +47,7 @@ export type ALChannelSurfaceMutationEvent = Readonly<{
 }
 >;
 
-export type ALSurfaceMutationChannel = Channel<ALChannelSurfaceMutationEvent & ALChannelSurfaceEvent>;
+export type ALSurfaceMutationChannel = Channel<ALChannelSurfaceMutationEvent & ALChannelSurfaceEvent & ALCustomEvent.ALChannelCustomEvent>;
 
 type SurfaceInfo = ALReactElementEvent & ALElementTextEvent & ALMetadataEvent & ALFlowletEvent & {
   surface: string,
@@ -171,5 +172,4 @@ export function publish(options: InitOptions): void {
   channel.addListener('al_surface_unmount', event => {
     processNode(event, 'removed');
   });
-
 }

--- a/packages/hyperion-autologging/src/ALType.ts
+++ b/packages/hyperion-autologging/src/ALType.ts
@@ -6,6 +6,7 @@
 
 import * as Types from "@hyperion/hyperion-util/src/Types";
 import { IALFlowlet, ALFlowletManager } from './ALFlowletManager';
+import { ALID } from "./ALID";
 
 export type ALFlowletEvent = Readonly<{
   callFlowlet: IALFlowlet;
@@ -41,6 +42,7 @@ export type ALMetadataEvent = Readonly<{
  */
 export type ALLoggableEvent = ALTimedEvent & ALMetadataEvent & Readonly<{
   eventIndex: number;
+  relatedEventIndex?: number;
 }>;
 
 export type ALReactElementEvent = Readonly<{
@@ -50,4 +52,9 @@ export type ALReactElementEvent = Readonly<{
 
 export type ALSharedInitOptions = Types.Options<{
   flowletManager: ALFlowletManager;
+}>;
+
+export type ALElementEvent = Readonly<{
+  element: HTMLElement;
+  autoLoggingID: ALID;
 }>;

--- a/packages/hyperion-autologging/src/ALUIEventPublisher.ts
+++ b/packages/hyperion-autologging/src/ALUIEventPublisher.ts
@@ -12,13 +12,15 @@ import { setTriggerFlowlet } from "@hyperion/hyperion-flowlet/src/TriggerFlowlet
 import { TimedTrigger } from "@hyperion/hyperion-util/src/TimedTrigger";
 import performanceAbsoluteNow from "@hyperion/hyperion-util/src/performanceAbsoluteNow";
 import ALElementInfo from './ALElementInfo';
+import * as ALEventIndex from "./ALEventIndex";
 import { ALFlowletManager, IALFlowlet } from "./ALFlowletManager";
 import { ALID, getOrSetAutoLoggingID } from "./ALID";
-import { ALElementTextEvent, getElementTextEvent, getInteractable, isTrackedEvent, enableUIEventHandlers, TrackEventHandlerConfig } from "./ALInteractableDOMElement";
+import { ALElementTextEvent, TrackEventHandlerConfig, enableUIEventHandlers, getElementTextEvent, getInteractable, isTrackedEvent } from "./ALInteractableDOMElement";
 import { ReactComponentData } from "./ALReactUtils";
 import { getSurfacePath } from "./ALSurfaceUtils";
-import { ALFlowletEvent, ALMetadataEvent, ALReactElementEvent, ALSharedInitOptions, ALTimedEvent } from "./ALType";
+import { ALFlowletEvent, ALLoggableEvent, ALMetadataEvent, ALReactElementEvent, ALSharedInitOptions, ALTimedEvent } from "./ALType";
 import * as ALUIEventGroupPublisher from "./ALUIEventGroupPublisher";
+
 
 /**
  * Generates a union type of all handler event and domEvent permutations.
@@ -45,7 +47,8 @@ export type ALUIEventCaptureData = Readonly<
   ALReactElementEvent &
   ALElementTextEvent &
   {
-    surface: string | null,
+    surface: string | null;
+    value?: string;
   }
 >;
 
@@ -54,7 +57,8 @@ export type ALUIEventBubbleData = Readonly<
 >;
 
 export type ALLoggableUIEvent = Readonly<
-  ALUIEventCaptureData
+  ALUIEventCaptureData &
+  ALLoggableEvent
 >;
 
 export type ALUIEventData = Readonly<
@@ -295,7 +299,10 @@ export function publish(options: InitOptions): void {
       timedEmitter.run();
     }
 
-    const data: ALUIEventData = eventData;
+    const data: ALUIEventData = {
+      ...eventData,
+      eventIndex: ALEventIndex.getNextEventIndex(),
+    };
 
     lastUIEvent = {
       data,

--- a/packages/hyperion-autologging/src/AutoLogging.ts
+++ b/packages/hyperion-autologging/src/AutoLogging.ts
@@ -35,7 +35,6 @@ export type ALChannelEvent = (
   ALHeartbeat.InitOptions['channel'] &
   ALSurfaceMutationPublisher.InitOptions['channel'] &
   ALNetworkPublisher.InitOptions['channel'] &
-  ALElementValuePublisher.InitOptions['channel'] &
   ALCustomEvent.ALCustomEventChannel
 ) extends Channel<infer EventType> ? EventType : never;
 
@@ -53,7 +52,6 @@ export type InitOptions = Types.Options<
     uiEventPublisher?: PublicInitOptions<ALUIEventPublisher.InitOptions> | null;
     heartbeat?: ALHeartbeat.InitOptions | null;
     surfaceMutationPublisher?: PublicInitOptions<ALSurfaceMutationPublisher.InitOptions> | null;
-    elementValuePublisher?: PublicInitOptions<ALElementValuePublisher.InitOptions> | null,
     network?: PublicInitOptions<ALNetworkPublisher.InitOptions> | null;
     triggerFlowlet?: PublicInitOptions<ALTriggerFlowlet.InitOptions> | null;
   }
@@ -132,17 +130,6 @@ export function init(options: InitOptions): boolean {
     ALFlowletPublisher.publish(options.flowletPublisher);
   }
 
-  if (options.uiEventPublisher) {
-    ALUIEventPublisher.publish({
-      ...sharedOptions,
-      ...options.uiEventPublisher
-    });
-  }
-
-  if (options.heartbeat) {
-    ALHeartbeat.start(options.heartbeat);
-  }
-
   if (options.surfaceMutationPublisher) {
     ALSurfaceMutationPublisher.publish({
       ...sharedOptions,
@@ -150,12 +137,27 @@ export function init(options: InitOptions): boolean {
     });
   }
 
-  if (options.elementValuePublisher) {
+  if (options.uiEventPublisher) {
+    ALUIEventPublisher.publish({
+      ...sharedOptions,
+      ...options.uiEventPublisher
+    });
+
+    /**
+     * The following will depend on the surface mutation events
+     * so we need to make sure it is initialized afterwards
+     */
     ALElementValuePublisher.publish({
       ...sharedOptions,
-      ...options.elementValuePublisher
+      ...options.uiEventPublisher,
+      surfaceChannel: options.surface.channel,
     });
   }
+
+  if (options.heartbeat) {
+    ALHeartbeat.start(options.heartbeat);
+  }
+
 
   if (options.network) {
     ALNetworkPublisher.publish({

--- a/packages/hyperion-autologging/src/AutoLogging.ts
+++ b/packages/hyperion-autologging/src/AutoLogging.ts
@@ -11,6 +11,7 @@ import { initFlowletTrackers } from "@hyperion/hyperion-flowlet/src/FlowletWrapp
 import * as IReactComponent from "@hyperion/hyperion-react/src/IReactComponent";
 import * as Types from "@hyperion/hyperion-util/src/Types";
 import * as ALCustomEvent from "./ALCustomEvent";
+import * as ALElementValuePublisher from "./ALElementValuePublisher";
 import * as ALFlowletPublisher from "./ALFlowletPublisher";
 import * as ALHeartbeat from "./ALHeartbeat";
 import * as ALInteractableDOMElement from "./ALInteractableDOMElement";
@@ -22,6 +23,7 @@ import * as ALTriggerFlowlet from "./ALTriggerFlowlet";
 import { ALSharedInitOptions } from "./ALType";
 import * as ALUIEventGroupPublishers from "./ALUIEventGroupPublisher";
 import * as ALUIEventPublisher from "./ALUIEventPublisher";
+
 /**
  * This type extracts the union of all events types so that external modules
  * don't have to import these types one by one.
@@ -33,6 +35,7 @@ export type ALChannelEvent = (
   ALHeartbeat.InitOptions['channel'] &
   ALSurfaceMutationPublisher.InitOptions['channel'] &
   ALNetworkPublisher.InitOptions['channel'] &
+  ALElementValuePublisher.InitOptions['channel'] &
   ALCustomEvent.ALCustomEventChannel
 ) extends Channel<infer EventType> ? EventType : never;
 
@@ -50,6 +53,7 @@ export type InitOptions = Types.Options<
     uiEventPublisher?: PublicInitOptions<ALUIEventPublisher.InitOptions> | null;
     heartbeat?: ALHeartbeat.InitOptions | null;
     surfaceMutationPublisher?: PublicInitOptions<ALSurfaceMutationPublisher.InitOptions> | null;
+    elementValuePublisher?: PublicInitOptions<ALElementValuePublisher.InitOptions> | null,
     network?: PublicInitOptions<ALNetworkPublisher.InitOptions> | null;
     triggerFlowlet?: PublicInitOptions<ALTriggerFlowlet.InitOptions> | null;
   }
@@ -143,6 +147,13 @@ export function init(options: InitOptions): boolean {
     ALSurfaceMutationPublisher.publish({
       ...sharedOptions,
       ...options.surfaceMutationPublisher
+    });
+  }
+
+  if (options.elementValuePublisher) {
+    ALElementValuePublisher.publish({
+      ...sharedOptions,
+      ...options.elementValuePublisher
     });
   }
 

--- a/packages/hyperion-dom/src/DOMShadowPrototype.ts
+++ b/packages/hyperion-dom/src/DOMShadowPrototype.ts
@@ -90,7 +90,7 @@ export class DOMShadowPrototype<ClassType extends Object, ParentType extends Obj
 
 }
 
-export const sampleHTMLElement = window.document.head;
+export const sampleHTMLElement: HTMLElement = window.document.head;
 
 export function getVirtualAttribute<Name extends string>(obj: Object, name: Name): VirtualAttribute<Element, Name> | null {
   let shadowProto = getObjectExtension(obj, true)?.shadowPrototype;

--- a/packages/hyperion-dom/src/IHTMLInputElement.ts
+++ b/packages/hyperion-dom/src/IHTMLInputElement.ts
@@ -1,0 +1,18 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved.
+ */
+
+import { interceptAttribute } from "@hyperion/hyperion-core/src/AttributeInterceptor";
+import { DOMShadowPrototype } from "./DOMShadowPrototype";
+import * as IHTMLElement from "./IHTMLElement";
+
+export const IHTMLInputElementPrototype = new DOMShadowPrototype(
+  HTMLInputElement,
+  IHTMLElement.IHTMLElementtPrototype,
+  {
+    sampleObject: document.createElement("input"),
+    nodeType: document.ELEMENT_NODE
+  }
+);
+
+export const checked = interceptAttribute("checked", IHTMLInputElementPrototype);

--- a/packages/hyperion-react-testapp/src/AutoLoggingWrapper.ts
+++ b/packages/hyperion-react-testapp/src/AutoLoggingWrapper.ts
@@ -18,7 +18,6 @@ export let interceptionStatus = "disabled";
 
 export function init() {
   interceptionStatus = "enabled";
-  const domSurfaceAttributeName = 'data-surfaceid';
   const flowletManager = FlowletManager;
 
   const IReactModule = IReact.intercept("react", React, [])
@@ -29,7 +28,6 @@ export function init() {
 
   Visualizer.init({
     flowletManager,
-    domSurfaceAttributeName,
     channel,
   });
 
@@ -50,7 +48,6 @@ export function init() {
 
   AutoLogging.init({
     flowletManager,
-    domSurfaceAttributeName,
     componentNameValidator: testCompValidator,
     flowletPublisher: {
       channel
@@ -103,6 +100,10 @@ export function init() {
       heartbeatInterval: 30 * 1000
     },
     surfaceMutationPublisher: {
+      channel,
+      cacheElementReactInfo: true,
+    },
+    elementValuePublisher: {
       channel,
       cacheElementReactInfo: true,
     },

--- a/packages/hyperion-react-testapp/src/AutoLoggingWrapper.ts
+++ b/packages/hyperion-react-testapp/src/AutoLoggingWrapper.ts
@@ -108,10 +108,6 @@ export function init() {
       channel,
       cacheElementReactInfo: true,
     },
-    elementValuePublisher: {
-      channel,
-      cacheElementReactInfo: true,
-    },
     network: {
       channel,
       requestFilter: request => !/robots/.test(request.url.toString()),

--- a/packages/hyperion-react-testapp/src/AutoLoggingWrapper.ts
+++ b/packages/hyperion-react-testapp/src/AutoLoggingWrapper.ts
@@ -93,6 +93,11 @@ export function init() {
           interactableElementsOnly: false,
           eventFilter: (domEvent) => domEvent.code === 'Enter',
         },
+        {
+          eventName: 'change',
+          cacheElementReactInfo: true,
+          interactableElementsOnly: false,
+        }
       ]
     },
     heartbeat: {

--- a/packages/hyperion-react-testapp/src/component/ALEventLogger.tsx
+++ b/packages/hyperion-react-testapp/src/component/ALEventLogger.tsx
@@ -16,7 +16,6 @@ const EventsWithFlowlet = [
   'al_network_response',
   'al_flowlet_event',
   'al_custom_event',
-  'al_element_value_event',
 ] as const;
 
 const EventsWithoutFlowlet = [

--- a/packages/hyperion-react-testapp/src/component/ALEventLogger.tsx
+++ b/packages/hyperion-react-testapp/src/component/ALEventLogger.tsx
@@ -7,6 +7,7 @@ import { SyncChannel } from "../Channel";
 import { ALChannelEvent } from "@hyperion/hyperion-autologging/src/AutoLogging";
 import { ALSessionGraph } from "@hyperion/hyperion-autologging-visualizer/src/component/ALSessionGraph.react";
 import { LocalStoragePersistentData } from "@hyperion/hyperion-util/src/PersistentData";
+import { ALFlowletEvent } from "@hyperion/hyperion-autologging/src/ALType";
 
 const EventsWithFlowlet = [
   'al_ui_event',
@@ -14,6 +15,8 @@ const EventsWithFlowlet = [
   'al_network_request',
   'al_network_response',
   'al_flowlet_event',
+  'al_custom_event',
+  'al_element_value_event',
 ] as const;
 
 const EventsWithoutFlowlet = [
@@ -47,8 +50,8 @@ function EventField<T extends keyof ALChannelEvent>(props: { eventName: T, onEna
     const newValue = !checked;
     value.setValue(newValue);
     setChecked(newValue);
-  }, []);
-  React.useEffect(() => {
+  }, [eventName, checked]);
+  React.useLayoutEffect(() => {
     const handler = SyncChannel.on(eventName).add(ev => {
       // console.log(eventName, ev, performance.now(), ev.flowlet?.getFullName());
       if (checked) {
@@ -56,7 +59,7 @@ function EventField<T extends keyof ALChannelEvent>(props: { eventName: T, onEna
       }
     });
     return () => { SyncChannel.on(eventName).remove(handler); };
-  })
+  }, [eventName, checked]);
 
   return <div>
     <input type="checkbox" id={eventName} onChange={onChange} defaultChecked={checked} ></input>

--- a/packages/hyperion-react-testapp/src/component/ElementNameComponent.tsx
+++ b/packages/hyperion-react-testapp/src/component/ElementNameComponent.tsx
@@ -1,13 +1,14 @@
 import React from "react";
+import { Surface } from "./Surface";
 
 export default function (/* props: Props */) {
   function setExpectedElementName(name: string): void {
     const element = document.getElementById('expectedElementName');
-    if(element != null) {
+    if (element != null) {
       element.innerHTML = name;
     }
   }
-  return(
+  return Surface({ surface: 'inputs1' })(
     <div>
       <h3>Element Name Testing</h3>
       Check the console for al_ui_events after clicking the buttons. <br />
@@ -45,15 +46,30 @@ export default function (/* props: Props */) {
             <td>
               <button onClick={() => {
                 setExpectedElementName('Test Description 2 Another Description');
-              }}aria-describedby="desc2 desc3">&nbsp;</button>
+              }} aria-describedby="desc2 desc3">&nbsp;</button>
             </td>
           </tr>
         </tbody>
       </table>
-      <div style={{display: 'none'}} id="label2">Test Label 2</div>
-      <div style={{display: 'none'}} id="label3">Another Label</div>
-      <div style={{display: 'none'}} id="desc2">Test Description 2</div>
-      <div style={{display: 'none'}} id="desc3">Another Description</div>
+      <div style={{ display: 'none' }} id="label2">Test Label 2</div>
+      <div style={{ display: 'none' }} id="label3">Another Label</div>
+      <div style={{ display: 'none' }} id="desc2">Test Description 2</div>
+      <div style={{ display: 'none' }} id="desc3">Another Description</div>
+      <div>
+        <label id='ch1'>Check box 1</label>
+        <input type='checkbox' aria-labelledby="ch1" checked></input>
+        <input type='checkbox' aria-label="Check box 2" ></input>
+        {Surface({ surface: 'inputs2' })(<>
+          <input type='radio' aria-label="Radio 1" name='radios'></input>
+          <input type="radio" aria-label="Radio 2" name='radios'></input>
+        </>
+        )}
+        <select>
+          <option value='v1' >V1</option>
+          <option value='v2' selected>V2</option>
+          <option value='v3' >V3</option>
+        </select>
+      </div>
     </div>
   );
 }

--- a/packages/hyperion-react-testapp/src/component/ElementNameComponent.tsx
+++ b/packages/hyperion-react-testapp/src/component/ElementNameComponent.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Surface } from "./Surface";
+import { SurfaceComp } from "./Surface";
 
 export default function (/* props: Props */) {
   function setExpectedElementName(name: string): void {
@@ -8,7 +8,7 @@ export default function (/* props: Props */) {
       element.innerHTML = name;
     }
   }
-  return Surface({ surface: 'inputs1' })(
+  return <SurfaceComp surface='inputs1'>
     <div>
       <h3>Element Name Testing</h3>
       Check the console for al_ui_events after clicking the buttons. <br />
@@ -57,19 +57,22 @@ export default function (/* props: Props */) {
       <div style={{ display: 'none' }} id="desc3">Another Description</div>
       <div>
         <label id='ch1'>Check box 1</label>
-        <input type='checkbox' aria-labelledby="ch1" checked></input>
+        <input type='checkbox' aria-labelledby="ch1" defaultChecked></input>
         <input type='checkbox' aria-label="Check box 2" ></input>
-        {Surface({ surface: 'inputs2' })(<>
-          <input type='radio' aria-label="Radio 1" name='radios'></input>
-          <input type="radio" aria-label="Radio 2" name='radios'></input>
-        </>
-        )}
-        <select>
-          <option value='v1' >V1</option>
-          <option value='v2' selected>V2</option>
-          <option value='v3' >V3</option>
+        <SurfaceComp surface="inputs2">
+          <input type='radio' aria-label="Radio 1" name='radios1'></input>
+          <input type="radio" aria-label="Radio 2" name='radios1' defaultChecked></input>
+          <SurfaceComp surface="inputs3">
+            <input type='radio' aria-label="Radio 3" name='radios2'></input>
+            <input type="radio" aria-label="Radio 4" name='radios2'></input>
+          </SurfaceComp>
+        </SurfaceComp>
+        <select defaultValue="_v2">
+          <option value='_v1' >V1</option>
+          <option value='_v2' >V2</option>
+          <option value='_v3' >V3</option>
         </select>
       </div>
     </div>
-  );
+  </SurfaceComp>;
 }

--- a/packages/hyperion-util/src/Types.ts
+++ b/packages/hyperion-util/src/Types.ts
@@ -11,3 +11,5 @@ export type Options<Options extends [...any[]] | {}> = Beautify<
   ? CombineReadonly<Options>
   : Options
 >;
+
+export type Writeable<T> = { -readonly [P in keyof T]: T[P] };

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -29,6 +29,7 @@ export default defineConfig({
         "@hyperion/hyperion-dom/src/IElement_",
         "@hyperion/hyperion-dom/src/IElement",
         "@hyperion/hyperion-dom/src/IHTMLElement",
+        "@hyperion/hyperion-dom/src/IHTMLInputElement",
         "@hyperion/hyperion-dom/src/IWindow",
         "@hyperion/hyperion-dom/src/IXMLHttpRequest",
         "@hyperion/hyperion-dom/src/ICSSStyleDeclaration",

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,7 @@ export * as IEventTarget from "@hyperion/hyperion-dom/src/IEventTarget";
 // export * as INode from "@hyperion/hyperion-dom/src/INode";
 export * as IElement from "@hyperion/hyperion-dom/src/IElement";
 export * as IHTMLElement from "@hyperion/hyperion-dom/src/IHTMLElement";
+export * as IHTMLInputElement from "@hyperion/hyperion-dom/src/IHTMLInputElement";
 export * as ICSSStyleDeclaration from "@hyperion/hyperion-dom/src/ICSSStyleDeclaration";
 // export * as IGlobalEventHandlers from "@hyperion/hyperion-dom/src/IGlobalEventHandlers";
 export * as IWindow from "@hyperion/hyperion-dom/src/IWindow";


### PR DESCRIPTION
In some cases, the user may not click on any of the interactable elements and application will use the default values in such elements. This commit, adds an option to collect the value of some of these elements (radio/checkbox inputs, and selectors) and add then to the metadata of the surface that just mounted.

I also updated the test react app to ensure this is working.