### PR TITLE
Capture window.location.href during capture phase of UI event

### DIFF
--- a/packages/hyperion-autologging/src/ALElementValuePublisher.ts
+++ b/packages/hyperion-autologging/src/ALElementValuePublisher.ts
@@ -76,6 +76,7 @@ export function publish(options: InitOptions): void {
       ...elementText,
       reactComponentName: reactComponentData?.name,
       reactComponentStack: reactComponentData?.stack,
+      pageURI: window.location.href,
     });
   }
 

--- a/packages/hyperion-autologging/src/ALType.ts
+++ b/packages/hyperion-autologging/src/ALType.ts
@@ -46,6 +46,11 @@ export type ALLoggableEvent = ALTimedEvent & ALMetadataEvent & Readonly<{
   relatedEventIndex?: number;
 }>;
 
+export type ALPageEvent = {
+  // window.location.href when the event was captured
+  pageURI: string;
+};
+
 export type ALReactElementEvent = Readonly<{
   reactComponentName?: string | null;
   reactComponentStack?: string[] | null;

--- a/packages/hyperion-autologging/src/ALUIEventPublisher.ts
+++ b/packages/hyperion-autologging/src/ALUIEventPublisher.ts
@@ -17,7 +17,7 @@ import { ALID, getOrSetAutoLoggingID } from "./ALID";
 import { ALElementTextEvent, TrackEventHandlerConfig, enableUIEventHandlers, getElementTextEvent, getInteractable, isTrackedEvent } from "./ALInteractableDOMElement";
 import { ReactComponentData } from "./ALReactUtils";
 import { getSurfacePath } from "./ALSurfaceUtils";
-import { ALFlowletEvent, ALLoggableEvent, ALMetadataEvent, ALReactElementEvent, ALSharedInitOptions, ALTimedEvent, Metadata } from "./ALType";
+import { ALFlowletEvent, ALLoggableEvent, ALMetadataEvent, ALPageEvent, ALReactElementEvent, ALSharedInitOptions, ALTimedEvent, Metadata } from "./ALType";
 import * as ALUIEventGroupPublisher from "./ALUIEventGroupPublisher";
 
 
@@ -33,9 +33,8 @@ type ALUIEvent<T = EventHandlerMap> = ALTimedEvent & ALMetadataEvent & {
     event: K,
     // Element target associated with the domEvent; With interactableElementsOnly, will be the interactable element target.
     element: HTMLElement | null,
-
+    // The event.target element,  as opposed to element which represents the interactableElement
     targetElement: HTMLElement | null,
-
     // Whether the event is generated from a user action or dispatched via script
     isTrusted: boolean,
     // The underlying identifier assigned to this element
@@ -48,6 +47,7 @@ export type ALUIEventCaptureData = Readonly<
   ALFlowletEvent &
   ALReactElementEvent &
   ALElementTextEvent &
+  ALPageEvent &
   {
     surface: string | null;
     value?: string;
@@ -64,6 +64,7 @@ export type ALLoggableUIEvent = Readonly<
 >;
 
 export type ALUIEventData = Readonly<
+  ALPageEvent &
   ALLoggableUIEvent
 >;
 
@@ -101,7 +102,7 @@ export type InitOptions = Types.Options<
   }
 >;
 
-type CommonEventData = (ALUIEvent & ALTimedEvent) & {
+type CommonEventData = (ALUIEvent & ALTimedEvent & ALPageEvent) & {
   // The event.target element,  as opposed to element which represents the interactableElement
   targetElement: HTMLElement | null;
   value?: string;
@@ -185,6 +186,7 @@ function getCommonEventData<T extends keyof DocumentEventMap>(eventConfig: UIEve
     autoLoggingID,
     metadata,
     value,
+    pageURI: window.location.href,
   };
 }
 


### PR DESCRIPTION
If we don't capture this as early as possible then there is a chance the action caused a location change and once ultimately logged will have the URI for where the action took the user and not necessarily where the action took place.

Example,  click anything that causes a page transition.  If this lookup is delayed it will get the destination URI and not where the action took place.

Open to naming this something else,  but `windowLocationHref` seemed a bit excessive,  `uri` or `page_uri` may work so long as it's clear where it comes from. 