### PR TITLE
Allow configuring whether to emit initial state for disabled element …

### DIFF
--- a/packages/hyperion-autologging/src/ALElementValuePublisher.ts
+++ b/packages/hyperion-autologging/src/ALElementValuePublisher.ts
@@ -28,7 +28,7 @@ export type InitOptions = Types.Options<
 >;
 
 export function publish(options: InitOptions): void {
-  const { channel, includeInitialDisabledState = false } = options;
+  const { channel } = options;
 
   const changeEvent = options.uiEvents.find(config => config.eventName === 'change');
 
@@ -37,7 +37,12 @@ export function publish(options: InitOptions): void {
     return;
   }
 
-  const { cacheElementReactInfo } = changeEvent;
+  // Won't refine below property includeInitialDisabledState as being available without this check...
+  if (changeEvent.eventName !== 'change') {
+    return;
+  }
+
+  const { cacheElementReactInfo, includeInitialDisabledState } = changeEvent;
 
   /**
    * In most cases, the application may not have 'change' listener. We mainly want to track

--- a/packages/hyperion-autologging/src/ALElementValuePublisher.ts
+++ b/packages/hyperion-autologging/src/ALElementValuePublisher.ts
@@ -100,13 +100,24 @@ export function publish(options: InitOptions): void {
       return null;
     }
 
-    return tryQuery(
-      'input[type=radio][checked], input[type=checkbox], select:has(option[selected])'
-    ) ?? tryQuery(
-      'input[type=radio][checked], input[type=checkbox], select'
-    ) ?? (
-        'input[type=radio], input[type=checkbox], select'
-      );
+    if (includeInitialDisabledState) {
+      // Removes the [checked] for inputs when enabled
+      return tryQuery(
+        'input[type=radio][checked], input[type=checkbox], select:has(option[selected])'
+      ) ?? tryQuery(
+        'input[type=radio][checked], input[type=checkbox], select'
+      ) ?? (
+          'input[type=radio], input[type=checkbox], select'
+        );
+    } else {
+      return tryQuery(
+        'input[type=radio][checked], input[type=checkbox][checked], select:has(option[selected])'
+      ) ?? tryQuery(
+        'input[type=radio][checked], input[type=checkbox][checked], select'
+      ) ?? (
+          'input[type=radio], input[type=checkbox], select'
+        );
+    }
   })();
 
   function trackElementValues(surface: string, surfaceElement: Element) {

--- a/packages/hyperion-autologging/src/ALElementValuePublisher.ts
+++ b/packages/hyperion-autologging/src/ALElementValuePublisher.ts
@@ -24,11 +24,7 @@ import * as ALUIEventPublisher from "./ALUIEventPublisher";
 
 export type InitOptions = Types.Options<
   ALUIEventPublisher.InitOptions &
-  ALSharedInitOptions<ChannelEventType<(ALUIEventPublisher.InitOptions & ALSurface.InitOptions & ALSurfaceMutationPublisher.InitOptions)['channel']>> &
-  {
-    // Whether to enable element_value checked=false events on initial surface mount.
-    includeInitialDisabledState?: boolean;
-  }
+  ALSharedInitOptions<ChannelEventType<(ALUIEventPublisher.InitOptions & ALSurface.InitOptions & ALSurfaceMutationPublisher.InitOptions)['channel']>>
 >;
 
 export function publish(options: InitOptions): void {
@@ -100,9 +96,9 @@ export function publish(options: InitOptions): void {
     }
 
     return tryQuery(
-      'input[type=radio][checked], input[type=checkbox][checked], select:has(option[selected])'
+      'input[type=radio][checked], input[type=checkbox], select:has(option[selected])'
     ) ?? tryQuery(
-      'input[type=radio][checked], input[type=checkbox][checked], select'
+      'input[type=radio][checked], input[type=checkbox], select'
     ) ?? (
         'input[type=radio], input[type=checkbox], select'
       );

--- a/packages/hyperion-autologging/src/ALElementValuePublisher.ts
+++ b/packages/hyperion-autologging/src/ALElementValuePublisher.ts
@@ -24,11 +24,15 @@ import * as ALUIEventPublisher from "./ALUIEventPublisher";
 
 export type InitOptions = Types.Options<
   ALUIEventPublisher.InitOptions &
-  ALSharedInitOptions<ChannelEventType<(ALUIEventPublisher.InitOptions & ALSurface.InitOptions & ALSurfaceMutationPublisher.InitOptions)['channel']>>
+  ALSharedInitOptions<ChannelEventType<(ALUIEventPublisher.InitOptions & ALSurface.InitOptions & ALSurfaceMutationPublisher.InitOptions)['channel']>> &
+  {
+    // Whether to enable element_value checked=false events on initial surface mount.
+    includeInitialDisabledState?: boolean;
+  }
 >;
 
 export function publish(options: InitOptions): void {
-  const { channel } = options;
+  const { channel, includeInitialDisabledState = false } = options;
 
   const changeEvent = options.uiEvents.find(config => config.eventName === 'change');
 
@@ -132,12 +136,12 @@ export function publish(options: InitOptions): void {
              * We know we are lookging for checkbox/radio inputs, so checked is good enough
              * Also, the following check ensures we are not reading PII from other inputs, in case we expand the search
              */
-            if (input.checked) {
+            if (includeInitialDisabledState || input.checked) {
               emitEvent({
                 surface,
                 element,
                 relatedEventIndex,
-                value: 'true',
+                value: String(input.checked),
                 metadata: {
                   type: input.getAttribute('type') ?? '',
                   is_default: "true",

--- a/packages/hyperion-autologging/src/ALUIEventPublisher.ts
+++ b/packages/hyperion-autologging/src/ALUIEventPublisher.ts
@@ -82,27 +82,26 @@ type CurrentUIEvent = {
 
 type EventHandlerMap = DocumentEventMap;
 
-export type UIEventConfig<T = EventHandlerMap> = {
-  [K in keyof T]: Readonly<{
+type UIEventConfigMap = {
+  [K in keyof EventHandlerMap]: Readonly<{
     eventName: K,
     // A callable filter for this event, returning true if the event should be emitted, or false if it should be discarded up front
-    eventFilter?: (domEvent: T[K]) => boolean;
+    eventFilter?: (domEvent: EventHandlerMap[K]) => boolean;
     // Whether to limit to elements that are "interactable", i.e. those that have event handlers registered to the element.  Defaults to true.
     interactableElementsOnly?: boolean;
     // Whether to cache element's react information on capture, defaults to false.
     cacheElementReactInfo?: boolean;
   }>
-}[keyof T];
+};
+
+// Extend UIEventConfig with additional event-specific configuration
+export type UIEventConfig = UIEventConfigMap[keyof Omit<EventHandlerMap, 'change'>]
+  | (UIEventConfigMap['change'] & { includeInitialDisabledState?: boolean });
 
 export type InitOptions = Types.Options<
   ALSharedInitOptions<ALChannelUIEvent> &
   {
     uiEvents: Array<UIEventConfig>;
-  } &
-  // For ALElementValuePublisher,  temp to experiment collecting default disabled state for change events
-  {
-    // Whether to enable element_value checked=false events on initial surface mount.
-    includeInitialDisabledState?: boolean;
   }
 >;
 
@@ -129,7 +128,7 @@ const activeUIEventFlowlets = new Map<UIEventConfig['eventName'], IALFlowlet>();
 
 const uiEventFlowletManager = new ALFlowletManager();
 
-function getCommonEventData<T extends keyof DocumentEventMap>(eventConfig: UIEventConfig<DocumentEventMap>, eventName: T, event: DocumentEventMap[T]): CommonEventData | null {
+function getCommonEventData<T extends keyof DocumentEventMap>(eventConfig: UIEventConfig, eventName: T, event: DocumentEventMap[T]): CommonEventData | null {
   const eventTimestamp = performanceAbsoluteNow();
 
   const { eventFilter, interactableElementsOnly = true } = eventConfig;

--- a/packages/hyperion-autologging/src/ALUIEventPublisher.ts
+++ b/packages/hyperion-autologging/src/ALUIEventPublisher.ts
@@ -98,6 +98,11 @@ export type InitOptions = Types.Options<
   ALSharedInitOptions<ALChannelUIEvent> &
   {
     uiEvents: Array<UIEventConfig>;
+  } &
+  // For ALElementValuePublisher,  temp to experiment collecting default disabled state for change events
+  {
+    // Whether to enable element_value checked=false events on initial surface mount.
+    includeInitialDisabledState?: boolean;
   }
 >;
 


### PR DESCRIPTION
…value events

By default we only emit events for `checked=true`,  however there are some cases where the default values when disabled are useful for understanding flows.