### PR TITLE
Remove customFlowlet from FlowletManager.wrap

### DIFF
--- a/packages/hyperion-flowlet/src/FlowletManager.ts
+++ b/packages/hyperion-flowlet/src/FlowletManager.ts
@@ -139,7 +139,6 @@ export class FlowletManager<T extends Flowlet = Flowlet> {
   wrap<C extends CallbackType | undefined | null>(
     listener: C,
     apiName: string,
-    customFlowlet?: T,
     getTriggerFlowlet?: (...args: any) => T | null | undefined
   ): C {
     if (!listener) {
@@ -149,7 +148,7 @@ export class FlowletManager<T extends Flowlet = Flowlet> {
     const funcInterceptor = interceptEventListener(listener);
     if (funcInterceptor && !funcInterceptor.testAndSet(IS_FLOWLET_SETUP_PROP_NAME)) {
 
-      const flowlet = customFlowlet ?? new this.flowletCtor(apiName, this.top());
+      const flowlet = new this.flowletCtor(apiName, this.top());
       if (!getTriggerFlowlet) {
         /**
          * we are not going to pickup an actual trigger later, which means whatever triggered

--- a/packages/hyperion-flowlet/src/FlowletWrappers.ts
+++ b/packages/hyperion-flowlet/src/FlowletWrappers.ts
@@ -153,13 +153,13 @@ export function initFlowletTrackers(flowletManager: FlowletManager) {
   ]) {
     eventHandler.setter.onBeforeCallMapperAdd(function (this, args: [any]) {
       const func = args[0];
-      args[0] = flowletManager.wrap(func, eventHandler.name, void 0, getTriggerFlowletFromEvent);
+      args[0] = flowletManager.wrap(func, eventHandler.name, getTriggerFlowletFromEvent);
       return args;
     });
   }
 
   IEventTarget.addEventListener.onBeforeCallMapperAdd(args => {
-    args[1] = flowletManager.wrap(args[1], `${IEventTarget.addEventListener.name}(${args[0]})`, void 0, getTriggerFlowletFromEvent);
+    args[1] = flowletManager.wrap(args[1], `${IEventTarget.addEventListener.name}(${args[0]})`, getTriggerFlowletFromEvent);
     return args;
   });
   IEventTarget.removeEventListener.onBeforeCallMapperAdd(args => {
@@ -254,8 +254,8 @@ export function initFlowletTrackers(flowletManager: FlowletManager) {
 
   IPromise.then.onBeforeAndAfterCallMapperAdd(function (this, args) {
     const triggerFlowlet = getTriggerFlowlet(this);
-    args[0] = flowletManager.wrap(args[0], IPromise.then.name, void 0, () => triggerFlowlet);
-    args[1] = flowletManager.wrap(args[1], IPromise.then.name, void 0, () => triggerFlowlet);
+    args[0] = flowletManager.wrap(args[0], IPromise.then.name, () => triggerFlowlet);
+    args[1] = flowletManager.wrap(args[1], IPromise.then.name, () => triggerFlowlet);
     return value => {
       if (value !== this && triggerFlowlet) {
         const newTriggerFlowlet = getTriggerFlowlet(value);
@@ -269,7 +269,7 @@ export function initFlowletTrackers(flowletManager: FlowletManager) {
 
   IPromise.Catch.onBeforeAndAfterCallMapperAdd(function (this, args) {
     const triggerFlowlet = getTriggerFlowlet(this);
-    args[0] = flowletManager.wrap(args[0], IPromise.then.name, void 0, () => triggerFlowlet);
+    args[0] = flowletManager.wrap(args[0], IPromise.then.name, () => triggerFlowlet);
     return value => {
       if (value !== this && triggerFlowlet) {
         const newTriggerFlowlet = getTriggerFlowlet(value);


### PR DESCRIPTION
The `customFlowlet` argument for `FlowletManager.wrap` is not being used anywhere. Based on flowlet design principles, we should also not be setting the custom top call flowlet when wrapping, and instead use trigger flowlet to mark custom flowlet links wherever necessary. This change removes the deprecated `customFlowlet` argument.