### PR TITLE
Convert Surface capability to object instead of bitset

### DIFF
--- a/packages/hyperion-autologging/src/ALElementValuePublisher.ts
+++ b/packages/hyperion-autologging/src/ALElementValuePublisher.ts
@@ -67,6 +67,7 @@ export function publish(options: InitOptions): void {
       domEvent: new CustomEvent('change'),
       isTrusted: false, // We can use this to differnciate between browser events and ours.
       ...elementValueEventData,
+      targetElement: elementValueEventData.element,
       eventIndex: ALEventIndex.getNextEventIndex(),
       eventTimestamp: performanceAbsoluteNow(),
       autoLoggingID: ALID.getOrSetAutoLoggingID(element),

--- a/packages/hyperion-autologging/src/ALElementValuePublisher.ts
+++ b/packages/hyperion-autologging/src/ALElementValuePublisher.ts
@@ -168,7 +168,7 @@ export function publish(options: InitOptions): void {
   }
 
   channel.addListener('al_surface_mount', surfaceEventData => {
-    if (!(surfaceEventData.capability & ALSurface.ALSurfaceCapability.TrackInteraction)) {
+    if (surfaceEventData.capability?.nonInteractive) {
       return; // this is not an interactable surface, so don't even try
     }
 

--- a/packages/hyperion-autologging/src/ALSurface.ts
+++ b/packages/hyperion-autologging/src/ALSurface.ts
@@ -22,9 +22,9 @@ import * as SurfaceProxy from "./ALSurfaceProxy";
 import { ALFlowletEvent, ALMetadataEvent, ALSharedInitOptions } from "./ALType";
 
 
-export type ALChannelSurfaceEventData = ALMetadataEvent & ALFlowletEvent & Readonly<{
+export type ALSurfaceEventData = ALMetadataEvent & ALFlowletEvent & Readonly<{
   surface: string;
-  element: Element | null | undefined;
+  element: Element;
   isProxy: boolean;
   capability: ALSurfaceCapability | null | undefined;
 }>;
@@ -61,8 +61,8 @@ export type ALSurfaceRenderer = (node: React.ReactNode) => React.ReactElement;
 export type ALSurfaceHOC = (props: ALSurfaceProps, renderer?: ALSurfaceRenderer) => ALSurfaceRenderer;
 
 export type ALChannelSurfaceEvent = Readonly<{
-  al_surface_mount: [ALChannelSurfaceEventData];
-  al_surface_unmount: [ALChannelSurfaceEventData];
+  al_surface_mount: [ALSurfaceEventData];
+  al_surface_unmount: [ALSurfaceEventData];
 }>;
 
 type DataType = ALFlowletDataType;
@@ -337,7 +337,7 @@ export function init(options: InitOptions): ALSurfaceHOC {
       element.setAttribute(domAttributeName, domAttributeValue);
       __DEV__ && assert(element != null, "Invalid surface effect without an element: " + surface);
 
-      const event: ALChannelSurfaceEventData = {
+      const event: ALSurfaceEventData = {
         surface: domAttributeValue,
         callFlowlet,
         triggerFlowlet,

--- a/packages/hyperion-autologging/src/ALSurface.ts
+++ b/packages/hyperion-autologging/src/ALSurface.ts
@@ -43,7 +43,7 @@ export interface ALSurfaceCapability {
   trackVisibilityThreshold?: number;
 }
 
-function surfaceCapabilityToString(capability?: ALSurfaceCapability): string {
+function surfaceCapabilityToString(capability?: ALSurfaceCapability | null): string {
   if (!capability) {
     return '';
   }
@@ -256,7 +256,7 @@ export function init(options: InitOptions): ALSurfaceHOC {
     let localRef = ReactModule.useRef<Element>();
 
     // empty .capability field is default, means all enabled!
-    const capability = props.capability;
+    const capability = props.capability ?? proxiedContext?.capability;
 
     if (!proxiedContext) {
       nonInteractiveSurfacePath = (parentNonInteractiveSurface ?? '') + SURFACE_SEPARATOR + surface;
@@ -271,7 +271,7 @@ export function init(options: InitOptions): ALSurfaceHOC {
       }
     } else {
       surfacePath = proxiedContext.surface;
-      nonInteractiveSurfacePath = proxiedContext.nonInteractiveSurface;
+      nonInteractiveSurfacePath = proxiedContext.nonInteractiveSurface;      
       domAttributeName = AUTO_LOGGING_SURFACE
       domAttributeValue = surfacePath;
       if (proxiedContext.container instanceof Element) {
@@ -302,6 +302,7 @@ export function init(options: InitOptions): ALSurfaceHOC {
         callFlowlet,
         domAttributeName,
         domAttributeValue,
+        capability,
       };
       SurfaceDataMap.set(nonInteractiveSurfacePath, surfaceData);
     } else {

--- a/packages/hyperion-autologging/src/ALSurface.ts
+++ b/packages/hyperion-autologging/src/ALSurface.ts
@@ -15,7 +15,7 @@ import * as IReactPropsExtension from "@hyperion/hyperion-react/src/IReactPropsE
 import * as Types from "@hyperion/hyperion-util/src/Types";
 import type * as React from 'react';
 import { ALFlowletDataType, IALFlowlet } from "./ALFlowletManager";
-import { AUTO_LOGGING_NON_INTERACTIVE_SURFACE, AUTO_LOGGING_SURFACE } from './ALSurfaceConsts';
+import { AUTO_LOGGING_NON_INTERACTIVE_SURFACE, AUTO_LOGGING_SURFACE, SURFACE_SEPARATOR, SURFACE_WRAPPER_ATTRIBUTE_NAME } from './ALSurfaceConsts';
 import * as ALSurfaceContext from "./ALSurfaceContext";
 import type { SurfacePropsExtension } from "./ALSurfacePropsExtension";
 import * as SurfaceProxy from "./ALSurfaceProxy";
@@ -36,8 +36,11 @@ export interface ALSurfaceCapability {
    * the following flag is set.
    */
   nonInteractive?: boolean;
-  // TrackVisibility = 1 << 2, // track when mounted surface's visibility changes
-  // TrackBoundingRect = 1 << 3, // Report the size of the bounding rect of the surface on the screen.
+
+  /**
+   * When set, will track when the provided ratio [0,1] of the surface becomes visible
+   */
+  trackVisibilityThreshold?: number;
 }
 
 function surfaceCapabilityToString(capability?: ALSurfaceCapability): string {
@@ -50,7 +53,7 @@ function surfaceCapabilityToString(capability?: ALSurfaceCapability): string {
 export type ALSurfaceProps = Readonly<{
   surface: string;
   metadata?: ALMetadataEvent['metadata'];
-  capability?: ALSurfaceCapability, // a one-hot encoding what the surface can do.
+  capability?: ALSurfaceCapability,
   nodeRef?: React.RefObject<Element | null | undefined>,
 }>;
 
@@ -103,8 +106,6 @@ export type InitOptions = Types.Options<
   }
 >;
 
-const SURFACE_SEPARATOR = "/";
-const SURFACE_WRAPPER_ATTRIBUTE_NAME = "data-surface-wrapper";
 
 class SurfaceDOMString<
   DataType extends ALFlowletDataType,

--- a/packages/hyperion-autologging/src/ALSurfaceConsts.ts
+++ b/packages/hyperion-autologging/src/ALSurfaceConsts.ts
@@ -6,3 +6,5 @@
 
 export const AUTO_LOGGING_SURFACE = "data-surface";
 export const AUTO_LOGGING_NON_INTERACTIVE_SURFACE = "data-non-int-surface";
+export const SURFACE_SEPARATOR = "/";
+export const SURFACE_WRAPPER_ATTRIBUTE_NAME = "data-surface-wrapper";

--- a/packages/hyperion-autologging/src/ALSurfaceContext.ts
+++ b/packages/hyperion-autologging/src/ALSurfaceContext.ts
@@ -8,6 +8,7 @@ import { assert } from '@hyperion/hyperion-global';
 import type * as React from 'react';
 import { IALFlowlet } from './ALFlowletManager';
 import * as Types from "@hyperion/hyperion-util/src/Types";
+import { ALSurfaceCapability } from './ALSurface';
 
 
 export type InitOptions = Types.Options<{
@@ -23,6 +24,7 @@ export type ALSurfaceContextFilledValue = {
   nonInteractiveSurface: string;
   surface: string;
   callFlowlet: IALFlowlet;
+  capability: ALSurfaceCapability | null | undefined;
 };
 
 type ALSurfaceContextValue =
@@ -31,12 +33,14 @@ type ALSurfaceContextValue =
     nonInteractiveSurface: null;
     surface: null;
     callFlowlet: null;
+    capability: null;
   };
 
 const DefaultSurfaceContext: ALSurfaceContextValue = {
   nonInteractiveSurface: null,
   surface: null,
   callFlowlet: null,
+  capability: null,
 };
 
 export let ALSurfaceContext: React.Context<ALSurfaceContextValue> | null = null;

--- a/packages/hyperion-autologging/src/ALSurfaceMutationPublisher.ts
+++ b/packages/hyperion-autologging/src/ALSurfaceMutationPublisher.ts
@@ -12,7 +12,7 @@ import * as ALEventIndex from './ALEventIndex';
 import * as ALID from './ALID';
 import { ALElementTextEvent, getElementTextEvent } from './ALInteractableDOMElement';
 import { ReactComponentData } from './ALReactUtils';
-import type { ALChannelSurfaceEvent, ALChannelSurfaceEventData } from './ALSurface';
+import type { ALChannelSurfaceEvent, ALChannelSurfaceEventData, ALSurfaceCapability } from './ALSurface';
 import { ALElementEvent, ALFlowletEvent, ALLoggableEvent, ALMetadataEvent, ALReactElementEvent, ALSharedInitOptions } from "./ALType";
 
 type ALMutationEvent =
@@ -24,6 +24,7 @@ type ALMutationEvent =
   Readonly<
     {
       surface: string;
+      capability: ALSurfaceCapability | null | undefined
     }
     &
     (

--- a/packages/hyperion-autologging/src/ALSurfaceMutationPublisher.ts
+++ b/packages/hyperion-autologging/src/ALSurfaceMutationPublisher.ts
@@ -12,7 +12,7 @@ import * as ALEventIndex from './ALEventIndex';
 import * as ALID from './ALID';
 import { ALElementTextEvent, getElementTextEvent } from './ALInteractableDOMElement';
 import { ReactComponentData } from './ALReactUtils';
-import type { ALChannelSurfaceEvent, ALChannelSurfaceEventData, ALSurfaceCapability } from './ALSurface';
+import type { ALChannelSurfaceEvent, ALSurfaceEventData, ALSurfaceCapability } from './ALSurface';
 import { ALElementEvent, ALFlowletEvent, ALLoggableEvent, ALMetadataEvent, ALReactElementEvent, ALSharedInitOptions } from "./ALType";
 
 type ALMutationEvent =
@@ -70,7 +70,7 @@ export type InitOptions = Types.Options<
 export function publish(options: InitOptions): void {
   const { channel, flowletManager, cacheElementReactInfo } = options;
 
-  function processNode(event: ALChannelSurfaceEventData, action: 'added' | 'removed') {
+  function processNode(event: ALSurfaceEventData, action: 'added' | 'removed') {
     const timestamp = performanceAbsoluteNow();
     const { element, surface, metadata } = event;
 

--- a/packages/hyperion-autologging/src/ALSurfaceUtils.ts
+++ b/packages/hyperion-autologging/src/ALSurfaceUtils.ts
@@ -4,20 +4,25 @@
 
 'use strict';
 
-import { AUTO_LOGGING_SURFACE } from "./ALSurfaceConsts";
+import { AUTO_LOGGING_SURFACE, SURFACE_WRAPPER_ATTRIBUTE_NAME } from './ALSurfaceConsts';
 
-export function getSurfacePath(node: HTMLElement | null): string| null {
+
+export function getSurfacePath(node: HTMLElement | null): string | null {
   return getAncestralSurfaceNode(node)?.getAttribute(AUTO_LOGGING_SURFACE) ?? null;
 }
 
-export function getAncestralSurfaceNode(node: Element | null): Element| null {
+export function getAncestralSurfaceNode(node: Element | null): Element | null {
   return node?.closest(`[${AUTO_LOGGING_SURFACE}]`) ?? null;
 }
 
-export function getElementSurface(node: Element | null): string| null {
+export function getElementSurface(node: Element | null): string | null {
   return node?.getAttribute(AUTO_LOGGING_SURFACE) ?? null;
 }
 
 export function getElementsWithSurfaces(): NodeListOf<Element> {
   return document.querySelectorAll(`[${AUTO_LOGGING_SURFACE}]`);
+}
+
+export function isSurfaceWrapper(node: HTMLElement): boolean {
+  return node.getAttribute(SURFACE_WRAPPER_ATTRIBUTE_NAME) === '1';
 }

--- a/packages/hyperion-autologging/src/ALSurfaceVisibilityPublisher.ts
+++ b/packages/hyperion-autologging/src/ALSurfaceVisibilityPublisher.ts
@@ -1,0 +1,144 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved.
+ */
+
+'use strict';
+
+import * as Types from "@hyperion/hyperion-util/src/Types";
+import performanceAbsoluteNow from "@hyperion/hyperion-util/src/performanceAbsoluteNow";
+import { ALChannelSurfaceMutationEvent, ALSurfaceMutationEventData } from "./ALSurfaceMutationPublisher";
+import * as ALSurfaceUtils from './ALSurfaceUtils';
+import { ALElementEvent, ALFlowletEvent, ALLoggableEvent, ALMetadataEvent, ALSharedInitOptions } from "./ALType";
+
+import * as ALEventIndex from './ALEventIndex';
+import { assert } from "@hyperion/hyperion-global";
+
+
+export type ALSurfaceVisibilityEventData =
+  ALFlowletEvent &
+  ALMetadataEvent &
+  ALElementEvent &
+  ALLoggableEvent &
+  Readonly<
+    {
+      surface: string;
+      event: 'component_visibility';
+      intersectionEntry: IntersectionObserverEntry;
+    }
+  >;
+
+export type ALChannelSurfaceVisibilityEvent = Readonly<{
+  al_surface_visibility_event: [ALSurfaceVisibilityEventData],
+}
+>;
+
+export type InitOptions = Types.Options<
+  ALSharedInitOptions<ALChannelSurfaceVisibilityEvent & ALChannelSurfaceMutationEvent>
+>;
+
+
+export function publish(options: InitOptions): void {
+  const { channel } = options;
+
+  // lookup surfaces that are mounted by their root element 
+  const activeSurfaces = new Map<Element | null, ALSurfaceMutationEventData>();
+
+  // We need one observer per threshold
+  const observers = new Map<number, IntersectionObserver>();
+
+  channel.addListener('al_surface_mutation_event', event => {
+    switch (event.event) {
+      case 'mount_component': {
+        if (event.capability?.trackVisibilityThreshold) {
+          const observer = getOrCreateObserver(event.capability.trackVisibilityThreshold);
+          const { element } = event;
+          /**
+           * IntersectionObserver cannot track display:content styles because
+           * these elements don't have their own "box".
+           * So, instead we have to focus on the children of the parent element
+           */
+          if (ALSurfaceUtils.isSurfaceWrapper(element)) {
+            for (let el = element.firstElementChild; el; el = el.nextElementSibling) {
+              observer.observe(el);
+            }
+          } else {
+            observer.observe(element);
+          }
+          activeSurfaces.set(element, event);
+        }
+
+        break;
+      }
+      case 'unmount_component': {
+        if (event.capability?.trackVisibilityThreshold) {
+          const observer = getOrCreateObserver(event.capability.trackVisibilityThreshold);
+          const { element } = event;
+          if (ALSurfaceUtils.isSurfaceWrapper(element)) {
+            for (let el = element.firstElementChild; el; el = el.nextElementSibling) {
+              observer.unobserve(el);
+            }
+          } else {
+            observer.unobserve(element);
+          }
+          activeSurfaces.delete(element);
+        }
+        break;
+      }
+    }
+
+    function getOrCreateObserver(threshold: number): IntersectionObserver {
+      let observer = observers.get(threshold);
+      if (!observer) {
+        observer = new IntersectionObserver(
+          (entries: IntersectionObserverEntry[], _observer: IntersectionObserver) => {
+            /**
+             * Since surface may have many children that we added above, we need to merge
+             * all the entries, however, in most cases we may have only one entry
+             */
+            const visibleSet = new Map<ALSurfaceMutationEventData, IntersectionObserverEntry[]>();
+            for (const entry of entries) {
+              if (entry.isIntersecting) {
+                const element = entry.target;
+                const surfaceEvent = activeSurfaces.get(element) ?? activeSurfaces.get(element.parentElement); // element or its parent, see above for .observe(...)
+                if (surfaceEvent) {
+                  let entries = visibleSet.get(surfaceEvent);
+                  if (!entries) {
+                    entries = [];
+                    visibleSet.set(surfaceEvent, entries);
+                  }
+                  entries.push(entry);
+                }
+              }
+            }
+            for (const [surfaceEvent, entries] of visibleSet) {
+              let entry = entries[0];
+              __DEV__ && assert(entry != null, 'Unexpected situation');
+              if (entries.length > 1) {
+                // Need to merge the entries
+                // ??
+                console.warn("Don't know yet how to merge entries!");
+              }
+
+              channel.emit('al_surface_visibility_event', {
+                event: 'component_visibility',
+                eventTimestamp: performanceAbsoluteNow(),
+                eventIndex: ALEventIndex.getNextEventIndex(),
+                relatedEventIndex: surfaceEvent.eventIndex,
+                surface: surfaceEvent.surface,
+                element: surfaceEvent.element,
+                autoLoggingID: surfaceEvent.autoLoggingID, // same element, same ID
+                metadata: {},
+                callFlowlet: surfaceEvent.callFlowlet,
+                triggerFlowlet: surfaceEvent.triggerFlowlet,
+                intersectionEntry: entry,
+              })
+            }
+          },
+          { threshold }
+        );
+        observers.set(threshold, observer);
+      }
+      return observer;
+    }
+  });
+}

--- a/packages/hyperion-autologging/src/ALUIEventPublisher.ts
+++ b/packages/hyperion-autologging/src/ALUIEventPublisher.ts
@@ -33,6 +33,9 @@ type ALUIEvent<T = EventHandlerMap> = ALTimedEvent & ALMetadataEvent & {
     event: K,
     // Element target associated with the domEvent; With interactableElementsOnly, will be the interactable element target.
     element: HTMLElement | null,
+
+    targetElement: HTMLElement | null,
+
     // Whether the event is generated from a user action or dispatched via script
     isTrusted: boolean,
     // The underlying identifier assigned to this element

--- a/packages/hyperion-autologging/src/AutoLogging.ts
+++ b/packages/hyperion-autologging/src/AutoLogging.ts
@@ -19,6 +19,7 @@ import * as ALNetworkPublisher from "./ALNetworkPublisher";
 import { ComponentNameValidator, setComponentNameValidator } from "./ALReactUtils";
 import * as ALSurface from "./ALSurface";
 import * as ALSurfaceMutationPublisher from "./ALSurfaceMutationPublisher";
+import * as ALSurfaceVisibilityPublisher from "./ALSurfaceVisibilityPublisher";
 import * as ALTriggerFlowlet from "./ALTriggerFlowlet";
 import { ALSharedInitOptions } from "./ALType";
 import * as ALUIEventGroupPublishers from "./ALUIEventGroupPublisher";
@@ -34,6 +35,7 @@ export type ALChannelEvent = ChannelEventType<
   ALUIEventPublisher.InitOptions['channel'] &
   ALHeartbeat.InitOptions['channel'] &
   ALSurfaceMutationPublisher.InitOptions['channel'] &
+  ALSurfaceVisibilityPublisher.InitOptions['channel'] &
   ALNetworkPublisher.InitOptions['channel'] &
   ALCustomEvent.ALCustomEventChannel
 >;
@@ -52,6 +54,7 @@ export type InitOptions = Types.Options<
     uiEventPublisher?: PublicInitOptions<ALUIEventPublisher.InitOptions> | null;
     heartbeat?: PublicInitOptions<ALHeartbeat.InitOptions> | null;
     surfaceMutationPublisher?: PublicInitOptions<ALSurfaceMutationPublisher.InitOptions> | null;
+    surfaceVisibilityPublisher?: PublicInitOptions<ALSurfaceVisibilityPublisher.InitOptions> | null;
     network?: PublicInitOptions<ALNetworkPublisher.InitOptions> | null;
     triggerFlowlet?: PublicInitOptions<ALTriggerFlowlet.InitOptions> | null;
   }
@@ -136,6 +139,13 @@ export function init(options: InitOptions): boolean {
 
   if (options.surfaceMutationPublisher) {
     ALSurfaceMutationPublisher.publish({
+      ...sharedOptions,
+      ...options.surfaceMutationPublisher
+    });
+  }
+
+  if (options.surfaceVisibilityPublisher) {
+    ALSurfaceVisibilityPublisher.publish({
       ...sharedOptions,
       ...options.surfaceMutationPublisher
     });

--- a/packages/hyperion-react-testapp/src/AutoLoggingWrapper.ts
+++ b/packages/hyperion-react-testapp/src/AutoLoggingWrapper.ts
@@ -104,6 +104,7 @@ export function init() {
     surfaceMutationPublisher: {
       cacheElementReactInfo: true,
     },
+    surfaceVisibilityPublisher: {},
     network: {
       requestFilter: request => !/robots/.test(request.url.toString()),
       requestUrlMarker: (request, params) => {

--- a/packages/hyperion-react-testapp/src/AutoLoggingWrapper.ts
+++ b/packages/hyperion-react-testapp/src/AutoLoggingWrapper.ts
@@ -99,7 +99,6 @@ export function init() {
       ]
     },
     heartbeat: {
-      channel,
       heartbeatInterval: 30 * 1000
     },
     surfaceMutationPublisher: {

--- a/packages/hyperion-react-testapp/src/component/ALEventLogger.tsx
+++ b/packages/hyperion-react-testapp/src/component/ALEventLogger.tsx
@@ -12,6 +12,7 @@ import { ALFlowletEvent } from "@hyperion/hyperion-autologging/src/ALType";
 const EventsWithFlowlet = [
   'al_ui_event',
   'al_surface_mutation_event',
+  'al_surface_visibility_event',
   'al_network_request',
   'al_network_response',
   'al_flowlet_event',
@@ -60,10 +61,10 @@ function EventField<T extends keyof ALChannelEvent>(props: { eventName: T, onEna
     return () => { SyncChannel.on(eventName).remove(handler); };
   }, [eventName, checked]);
 
-  return <div>
-    <input type="checkbox" id={eventName} onChange={onChange} defaultChecked={checked} ></input>
-    <label htmlFor={eventName}>{eventName}</label>
-  </div>;
+  return <tr>
+    <td><input type="checkbox" id={eventName} onChange={onChange} defaultChecked={checked} ></input></td>
+    <td align="left"><label htmlFor={eventName}>{eventName}</label></td>
+  </tr>;
 }
 
 export default function () {
@@ -71,25 +72,29 @@ export default function () {
 
   return <div>
     <div style={{ display: "flex", justifyContent: "space-around" }}>
-      {
-        EventsWithFlowlet.map(eventName =>
-          <EventField key={eventName} eventName={eventName} onEnable={() => {
-            const handler = SyncChannel.on(eventName).add(ev => {
-              console.log(eventName, ev, performance.now(), ev.flowlet?.getFullName());
-            });
-            return () => SyncChannel.on(eventName).remove(handler);
-          }} />
-        ).concat(
-          EventsWithoutFlowlet.map(eventName =>
+      <table>
+        <tbody>
+        {
+          EventsWithFlowlet.map(eventName =>
             <EventField key={eventName} eventName={eventName} onEnable={() => {
               const handler = SyncChannel.on(eventName).add(ev => {
-                console.log(eventName, ev, performance.now());
+                console.log(eventName, ev, performance.now(), ev.triggerFlowlet?.getFullName());
               });
               return () => SyncChannel.on(eventName).remove(handler);
             }} />
+          ).concat(
+            EventsWithoutFlowlet.map(eventName =>
+              <EventField key={eventName} eventName={eventName} onEnable={() => {
+                const handler = SyncChannel.on(eventName).add(ev => {
+                  console.log(eventName, ev, performance.now());
+                });
+                return () => SyncChannel.on(eventName).remove(handler);
+              }} />
+            )
           )
-        )
-      }
+        }
+        </tbody>
+      </table>
     </div>
     <div>
       <ALSessionGraph />

--- a/packages/hyperion-react-testapp/src/component/DynamicSvgComponent.tsx
+++ b/packages/hyperion-react-testapp/src/component/DynamicSvgComponent.tsx
@@ -14,7 +14,7 @@ function ResultViewer(props: { text: string }) {
     }
   });
 
-  return Surface({ surface: 'result' })(
+  return Surface({ surface: 'result', capability:{trackVisibilityThreshold: .5} })(
     <div ref={ref} style={{ width: "100px" }}></div>
   );
 }

--- a/packages/hyperion-react-testapp/src/component/NestedComponent.tsx
+++ b/packages/hyperion-react-testapp/src/component/NestedComponent.tsx
@@ -39,7 +39,7 @@ export default function AdsSpeedLabAutoLoggingImpl(_props: {}): React.ReactEleme
       <p>Auto Logging Example</p>
       <FuncComponent message={`1st comp: ${count}`}>
         <ClassComponent message={`2nd comp: ${count}`} />
-        {Surface({ surface: 'LocalSub' })(
+        {Surface({ surface: 'LocalSub', capability: {trackVisibilityThreshold: 0.5} })(
           <>
             <ClassComponent message="nested surface" />
             <PortalComponent message='This is portal'></PortalComponent>

--- a/packages/hyperion-react-testapp/src/component/NonInteractiveSurfaceComponent.tsx
+++ b/packages/hyperion-react-testapp/src/component/NonInteractiveSurfaceComponent.tsx
@@ -16,11 +16,11 @@ export default function (_props: {}): React.ReactElement {
   return (
     <SurfaceComp surface='S1'>
       <div>S1</div>
-      <SurfaceComp surface='R1' capability={ALSurfaceCapability.TrackMutation} nodeRef={EMPTY_REF}>
+      <SurfaceComp surface='R1' capability={{nonInteractive: true}} nodeRef={EMPTY_REF}>
         <div>R1 (will not be tracked)</div>
         <SurfaceComp surface='S2'>
           <div>/S1/S2</div>
-          <SurfaceComp surface='R2' capability={ALSurfaceCapability.TrackMutation} nodeRef={refR2}>
+          <SurfaceComp surface='R2' capability={{nonInteractive: true}} nodeRef={refR2}>
             <div ref={refR2}>/S1/R1/S2/R2</div>
           </SurfaceComp>
         </SurfaceComp>

--- a/packages/hyperion-react-testapp/src/component/Surface.tsx
+++ b/packages/hyperion-react-testapp/src/component/Surface.tsx
@@ -19,7 +19,7 @@ let SurfaceRenderer: ALSurface.ALSurfaceHOC = (props, render) => {
 export const Surface = (props: ALSurface.ALSurfaceProps) =>
   AutoLogging.getSurfaceRenderer(SurfaceRenderer)(props, children => (
     <div style={{ border: '1px solid red', marginLeft: '5px' }}>
-      <div style={{ color: props.capability && !(props.capability & ALSurfaceCapability.TrackInteraction) ? 'blue' : 'red' }}>{props.surface}</div>
+      <div style={{ color: props.capability?.nonInteractive ? 'blue' : 'red' }}>{props.surface}</div>
       {children}
     </div>
   ));


### PR DESCRIPTION
We used to have a bitset for surface capability. There were several problems with it:
- FlowJS does not support bit set enums, so it was hard to use it in WWW
- TrackInteraction and TracMutation were sort of redundant. If both were missing, it would have been meaningless to have a surface. We really wanted to know if a surface was interactable or not
- We will need (next commit) more complex options for capability and bit set was not supporting it.

So, this commit simplifies the option (no other logical change) to an object.