### PR TITLE
Rename flowlet to call flowlet

### DIFF
--- a/packages/hyperion-autologging/src/ALCustomEvent.ts
+++ b/packages/hyperion-autologging/src/ALCustomEvent.ts
@@ -26,13 +26,13 @@ export type ALChannelCustomEvent = Readonly<{
 export type ALCustomEventChannel = Channel<ALChannelCustomEvent>;
 
 export function emitALCustomEvent<T extends ALFlowletDataType>(channel: ALCustomEventChannel, flowletManager: ALFlowletManager<T>, metadata: ALMetadataEvent['metadata'], nonLoggable?: boolean): ALCustomEventData {
-  const flowlet = flowletManager.top();
+  const callFlowlet = flowletManager.top();
   const event: ALCustomEventData = {
     event: 'custom',
     eventTimestamp: performanceAbsoluteNow(),
     eventIndex: nonLoggable ? void 0 : ALEventIndex.getNextEventIndex(),
-    flowlet,
-    triggerFlowlet: flowlet?.data.triggerFlowlet,
+    callFlowlet,
+    triggerFlowlet: callFlowlet?.data.triggerFlowlet,
     metadata
   }
   channel.emit('al_custom_event', event);

--- a/packages/hyperion-autologging/src/ALHeartbeat.ts
+++ b/packages/hyperion-autologging/src/ALHeartbeat.ts
@@ -133,7 +133,6 @@ function _logHeartbeat(heartbeatType: ALHeartbeatType): void {
       event: 'heartbeat',
       eventIndex: ALEventIndex.getNextEventIndex(),
       eventTimestamp: timestamp,
-      // flowlet: AdsALFlowletManager.top(),
       heartbeatType,
       metadata: {},
     });

--- a/packages/hyperion-autologging/src/ALNetworkPublisher.ts
+++ b/packages/hyperion-autologging/src/ALNetworkPublisher.ts
@@ -166,14 +166,14 @@ function captureFetch(options: InitOptions): void {
     let request: RequestInfo = getFetchRequestInfo(input, init);
 
     if (!options.requestFilter || options.requestFilter(request)) {
-      const flowlet = flowletManager.top();
+      const callFlowlet = flowletManager.top();
       channel.emit("al_network_request", ephemeralRequestEvent = {
         initiatorType: "fetch",
         event: "network",
         eventTimestamp: performanceAbsoluteNow(),
         eventIndex: ALEventIndex.getNextEventIndex(),
-        flowlet,
-        triggerFlowlet: flowlet?.data.triggerFlowlet,
+        callFlowlet,
+        triggerFlowlet: callFlowlet?.data.triggerFlowlet,
         ...request,
         metadata: {},
       });
@@ -200,7 +200,7 @@ function captureFetch(options: InitOptions): void {
         value.then(response => {
           const requestEvent = intercept.getVirtualPropertyValue<ALNetworkRequestEvent>(value, REQUEST_INFO_PROP_NAME);
           assert(requestEvent != null, `Unexpected situation! Request info missing from fetch promise object`);
-          const flowlet = requestEvent?.flowlet; // Reuse the same flowlet as request, since by now things have changed.
+          const callFlowlet = requestEvent?.callFlowlet; // Reuse the same flowlet as request, since by now things have changed.
 
           // const triggerFlowlet = flowletManager.top()?.data.triggerFlowlet;
           assert(triggerFlowlet === flowletManager.top()?.data.triggerFlowlet, `Broken trigger flowlet chain!`);
@@ -210,7 +210,7 @@ function captureFetch(options: InitOptions): void {
             event: "network",
             eventTimestamp: performanceAbsoluteNow(),
             eventIndex: ALEventIndex.getNextEventIndex(),
-            flowlet,
+            callFlowlet,
             triggerFlowlet,
             requestEvent,
             response,
@@ -323,7 +323,7 @@ function captureXHR(options: InitOptions): void {
     };
 
 
-    const flowlet = flowletManager.top(); // Before calling requestFilter and losing current top flowlet
+    const callFlowlet = flowletManager.top(); // Before calling requestFilter and losing current top callFlowlet
     const triggerFlowlet = getTriggerFlowlet(this);
 
     if (!options.requestFilter || options.requestFilter(request)) {
@@ -334,7 +334,7 @@ function captureXHR(options: InitOptions): void {
         event: "network",
         eventTimestamp: performanceAbsoluteNow(),
         eventIndex: ALEventIndex.getNextEventIndex(),
-        flowlet,
+        callFlowlet,
         triggerFlowlet,
         ...request, // assert already ensures request is not undefined
         metadata: {},
@@ -350,7 +350,7 @@ function captureXHR(options: InitOptions): void {
             event: "network",
             eventTimestamp: performanceAbsoluteNow(),
             eventIndex: ALEventIndex.getNextEventIndex(),
-            flowlet, // should carry request flowlet forward
+            callFlowlet, // should carry request flowlet forward
             triggerFlowlet, //should carry request triggerFlowlet forward as the main trigger
             requestEvent,
             response: this,

--- a/packages/hyperion-autologging/src/ALSurfaceContext.ts
+++ b/packages/hyperion-autologging/src/ALSurfaceContext.ts
@@ -22,7 +22,7 @@ export type InitOptions = Types.Options<{
 export type ALSurfaceContextFilledValue = {
   nonInteractiveSurface: string;
   surface: string;
-  flowlet: IALFlowlet;
+  callFlowlet: IALFlowlet;
 };
 
 type ALSurfaceContextValue =
@@ -30,13 +30,13 @@ type ALSurfaceContextValue =
   | {
     nonInteractiveSurface: null;
     surface: null;
-    flowlet: null;
+    callFlowlet: null;
   };
 
 const DefaultSurfaceContext: ALSurfaceContextValue = {
   nonInteractiveSurface: null,
   surface: null,
-  flowlet: null,
+  callFlowlet: null,
 };
 
 export let ALSurfaceContext: React.Context<ALSurfaceContextValue> | null = null;

--- a/packages/hyperion-autologging/src/ALSurfaceMutationPublisher.ts
+++ b/packages/hyperion-autologging/src/ALSurfaceMutationPublisher.ts
@@ -72,7 +72,7 @@ export function publish(options: InitOptions): void {
     const timestamp = performanceAbsoluteNow();
     const { element, surface, metadata } = event;
 
-    const currFlowlet = flowletManager.top();
+    const callFlowlet = flowletManager.top();
     if (!(element instanceof HTMLElement) || /LINK|SCRIPT/.test(element.nodeName)) {
       return;
     }
@@ -92,15 +92,14 @@ export function publish(options: InitOptions): void {
           } else {
             elementText = getElementTextEvent(null, surface);
           }
-          if (currFlowlet) {
-            metadata.add_flowlet = currFlowlet?.getFullName();
+          if (callFlowlet) {
+            metadata.add_call_flowlet = callFlowlet?.getFullName();
           }
           info = {
             ...event,
             surface,
             element,
             addTime: timestamp,
-            flowlet: event.flowlet,
             reactComponentName: reactComponentData?.name,
             reactComponentStack: reactComponentData?.stack,
             ...elementText,
@@ -126,8 +125,8 @@ export function publish(options: InitOptions): void {
           *  */
           info.element = element;
           info.addTime = timestamp;
-          if (currFlowlet) {
-            info.metadata.add_flowlet = currFlowlet.getFullName();
+          if (callFlowlet) {
+            info.metadata.add_call_flowlet = callFlowlet.getFullName();
           }
         }
         break;
@@ -146,8 +145,8 @@ export function publish(options: InitOptions): void {
            * // Object.assign(info.metadata, metadata);
            */
           assert(info.mountEvent != null, "Missing mutaion info for unmounting");
-          if (currFlowlet) {
-            info.metadata.remove_flowlet = currFlowlet.getFullName();
+          if (callFlowlet) {
+            info.metadata.remove_call_flowlet = callFlowlet.getFullName();
           }
           channel.emit('al_surface_mutation_event', {
             ...info,

--- a/packages/hyperion-autologging/src/ALSurfacePropsExtension.ts
+++ b/packages/hyperion-autologging/src/ALSurfacePropsExtension.ts
@@ -12,6 +12,6 @@ export class SurfacePropsExtension<
   DataType extends ALFlowletDataType,
   FlowletType extends Flowlet<DataType>> extends IReactFlowlet.PropsExtension<DataType, FlowletType>  {
   getSurface(): string | undefined {
-    return this.flowlet?.data.surface;
+    return this.callFlowlet?.data.surface;
   }
 }

--- a/packages/hyperion-autologging/src/ALType.ts
+++ b/packages/hyperion-autologging/src/ALType.ts
@@ -8,12 +8,12 @@ import * as Types from "@hyperion/hyperion-util/src/Types";
 import { IALFlowlet, ALFlowletManager } from './ALFlowletManager';
 
 export type ALFlowletEvent = Readonly<{
-  flowlet: IALFlowlet;
+  callFlowlet: IALFlowlet;
   triggerFlowlet: IALFlowlet | null | undefined;
 }>;
 
-export type ALOptionalFlowletEvent = Omit<ALFlowletEvent, 'flowlet'> & Readonly<{
-  flowlet: ALFlowletEvent['flowlet'] | null;
+export type ALOptionalFlowletEvent = Omit<ALFlowletEvent, 'callFlowlet'> & Readonly<{
+  callFlowlet: ALFlowletEvent['callFlowlet'] | null;
 }>;
 
 export type ALTimedEvent = Readonly<{

--- a/packages/hyperion-autologging/test/ALNetworkPublish.test.ts
+++ b/packages/hyperion-autologging/test/ALNetworkPublish.test.ts
@@ -9,10 +9,8 @@ import { intercept } from "@hyperion/hyperion-core/src/intercept";
 
 import { Channel } from "@hyperion/hook/src/Channel";
 import { ALFlowletManager } from "../src/ALFlowletManager";
-import { AUTO_LOGGING_SURFACE } from "../src/ALSurfaceConsts";
 import * as ALNetworkPublisher from "../src/ALNetworkPublisher";
 import { initFlowletTrackers } from "@hyperion/hyperion-flowlet/src/FlowletWrappers";
-import * as ALTriggerFlowlet from "../src/ALTriggerFlowlet";
 
 describe("Network event publisher", () => {
   beforeEach(() => {
@@ -29,7 +27,6 @@ describe("Network event publisher", () => {
 
     ALNetworkPublisher.publish({
       flowletManager,
-      domSurfaceAttributeName: AUTO_LOGGING_SURFACE,
       channel,
     });
 

--- a/packages/hyperion-autologging/test/ALUIEventPublisher.test.ts
+++ b/packages/hyperion-autologging/test/ALUIEventPublisher.test.ts
@@ -8,7 +8,6 @@ import "jest";
 
 import { Channel } from "@hyperion/hook/src/Channel";
 import { ALFlowletManager } from "../src/ALFlowletManager";
-import { AUTO_LOGGING_SURFACE } from "../src/ALSurfaceConsts";
 import * as ALUIEventPublisher from "../src/ALUIEventPublisher";
 import * as DomFragment from "./DomFragment";
 
@@ -20,7 +19,6 @@ describe("UI event publisher", () => {
 
     ALUIEventPublisher.publish({
       flowletManager,
-      domSurfaceAttributeName: AUTO_LOGGING_SURFACE,
       channel,
       uiEvents: [
         {

--- a/packages/hyperion-react/src/IReactFlowlet.ts
+++ b/packages/hyperion-react/src/IReactFlowlet.ts
@@ -21,14 +21,14 @@ export class PropsExtension<
   DataType extends FlowletDataType,
   FlowletType extends Flowlet<DataType>
 > {
-  flowlet: FlowletType;
+  callFlowlet: FlowletType;
 
-  constructor(flowlet: FlowletType) {
-    this.flowlet = flowlet;
+  constructor(callFlowlet: FlowletType) {
+    this.callFlowlet = callFlowlet;
   }
 
   toString(): string {
-    return this.flowlet.getFullName();
+    return this.callFlowlet.getFullName();
   }
 }
 
@@ -67,8 +67,8 @@ export function init<
   const extensionGetter = IReactPropsExtension.init({
     ...options,
     extensionCtor: () => {
-      const top = flowletManager.top();
-      return top ? new PropsExtension(top) : null
+      const callFlowlet = flowletManager.top();
+      return callFlowlet ? new PropsExtension(callFlowlet) : null
     }
   });
 
@@ -78,11 +78,11 @@ export function init<
 
   function flowletPusher(props?: ExtendedProps): FlowletType | undefined {
     const extension = extensionGetter(props);
-    const activeFlowlet = extension?.flowlet;
-    if (activeFlowlet) {
-      flowletManager.push(activeFlowlet);
+    const activeCallFlowlet = extension?.callFlowlet;
+    if (activeCallFlowlet) {
+      flowletManager.push(activeCallFlowlet);
     }
-    return activeFlowlet;
+    return activeCallFlowlet;
   }
 
   const IS_FLOWLET_SETUP_PROP = 'isFlowletSetup';
@@ -112,10 +112,10 @@ export function init<
        * We will expand these methods to other lifecycle methods later.
        */
       method.onBeforeAndAfterCallMapperAdd(function (this: ComponentWithFlowlet) {
-        const activeFlowlet = flowletPusher(this.props);
+        const activeCallFlowlet = flowletPusher(this.props);
         return (value) => {
-          if (activeFlowlet) {
-            flowletManager.pop(activeFlowlet);
+          if (activeCallFlowlet) {
+            flowletManager.pop(activeCallFlowlet);
           }
           return value;
         }
@@ -130,10 +130,10 @@ export function init<
         return;
       }
       fi.onBeforeAndAfterCallMapperAdd(([props]) => {
-        const activeFlowlet = flowletPusher(props);
+        const activeCallFlowlet = flowletPusher(props);
         return (value) => {
-          if (activeFlowlet) {
-            flowletManager.pop(activeFlowlet);
+          if (activeCallFlowlet) {
+            flowletManager.pop(activeCallFlowlet);
           }
           return value;
         }


### PR DESCRIPTION
For clarity, we are renaming flowlet (specifically any flowlet managed using the `FlowletManager` stack, i.e. the filtered async call stack) to call flowlet. This handles renames in Hyperion.