### PR TITLE
Expose a method to get current active UI event

### DIFF
--- a/packages/hyperion-autologging/src/ALUIEventPublisher.ts
+++ b/packages/hyperion-autologging/src/ALUIEventPublisher.ts
@@ -163,6 +163,11 @@ function getCommonEventData<T extends keyof DocumentEventMap>(eventConfig: UIEve
   };
 }
 
+let lastUIEvent: CurrentUIEvent | null;
+export function getCurrentUIEventData(): ALUIEventData | null | undefined {
+  return lastUIEvent?.data;
+}
+
 /**
  *
  * @param options - Configuration for determining which events to capture and emit events via provided channel.
@@ -173,7 +178,6 @@ function getCommonEventData<T extends keyof DocumentEventMap>(eventConfig: UIEve
 export function publish(options: InitOptions): void {
   const { uiEvents, flowletManager, channel } = options;
 
-  let lastUIEvent: CurrentUIEvent | null;
 
   uiEvents.forEach((eventConfig => {
     const { eventName, cacheElementReactInfo = false } = eventConfig;

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -79,6 +79,7 @@ export default defineConfig({
         "@hyperion/hyperion-autologging/src/ALElementInfo",
         "@hyperion/hyperion-autologging/src/ALInteractableDOMElement",
         "@hyperion/hyperion-autologging/src/AutoLogging",
+        "@hyperion/hyperion-autologging/src/ALUIEventPublisher",
       ]
     },
     chunkFileNames: "[name].js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -72,3 +72,4 @@ export * as AutoLogging from "@hyperion/hyperion-autologging/src/AutoLogging";
 export { ALSurfaceCapability } from "@hyperion/hyperion-autologging/src/ALSurface";
 export * as ALSurfaceUtils from "@hyperion/hyperion-autologging/src/ALSurfaceUtils";
 export * as ALCustomEvent from '@hyperion/hyperion-autologging/src/ALCustomEvent';
+export { getCurrentUIEventData } from "@hyperion/hyperion-autologging/src/ALUIEventPublisher";


### PR DESCRIPTION
In some cases, the application might want to add metadata to the current active ui event (in between capture and bubble). This simple PR exports a function to expose that data.