### PR TITLE
Remove flowlet instances from surface publisher useLayoutEffect depen…

### DIFF
--- a/packages/hyperion-autologging/src/ALSurface.ts
+++ b/packages/hyperion-autologging/src/ALSurface.ts
@@ -355,7 +355,7 @@ export function init(options: InitOptions): ALSurfaceHOC {
           triggerFlowlet: callFlowlet.data.triggerFlowlet
         });
       }
-    }, [domAttributeName, domAttributeValue, callFlowlet, triggerFlowlet, nodeRef]);
+    }, [domAttributeName, domAttributeValue, nodeRef]);
 
 
 


### PR DESCRIPTION
…dencies

These dependences seem to be causing many setup/teardowns of this effect to occur. Any time the triggerFlowlet is changing (e.g. on click) we are seeing mutation events re-occur.

This goes back to the old version prior to #160 that had only the dom* static dependencies.