### PR TITLE
Unify the Channel in all options.

### DIFF
--- a/packages/hyperion-autologging-visualizer/src/component/ALSessionGraph.react.tsx
+++ b/packages/hyperion-autologging-visualizer/src/component/ALSessionGraph.react.tsx
@@ -550,7 +550,7 @@ export function ALSessionGraph(): React.JSX.Element {
     // Set up listeners
     const removeListeners: Array<() => void> = [];
     const options = AutoLogging.getInitOptions();
-    const uiChannel = options.uiEventPublisher?.channel;
+    const uiChannel = options.channel;
     const uiEvents: Array<'al_ui_event' | 'al_ui_event_capture' | 'al_ui_event_bubble'> = [
       'al_ui_event',
       // Pretty noisy,  but may be useful to debug
@@ -565,14 +565,14 @@ export function ALSessionGraph(): React.JSX.Element {
         );
       }
     });
-    const surfaceChannel = options.surfaceMutationPublisher?.channel;
+    const surfaceChannel = options.channel;
     const surfaceListener = surfaceChannel?.on('al_surface_mutation_event').add(addEvent);
     if (surfaceListener) {
       removeListeners.push(
         () => surfaceChannel?.removeListener('al_surface_mutation_event', surfaceListener)
       );
     }
-    const heartbeatChannel = options.heartbeat?.channel;
+    const heartbeatChannel = options.channel;
     const heartbeatListener = heartbeatChannel?.on('al_heartbeat_event').add(addEvent);
     if (heartbeatListener) {
       removeListeners.push(
@@ -587,7 +587,7 @@ export function ALSessionGraph(): React.JSX.Element {
     //     () => flowletChannel?.removeListener('al_flowlet_event', flowletListener)
     //   );
     // }
-    const networkChannel = options.network?.channel;
+    const networkChannel = options.channel;
     const networkEvents: Array<'al_network_request' | 'al_network_response'> = [
       'al_network_request',
       'al_network_response',

--- a/packages/hyperion-autologging/src/ALElementValuePublisher.ts
+++ b/packages/hyperion-autologging/src/ALElementValuePublisher.ts
@@ -21,18 +21,16 @@ import { ALElementEvent, ALSharedInitOptions } from "./ALType";
 
 
 import * as ALUIEventPublisher from "./ALUIEventPublisher";
+import { ChannelEventType } from "@hyperion/hyperion-channel";
 
 
 export type InitOptions = Types.Options<
   ALUIEventPublisher.InitOptions &
-  ALSharedInitOptions &
-  {
-    surfaceChannel: ALSurface.InitOptions['channel']
-  }
+  ALSharedInitOptions<ChannelEventType<(ALUIEventPublisher.InitOptions & ALSurface.InitOptions)['channel']>>
 >;
 
 export function publish(options: InitOptions): void {
-  const { channel, surfaceChannel } = options;
+  const { channel } = options;
 
   const changeEvent = options.uiEvents.find(config => config.eventName === 'change');
 
@@ -158,7 +156,7 @@ export function publish(options: InitOptions): void {
     }
   }
 
-  surfaceChannel.addListener('al_surface_mount', surfaceEventData => {
+  channel.addListener('al_surface_mount', surfaceEventData => {
     const surfaceElement = surfaceEventData.element;
     const surface = surfaceEventData.surface;
 

--- a/packages/hyperion-autologging/src/ALNetworkPublisher.ts
+++ b/packages/hyperion-autologging/src/ALNetworkPublisher.ts
@@ -2,13 +2,12 @@
  * Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved.
  */
 
-import { assert } from "@hyperion/hyperion-global";
-import { Channel } from "@hyperion/hyperion-channel/src/Channel";
 import * as IPromise from "@hyperion/hyperion-core/src/IPromise";
 import * as intercept from "@hyperion/hyperion-core/src/intercept";
 import * as IWindow from "@hyperion/hyperion-dom/src/IWindow";
 import * as IXMLHttpRequest from "@hyperion/hyperion-dom/src/IXMLHttpRequest";
 import { getTriggerFlowlet, setTriggerFlowlet } from "@hyperion/hyperion-flowlet/src/TriggerFlowlet";
+import { assert } from "@hyperion/hyperion-global";
 import * as Types from "@hyperion/hyperion-util/src/Types";
 import performanceAbsoluteNow from "@hyperion/hyperion-util/src/performanceAbsoluteNow";
 import * as ALEventIndex from "./ALEventIndex";
@@ -57,12 +56,9 @@ export type ALChannelNetworkEvent = Readonly<{
 }>;
 
 
-type ALChannel = Channel<ALChannelNetworkEvent>;
-
 export type InitOptions = Types.Options<
-  ALSharedInitOptions &
+  ALSharedInitOptions<ALChannelNetworkEvent> &
   {
-    channel: ALChannel;
     /**
      * if provided, only requests that pass the filter function
      * will generate request/response events.

--- a/packages/hyperion-autologging/src/ALSurface.ts
+++ b/packages/hyperion-autologging/src/ALSurface.ts
@@ -4,9 +4,9 @@
 
 'use strict';
 
-import type { Channel } from "@hyperion/hyperion-channel/src/Channel";
 import * as IElement from "@hyperion/hyperion-dom/src/IElement";
 import { Flowlet } from "@hyperion/hyperion-flowlet/src/Flowlet";
+import { assert } from "@hyperion/hyperion-global";
 import * as IReact from "@hyperion/hyperion-react/src/IReact";
 import * as IReactComponent from "@hyperion/hyperion-react/src/IReactComponent";
 import * as IReactElementVisitor from '@hyperion/hyperion-react/src/IReactElementVisitor';
@@ -20,7 +20,6 @@ import * as ALSurfaceContext from "./ALSurfaceContext";
 import type { SurfacePropsExtension } from "./ALSurfacePropsExtension";
 import * as SurfaceProxy from "./ALSurfaceProxy";
 import { ALFlowletEvent, ALMetadataEvent, ALSharedInitOptions } from "./ALType";
-import { assert } from "@hyperion/hyperion-global";
 
 
 export type ALChannelSurfaceEventData = ALMetadataEvent & ALFlowletEvent & Readonly<{
@@ -67,7 +66,6 @@ export type ALChannelSurfaceEvent = Readonly<{
 type DataType = ALFlowletDataType;
 type FlowletType = IALFlowlet;
 type ALChannelEventType = ALChannelSurfaceEvent;
-type ALChannel = Channel<ALChannelEventType>;
 
 
 export type SurfaceComponent = (props:
@@ -86,7 +84,7 @@ export type SurfaceComponent = (props:
 ) => React.ReactElement;
 
 export type InitOptions = Types.Options<
-  ALSharedInitOptions &
+  ALSharedInitOptions<ALChannelEventType> &
   // IReactFlowlet.InitOptions<ALFlowletDataType, FlowletType, FlowletManagerType> &
   // ALIReactFlowlet.InitOptions &
   ALSurfaceContext.InitOptions &
@@ -102,7 +100,6 @@ export type InitOptions = Types.Options<
       IJsxRuntimeModule: IReact.IJsxRuntimeModuleExports;
     };
     domCallFlowletAttributeName?: string;
-    channel: ALChannel;
     enableReactDomPropsExtension?: boolean;
   }
 >;

--- a/packages/hyperion-autologging/src/ALSurfaceMutationPublisher.ts
+++ b/packages/hyperion-autologging/src/ALSurfaceMutationPublisher.ts
@@ -4,7 +4,6 @@
 
 'use strict';
 
-import type { Channel } from "@hyperion/hyperion-channel/src/Channel";
 import * as Types from "@hyperion/hyperion-util/src/Types";
 import performanceAbsoluteNow from '@hyperion/hyperion-util/src/performanceAbsoluteNow';
 import * as ALCustomEvent from "./ALCustomEvent";
@@ -50,8 +49,6 @@ export type ALChannelSurfaceMutationEvent = Readonly<{
 }
 >;
 
-export type ALSurfaceMutationChannel = Channel<ALChannelSurfaceMutationEvent & ALChannelSurfaceEvent & ALCustomEvent.ALChannelCustomEvent>;
-
 type SurfaceInfo = ALSurfaceMutationEventData & Types.Writeable<ALElementEvent> & {
   addTime: number,
 };
@@ -63,9 +60,8 @@ export function getSurfaceMountInfo(surface: string): ALSurfaceMutationEventData
 }
 
 export type InitOptions = Types.Options<
-  ALSharedInitOptions &
+  ALSharedInitOptions<ALChannelSurfaceMutationEvent & ALChannelSurfaceEvent & ALCustomEvent.ALChannelCustomEvent> &
   {
-    channel: ALSurfaceMutationChannel;
     cacheElementReactInfo: boolean;
   }
 >;

--- a/packages/hyperion-autologging/src/ALType.ts
+++ b/packages/hyperion-autologging/src/ALType.ts
@@ -4,8 +4,9 @@
 
 'use strict';
 
+import type { BaseChannelEventType, Channel } from "@hyperion/hyperion-channel/src/Channel";
 import * as Types from "@hyperion/hyperion-util/src/Types";
-import { IALFlowlet, ALFlowletManager } from './ALFlowletManager';
+import { ALFlowletManager, IALFlowlet } from './ALFlowletManager';
 import { ALID } from "./ALID";
 
 export type ALFlowletEvent = Readonly<{
@@ -50,8 +51,9 @@ export type ALReactElementEvent = Readonly<{
   reactComponentStack?: string[] | null;
 }>;
 
-export type ALSharedInitOptions = Types.Options<{
+export type ALSharedInitOptions<ChannelEventType extends BaseChannelEventType = never> = Types.Options<{
   flowletManager: ALFlowletManager;
+  channel: Channel<ChannelEventType>;
 }>;
 
 export type ALElementEvent = Readonly<{

--- a/packages/hyperion-autologging/src/ALUIEventGroupPublisher.ts
+++ b/packages/hyperion-autologging/src/ALUIEventGroupPublisher.ts
@@ -62,7 +62,7 @@ updateInfo(
 );
 
 export type InitOptions = Types.Options<
-  Pick<ALSharedInitOptions, 'flowletManager'>
+  Pick<ALSharedInitOptions<never>, 'flowletManager'>
 >;
 let _options: InitOptions | null = null;
 

--- a/packages/hyperion-autologging/src/ALUIEventPublisher.ts
+++ b/packages/hyperion-autologging/src/ALUIEventPublisher.ts
@@ -5,7 +5,6 @@
 'use strict';
 import type * as Types from "@hyperion/hyperion-util/src/Types";
 
-import { Channel } from "@hyperion/hyperion-channel/src/Channel";
 import { intercept } from "@hyperion/hyperion-core/src/intercept";
 import * as IEvent from "@hyperion/hyperion-dom/src/IEvent";
 import { setTriggerFlowlet } from "@hyperion/hyperion-flowlet/src/TriggerFlowlet";
@@ -78,8 +77,6 @@ type CurrentUIEvent = {
   timedEmitter: TimedTrigger,
 };
 
-type ALChannel = Channel<ALChannelUIEvent>;
-
 type EventHandlerMap = DocumentEventMap;
 
 export type UIEventConfig<T = EventHandlerMap> = {
@@ -95,10 +92,9 @@ export type UIEventConfig<T = EventHandlerMap> = {
 }[keyof T];
 
 export type InitOptions = Types.Options<
-  ALSharedInitOptions &
+  ALSharedInitOptions<ALChannelUIEvent> &
   {
     uiEvents: Array<UIEventConfig>;
-    channel: ALChannel;
   }
 >;
 

--- a/packages/hyperion-react-testapp/src/AutoLoggingWrapper.ts
+++ b/packages/hyperion-react-testapp/src/AutoLoggingWrapper.ts
@@ -48,12 +48,12 @@ export function init() {
 
   AutoLogging.init({
     flowletManager,
+    channel,
     componentNameValidator: testCompValidator,
     flowletPublisher: {
       channel
     },
     triggerFlowlet: {
-      channel,
       enableReactMethodFlowlet: false,
       enableFlowletConstructorTracking: false,
     },
@@ -64,7 +64,6 @@ export function init() {
       IJsxRuntimeModule,
     },
     surface: {
-      channel,
       enableReactDomPropsExtension: false,
     },
     elementText: {
@@ -74,7 +73,6 @@ export function init() {
       },
     },
     uiEventPublisher: {
-      channel,
       uiEvents: [
         {
           eventName: 'click',
@@ -105,11 +103,9 @@ export function init() {
       heartbeatInterval: 30 * 1000
     },
     surfaceMutationPublisher: {
-      channel,
       cacheElementReactInfo: true,
     },
     network: {
-      channel,
       requestFilter: request => !/robots/.test(request.url.toString()),
       requestUrlMarker: (request, params) => {
         const flowlet = FlowletManager.top();


### PR DESCRIPTION
We are preparing to improve the channel and allow much richer set of piping capability.
As first step, unified the channel option for the top init function. This way, the users of the code don't need to pass difference instances of channel to the options.