### PR TITLE
Add hover publisher,  configurable from UI publisher

### DIFF
--- a/packages/hyperion-autologging-visualizer/src/component/ALGraph.ts
+++ b/packages/hyperion-autologging-visualizer/src/component/ALGraph.ts
@@ -160,6 +160,7 @@ export type ALGraphDynamicOptionsType = {
     al_ui_event: {
       click: boolean;
       change: boolean;
+      hover: boolean;
       [key: string]: boolean;
     };
     al_surface_mutation_event: {
@@ -302,7 +303,7 @@ export class ALGraph {
       const { left: undesired, /* right: desired, both: _ */ } = this._elements.diff(this.dynamicOptions.filter);
       /**
        * Note: A bad filter can potentially cause problem later if we just remove the nodes.
-       * For example, if we add multiple nodes (e.g. trigger flowlet nodes) based on absence of one them, we may 
+       * For example, if we add multiple nodes (e.g. trigger flowlet nodes) based on absence of one them, we may
        * get errors for duplicate node addition.
        * So, instead of removing nodes, we just add a class to them that hides them.
        * This way, we can also chose to change the filter later and bring those nodes back (not yet implemented)
@@ -651,6 +652,3 @@ export class ALGraph {
     this.addSurfaceEvent(eventName, eventData);
   }
 }
-
-
-

--- a/packages/hyperion-autologging-visualizer/src/component/ALGraphInfo.react.tsx
+++ b/packages/hyperion-autologging-visualizer/src/component/ALGraphInfo.react.tsx
@@ -46,7 +46,7 @@ const StyleCss = `
 `;
 
 const DefaultOptions: ALGraph.ALGraphDynamicOptionsType = {
-  version: 1,
+  version: 2,
   events: {
     al_ui_event: {
       click: true,

--- a/packages/hyperion-autologging-visualizer/src/component/ALGraphInfo.react.tsx
+++ b/packages/hyperion-autologging-visualizer/src/component/ALGraphInfo.react.tsx
@@ -51,6 +51,7 @@ const DefaultOptions: ALGraph.ALGraphDynamicOptionsType = {
     al_ui_event: {
       click: true,
       change: false,
+      hover: false,
     },
     al_surface_mutation_event: {
       mount_component: false,
@@ -238,7 +239,7 @@ export function ALGraphInfo(props: {
 
   React.useEffect(() => {
     if (graphRef.current) {
-      // The following ensures that later the event handlers will see the latest value. 
+      // The following ensures that later the event handlers will see the latest value.
       graphRef.current.graph.setDynamicOptions(options);
     }
   }, [options]);

--- a/packages/hyperion-autologging/src/ALHoverPublisher.ts
+++ b/packages/hyperion-autologging/src/ALHoverPublisher.ts
@@ -1,0 +1,88 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved.
+ */
+
+'use strict';
+
+import { ChannelEventType } from "@hyperion/hyperion-channel/src/Channel";
+import * as Types from "@hyperion/hyperion-util/src/Types";
+import * as ALEventIndex from "./ALEventIndex";
+import { ALSharedInitOptions } from "./ALType";
+import * as ALUIEventPublisher from "./ALUIEventPublisher";
+import { ALUIEventCaptureData } from "./ALUIEventPublisher";
+import { assert } from "@hyperion/hyperion-global";
+
+
+export type InitOptions = Types.Options<
+  Pick<ALUIEventPublisher.InitOptions, 'uiEvents'> &
+  Pick<ALSharedInitOptions<ChannelEventType<(ALUIEventPublisher.InitOptions)['channel']>>, 'channel'> & {
+    hoverDurationThresholdMS: number;
+  }
+>;
+
+export function publish(options: InitOptions): void {
+  const { channel, uiEvents, hoverDurationThresholdMS } = options;
+
+  const mouseOverConfig = uiEvents.find(e => e.eventName === 'mouseover');
+  assert(mouseOverConfig != null, 'mouseover event must be included in uiEvents config to enable hover.');
+  const clickConfig = uiEvents.find(e => e.eventName === 'click');
+  assert(clickConfig != null, 'click event must be included in uiEvents config to enable hover.');
+
+  let activeHover: ALUIEventCaptureData | null = null;
+  channel.addListener('al_ui_event_capture', eventData => {
+    if (eventData.event === 'mouseover') {
+      if (
+        // Mousing over a new target and the activeHovers targetElement
+        // is now the relatedTarget of the new event.
+        // For mouseover:
+        //    event.target (from hyperion, targetElement) – is the element where the mouse came over.
+        //    event.relatedTarget – is the element from which the mouse came (relatedTarget → target).
+        activeHover?.targetElement === eventData.domEvent?.relatedTarget
+      ) {
+        activeHover != null &&
+          maybeEmitEvent(activeHover, eventData, hoverDurationThresholdMS);
+      }
+      // Set new active hover
+      activeHover = eventData;
+    }
+    // Click should end active hover.
+    // If the click is on an interactable element that contains the hovered element, then finish
+    // the hover event, utilizing the click event timestamp
+    else if (
+      activeHover != null &&
+      eventData.event === 'click' &&
+      // Clicked element (could be exact target or interactable parent) contains the active hover element
+      eventData.element?.contains(activeHover.targetElement)
+    ) {
+      activeHover != null &&
+        maybeEmitEvent(activeHover, eventData, hoverDurationThresholdMS);
+      // Reset the active hover
+      activeHover = null;
+    }
+  });
+
+  function maybeEmitEvent(
+    startEventData: ALUIEventCaptureData,
+    leaveEventData: ALUIEventCaptureData,
+    hoverDurationThresholdMS: number,
+  ): void {
+    const hoverDuration =
+      leaveEventData.eventTimestamp - startEventData.eventTimestamp;
+    if (hoverDuration > hoverDurationThresholdMS) {
+      // Should refine, since it's only assigned from mouseover
+      const domEvent = startEventData.domEvent as MouseEvent;
+      channel.emit('al_ui_event',
+        {
+          ...startEventData,
+          metadata: {
+            ...startEventData.metadata,
+            hover_duration_ms: hoverDuration.toString(),
+          },
+          domEvent: domEvent,
+          eventIndex: ALEventIndex.getNextEventIndex(),
+          event: 'hover',
+        }
+      );
+    }
+  }
+}

--- a/packages/hyperion-autologging/src/ALHoverPublisher.ts
+++ b/packages/hyperion-autologging/src/ALHoverPublisher.ts
@@ -10,7 +10,6 @@ import * as ALEventIndex from "./ALEventIndex";
 import { ALSharedInitOptions } from "./ALType";
 import * as ALUIEventPublisher from "./ALUIEventPublisher";
 import { ALUIEventCaptureData } from "./ALUIEventPublisher";
-import { assert } from "@hyperion/hyperion-global";
 
 
 export type InitOptions = Types.Options<
@@ -22,12 +21,8 @@ export function publish(options: InitOptions): void {
   const { channel, uiEvents } = options;
 
   const mouseOverConfig = uiEvents.find(e => e.eventName === 'mouseover');
-  assert(mouseOverConfig != null, 'mouseover event must be included in uiEvents config to enable hover.');
-  // const clickConfig = uiEvents.find(e => e.eventName === 'click');
-  // assert(clickConfig != null, 'click event must be included in uiEvents config to enable hover.');
-
-  // Won't refine below property durationThresholdToEmitHoverEvent as being available without this check...
-  if (mouseOverConfig.eventName !== 'mouseover') {
+  // Won't refine below property durationThresholdToEmitHoverEvent as being available without eventName check
+  if (mouseOverConfig == null || mouseOverConfig.eventName !== 'mouseover') {
     return;
   }
 
@@ -58,8 +53,8 @@ export function publish(options: InitOptions): void {
     // the hover event, utilizing the click event timestamp
     else if (
       activeHover != null &&
-      eventData.event === 'click' &&
-      // Clicked element (could be exact target or interactable parent) contains the active hover element
+      (eventData.event === 'click' || eventData.event === 'mousedown') &&
+      // Clicked/Mousedown element (could be exact target or interactable parent) contains the active hover element
       eventData.element?.contains(activeHover.targetElement)
     ) {
       activeHover != null &&

--- a/packages/hyperion-autologging/src/ALUIEventPublisher.ts
+++ b/packages/hyperion-autologging/src/ALUIEventPublisher.ts
@@ -19,7 +19,6 @@ import { ReactComponentData } from "./ALReactUtils";
 import { getSurfacePath } from "./ALSurfaceUtils";
 import { ALElementEvent, ALExtensibleEvent, ALFlowletEvent, ALLoggableEvent, ALMetadataEvent, ALPageEvent, ALReactElementEvent, ALSharedInitOptions, ALTimedEvent, Metadata } from "./ALType";
 import * as ALUIEventGroupPublisher from "./ALUIEventGroupPublisher";
-import * as ALHoverPublisher from "./ALHoverPublisher";
 
 
 /**

--- a/packages/hyperion-autologging/src/AutoLogging.ts
+++ b/packages/hyperion-autologging/src/AutoLogging.ts
@@ -25,6 +25,7 @@ import { ALSharedInitOptions } from "./ALType";
 import * as ALUIEventGroupPublishers from "./ALUIEventGroupPublisher";
 import * as ALUIEventPublisher from "./ALUIEventPublisher";
 import * as ALDOMSnapshotPublisher from "./ALDOMSnaptshotPublisher";
+import * as ALHoverPublisher from "./ALHoverPublisher";
 
 /**
  * This type extracts the union of all events types so that external modules
@@ -157,6 +158,11 @@ export function init(options: InitOptions): boolean {
     ALUIEventPublisher.publish({
       ...sharedOptions,
       ...options.uiEventPublisher
+    });
+
+    ALHoverPublisher.publish({
+      ...sharedOptions,
+      ...options.uiEventPublisher,
     });
 
     /**

--- a/packages/hyperion-react-testapp/src/App.tsx
+++ b/packages/hyperion-react-testapp/src/App.tsx
@@ -91,9 +91,11 @@ function App() {
 
     content2={
       // <ResizableSplitView direction='vertical' content1="T2" content2="T3" style={{ backgroundColor: 'red' }}></ResizableSplitView>
+      <>
       <ALGraphView />
-      // <TestDivGrid />s
-      // <ALEventLogger />
+      {/* <TestDivGrid /> */}
+      {/* <ALEventLogger /> */}
+      </>
     }
   />);
 

--- a/packages/hyperion-react-testapp/src/AutoLoggingWrapper.ts
+++ b/packages/hyperion-react-testapp/src/AutoLoggingWrapper.ts
@@ -102,11 +102,8 @@ export function init() {
           eventName: 'mouseover',
           cacheElementReactInfo: true,
           interactableElementsOnly: false,
+          durationThresholdToEmitHoverEvent: 1000,
         },
-        {
-          eventName: 'hover',
-          hoverDurationThresholdMS: 1000,
-        }
       ]
     },
     heartbeat: {

--- a/packages/hyperion-react-testapp/src/AutoLoggingWrapper.ts
+++ b/packages/hyperion-react-testapp/src/AutoLoggingWrapper.ts
@@ -97,6 +97,15 @@ export function init() {
           eventName: 'change',
           cacheElementReactInfo: true,
           interactableElementsOnly: false,
+        },
+        {
+          eventName: 'mouseover',
+          cacheElementReactInfo: true,
+          interactableElementsOnly: false,
+        },
+        {
+          eventName: 'hover',
+          hoverDurationThresholdMS: 1000,
         }
       ]
     },

--- a/packages/hyperion-react-testapp/src/AutoLoggingWrapper.ts
+++ b/packages/hyperion-react-testapp/src/AutoLoggingWrapper.ts
@@ -44,6 +44,8 @@ export function init() {
 
   // Better to first setup listeners before initializing AutoLogging so we don't miss any events (e.g. Heartbeat(START))
 
+
+
   interface ExtendedElementText extends ALElementText {
     isExtended?: boolean;
   }
@@ -129,4 +131,6 @@ export function init() {
       ]
     }
   });
+
+  console.log('AutoLogging.init options:', AutoLogging.getInitOptions());
 }


### PR DESCRIPTION
- This adds an ability to configure `hover` from UI publisher, although there are some differences in that this publisher relies upon `mouseover` (hard reliance),  and `click` (maybe optionally if we want to relax that).

Open to suggestions on how to configure this without complicating the types/reliance on target listener api supported events.
- Ideally this is:
  - configurable as other UI events via init
  - supports additional event-specific configuration
  - could enable underlying events it depends on automatically (wish, doesn't do this yet)
  - not need to match existing target api event configuration

Example in test app:
<img width="1280" alt="image" src="https://github.com/facebook/hyperion/assets/6064408/5054b74f-8e32-4e7b-8436-bcf80c49d4c6">
