### PR TITLE
DOM Snapshot publisher

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -4,21 +4,21 @@
   // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
   "version": "0.2.0",
   "configurations": [
-    {
-      "name": "Launch Program",
-      "type": "pwa-node",
-      "request": "launch",
-      "skipFiles": [
-        "<node_internals>/**"
-      ],
-      "program": "${workspaceFolder}\\packages\\hyperion-core\\test\\ShadowPrototype.ts",
-      "runtimeArgs": [
-        "--preserve-symlinks"
-      ],
-      "outFiles": [
-        "${workspaceFolder}/**/*.js"
-      ]
-    },
+    // {
+    //   "name": "Launch Program",
+    //   "type": "pwa-node",
+    //   "request": "launch",
+    //   "skipFiles": [
+    //     "<node_internals>/**"
+    //   ],
+    //   "program": "${workspaceFolder}\\packages\\hyperion-core\\test\\ShadowPrototype.ts",
+    //   "runtimeArgs": [
+    //     "--preserve-symlinks"
+    //   ],
+    //   "outFiles": [
+    //     "${workspaceFolder}/**/*.js"
+    //   ]
+    // },
     {
       "name": "Debug Jest Tests",
       "type": "node",
@@ -28,8 +28,8 @@
       // "cwd": "${workspaceRoot}/packages/hyperion-devtools",
       // "cwd": "${workspaceRoot}/packages/hyperion-global",
       // "cwd": "${workspaceRoot}/packages/hyperion-hook",
-      "cwd": "${workspaceRoot}/packages/hyperion-channel",
-      // "cwd": "${workspaceRoot}/packages/hyperion-autologging",
+      // "cwd": "${workspaceRoot}/packages/hyperion-channel",
+      "cwd": "${workspaceRoot}/packages/hyperion-autologging",
       // "cwd": "${workspaceRoot}/packages/hyperion-core",
       // "cwd": "${workspaceRoot}/packages/hyperion-dom",
       // "cwd": "${workspaceRoot}/packages/hyperion-flowlet",

--- a/packages/hyperion-autologging/src/ALCustomEvent.ts
+++ b/packages/hyperion-autologging/src/ALCustomEvent.ts
@@ -15,7 +15,7 @@ export type ALCustomEventData =
   ALMetadataEvent &
   ALOptionalFlowletEvent &
   ALTimedEvent &
-  Partial<ALLoggableEvent> & Readonly<{
+  ALLoggableEvent & Readonly<{
     event: 'custom';
   }>;
 
@@ -25,15 +25,16 @@ export type ALChannelCustomEvent = Readonly<{
 
 export type ALCustomEventChannel = Channel<ALChannelCustomEvent>;
 
-export function emitALCustomEvent<T extends ALFlowletDataType>(channel: ALCustomEventChannel, flowletManager: ALFlowletManager<T>, metadata: ALMetadataEvent['metadata'], nonLoggable?: boolean): ALCustomEventData {
+export function emitALCustomEvent<T extends ALFlowletDataType>(channel: ALCustomEventChannel, flowletManager: ALFlowletManager<T>, metadata: ALMetadataEvent['metadata'], eventData?: Partial<Pick<ALCustomEventData, 'eventIndex' | 'relatedEventIndex'>>): ALCustomEventData {
   const callFlowlet = flowletManager.top();
   const event: ALCustomEventData = {
     event: 'custom',
     eventTimestamp: performanceAbsoluteNow(),
-    eventIndex: nonLoggable ? void 0 : ALEventIndex.getNextEventIndex(),
+    eventIndex: eventData?.eventIndex ?? ALEventIndex.getNextEventIndex(),
     callFlowlet,
     triggerFlowlet: callFlowlet?.data.triggerFlowlet,
-    metadata
+    metadata,
+    ...eventData,
   }
   channel.emit('al_custom_event', event);
   return event;

--- a/packages/hyperion-autologging/src/ALDOMSnaptshotPublisher.ts
+++ b/packages/hyperion-autologging/src/ALDOMSnaptshotPublisher.ts
@@ -18,8 +18,10 @@ type TrackingChannels = (ALUIEventPublisher.InitOptions & ALSurfaceVisibilityPub
 type TrackingEvents = ChannelEventType<TrackingChannels>;
 type TrackingEventNames = (keyof TrackingEvents) & ('al_ui_event' | 'al_surface_visibility_event'); // & is added to ensure the event names are a correct subset
 
+export type ALChannelDOMSnapshotPublisherEvent = ChannelEventType<TrackingChannels & ALCustomEventChannel>;
+
 export type InitOptions = Types.Options<
-  ALSharedInitOptions<ChannelEventType<TrackingChannels & ALCustomEventChannel>>
+  ALSharedInitOptions<ALChannelDOMSnapshotPublisherEvent>
   & {
     eventConfig: (TrackingEventNames)[];
   }
@@ -62,7 +64,7 @@ export function publish(options: InitOptions): void {
       }
     );
     eventData.metadata.snapshot_event_index = '' + customEvent.eventIndex;
-    setEventExtension(eventData, 'autologging', {snapshot});
+    setEventExtension(eventData, 'autologging', { snapshot });
   }
 
   options.eventConfig.forEach(eventName => {

--- a/packages/hyperion-autologging/src/ALDOMSnaptshotPublisher.ts
+++ b/packages/hyperion-autologging/src/ALDOMSnaptshotPublisher.ts
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved.
+ */
+
+'use strict';
+
+
+import { ChannelEventType } from "@hyperion/hyperion-channel/src/Channel";
+import * as Types from "@hyperion/hyperion-util/src/Types";
+import { ALSharedInitOptions } from "./ALType";
+import * as ALUIEventPublisher from "./ALUIEventPublisher";
+import { ALCustomEventChannel, emitALCustomEvent } from "./ALCustomEvent";
+
+
+
+export type InitOptions = Types.Options<
+  ALSharedInitOptions<ChannelEventType<(ALUIEventPublisher.InitOptions)['channel'] & ALCustomEventChannel>>
+// Later we can add config similar to UIEventPublisher to better control snapshiots
+>;
+
+export function publish(options: InitOptions): void {
+  const { channel, flowletManager } = options;
+
+  function copyNodeStyle(sourceNode: HTMLElement, targetNode: HTMLElement) {
+    const computedStyle = window.getComputedStyle(sourceNode);
+    Array.from(computedStyle).forEach(key => targetNode.style.setProperty(key, computedStyle.getPropertyValue(key), computedStyle.getPropertyPriority(key)))
+  }
+  function getSnapshot<T extends Node>(node: T): T {
+    const clone = node.cloneNode() as T;
+    if (clone instanceof HTMLElement && node instanceof HTMLElement) {
+      copyNodeStyle(node, clone);
+      for (let child = node.firstChild; child; child = child.nextSibling) {
+        clone.appendChild(getSnapshot(child));
+      }
+    }
+    return clone;
+  }
+
+  channel.addListener('al_ui_event', eventData => {
+    const { event, element } = eventData;
+    if (event !== 'click' || !element) {
+      return;
+    }
+
+    const clone = getSnapshot(element);
+    const snapshot = clone.outerHTML;
+    const customEvent = emitALCustomEvent(
+      channel,
+      flowletManager,
+      {
+        event_name: "dom_snapshot",
+        snapshot,
+      },
+      {
+        relatedEventIndex: eventData.eventIndex,
+      }
+    );
+    eventData.metadata.snapshot_event_index = '' + customEvent.eventIndex;
+    eventData.metadata.snapshot = snapshot
+  });
+} 

--- a/packages/hyperion-autologging/src/ALEventExtension.ts
+++ b/packages/hyperion-autologging/src/ALEventExtension.ts
@@ -4,13 +4,13 @@
 
 'use strict';
 
-import { ALExtensibleEvent } from "./ALType";
+import { ALExtensibleEvent, ALExtensibleEventData } from "./ALType";
 
-export function getEventExtension<T extends { [key: string]: any } = { [key: string]: any }>(eventData: ALExtensibleEvent, namespace: string): T | undefined {
+export function getEventExtension<T extends ALExtensibleEventData = ALExtensibleEventData>(eventData: ALExtensibleEvent, namespace: string): T | undefined {
   return eventData.__ext?.[namespace] as T;
 }
 
-export function setEventExtension(eventData: ALExtensibleEvent, namespace: string, data: { [key: string]: any }) {
+export function setEventExtension(eventData: ALExtensibleEvent, namespace: string, data: ALExtensibleEventData) {
   eventData.__ext ??= {};
   const namespaceData = eventData.__ext[namespace] ??= {};
   Object.assign(namespaceData, data);

--- a/packages/hyperion-autologging/src/ALEventExtension.ts
+++ b/packages/hyperion-autologging/src/ALEventExtension.ts
@@ -1,0 +1,18 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved.
+ */
+
+'use strict';
+
+import { ALExtensibleEvent } from "./ALType";
+
+export function getEventExtension<T extends { [key: string]: any } = { [key: string]: any }>(eventData: ALExtensibleEvent, namespace: string): T | undefined {
+  return eventData.__ext?.[namespace] as T;
+}
+
+export function setEventExtension(eventData: ALExtensibleEvent, namespace: string, data: { [key: string]: any }) {
+  eventData.__ext ??= {};
+  const namespaceData = eventData.__ext[namespace] ??= {};
+  Object.assign(namespaceData, data);
+}
+

--- a/packages/hyperion-autologging/src/ALSurfaceVisibilityPublisher.ts
+++ b/packages/hyperion-autologging/src/ALSurfaceVisibilityPublisher.ts
@@ -8,7 +8,7 @@ import * as Types from "@hyperion/hyperion-util/src/Types";
 import performanceAbsoluteNow from "@hyperion/hyperion-util/src/performanceAbsoluteNow";
 import { ALChannelSurfaceMutationEvent, ALSurfaceMutationEventData } from "./ALSurfaceMutationPublisher";
 import * as ALSurfaceUtils from './ALSurfaceUtils';
-import { ALElementEvent, ALFlowletEvent, ALLoggableEvent, ALMetadataEvent, ALSharedInitOptions } from "./ALType";
+import { ALElementEvent, ALExtensibleEvent, ALFlowletEvent, ALLoggableEvent, ALMetadataEvent, ALSharedInitOptions } from "./ALType";
 
 import * as ALEventIndex from './ALEventIndex';
 import { assert } from "@hyperion/hyperion-global";
@@ -18,6 +18,7 @@ import * as ALSurfaceMutationPublisher from "./ALSurfaceMutationPublisher";
 export type ALSurfaceVisibilityEventData =
   ALFlowletEvent &
   ALMetadataEvent &
+  ALExtensibleEvent &
   ALElementEvent &
   ALLoggableEvent &
   Readonly<
@@ -45,7 +46,7 @@ export function publish(options: InitOptions): void {
   // lookup surfaces that are mounted by their root element 
   type SurfaceName = string;
   const activeSurfaces = new Map<SurfaceName, ALSurfaceMutationEventData>();
-  const observedRoots = new Map<Element|null, SurfaceName>();
+  const observedRoots = new Map<Element | null, SurfaceName>();
 
   // We need one observer per threshold
   const observers = new Map<number, IntersectionObserver>();
@@ -83,7 +84,7 @@ export function publish(options: InitOptions): void {
           if (ALSurfaceUtils.isSurfaceWrapper(element)) {
             for (let el = element.firstElementChild; el; el = el.nextElementSibling) {
               observer.unobserve(el);
-            observedRoots.delete(el);
+              observedRoots.delete(el);
             }
           } else {
             observer.unobserve(element);

--- a/packages/hyperion-autologging/src/ALType.ts
+++ b/packages/hyperion-autologging/src/ALType.ts
@@ -27,8 +27,21 @@ export type Metadata = {
 };
 
 export type ALMetadataEvent = Readonly<{
+  /**
+   * Extended data do be logged along with the event payload later
+   */
   metadata: Metadata;
 }>;
+
+export type ALExtensibleEvent = {
+  /**
+   * Temporary data that application might want to attach to 
+   * event payload but will be dropped when logging or serializing.
+   * The data must be organized with namespaces to avoid collision
+   */
+  __ext?: { [namespace: string]: { [key: string]: any } };
+};
+
 
 /**
  * Generally we will have publishers that generate various events.
@@ -62,6 +75,9 @@ export type ALSharedInitOptions<ChannelEventType extends BaseChannelEventType = 
 }>;
 
 export type ALElementEvent = Readonly<{
+  // Element associated with the event, usually the root of a sub-tree, an interactable target element, or domEvent.target
   element: HTMLElement;
+
+  // The underlying identifier assigned to this element
   autoLoggingID: ALID;
 }>;

--- a/packages/hyperion-autologging/src/ALType.ts
+++ b/packages/hyperion-autologging/src/ALType.ts
@@ -33,13 +33,14 @@ export type ALMetadataEvent = Readonly<{
   metadata: Metadata;
 }>;
 
+export type ALExtensibleEventData = { [key: string]: any };
 export type ALExtensibleEvent = {
   /**
    * Temporary data that application might want to attach to 
    * event payload but will be dropped when logging or serializing.
    * The data must be organized with namespaces to avoid collision
    */
-  __ext?: { [namespace: string]: { [key: string]: any } };
+  __ext?: { [namespace: string]: ALExtensibleEventData };
 };
 
 

--- a/packages/hyperion-autologging/src/ALUIEventPublisher.ts
+++ b/packages/hyperion-autologging/src/ALUIEventPublisher.ts
@@ -17,7 +17,7 @@ import { ALID, getOrSetAutoLoggingID } from "./ALID";
 import { ALElementTextEvent, TrackEventHandlerConfig, enableUIEventHandlers, getElementTextEvent, getInteractable, isTrackedEvent } from "./ALInteractableDOMElement";
 import { ReactComponentData } from "./ALReactUtils";
 import { getSurfacePath } from "./ALSurfaceUtils";
-import { ALFlowletEvent, ALLoggableEvent, ALMetadataEvent, ALPageEvent, ALReactElementEvent, ALSharedInitOptions, ALTimedEvent, Metadata } from "./ALType";
+import { ALElementEvent, ALExtensibleEvent, ALFlowletEvent, ALLoggableEvent, ALMetadataEvent, ALPageEvent, ALReactElementEvent, ALSharedInitOptions, ALTimedEvent, Metadata } from "./ALType";
 import * as ALUIEventGroupPublisher from "./ALUIEventGroupPublisher";
 
 
@@ -25,22 +25,28 @@ import * as ALUIEventGroupPublisher from "./ALUIEventGroupPublisher";
  * Generates a union type of all handler event and domEvent permutations.
  * e.g. {domEvent: KeyboardEvent, event: 'keydown', ...}
  */
-type ALUIEvent<T = EventHandlerMap> = ALTimedEvent & ALMetadataEvent & {
-  [K in keyof T]: Readonly<{
-    // The typed domEvent associated with the event we are capturing
-    domEvent: T[K],
-    // Event we are capturing
-    event: K,
-    // Element target associated with the domEvent; With interactableElementsOnly, will be the interactable element target.
-    element: HTMLElement | null,
-    // The event.target element,  as opposed to element which represents the interactableElement
+type ALUIEvent<T = EventHandlerMap> =
+  ALTimedEvent &
+  ALMetadataEvent &
+  ALExtensibleEvent &
+  Types.Nullable<ALElementEvent> &
+  {
+    /**
+     * .element field could be either target associated with the domEvent; With interactableElementsOnly, the interactable element target.
+     * .targetElement is the event.target element, as opposed to .element which could represent the interactableElement
+     */
     targetElement: HTMLElement | null,
-    // Whether the event is generated from a user action or dispatched via script
-    isTrusted: boolean,
-    // The underlying identifier assigned to this element
-    autoLoggingID: ALID | null,
-  }>
-}[keyof T];
+  } &
+  {
+    [K in keyof T]: Readonly<{
+      // The typed domEvent associated with the event we are capturing
+      domEvent: T[K],
+      // Event we are capturing
+      event: K,
+      // Whether the event is generated from a user action or dispatched via script
+      isTrusted: boolean,
+    }>
+  }[keyof T];
 
 export type ALUIEventCaptureData = Readonly<
   ALUIEvent &

--- a/packages/hyperion-autologging/src/AutoLogging.ts
+++ b/packages/hyperion-autologging/src/AutoLogging.ts
@@ -24,6 +24,7 @@ import * as ALTriggerFlowlet from "./ALTriggerFlowlet";
 import { ALSharedInitOptions } from "./ALType";
 import * as ALUIEventGroupPublishers from "./ALUIEventGroupPublisher";
 import * as ALUIEventPublisher from "./ALUIEventPublisher";
+import * as ALDOMSnapshotPublisher from "./ALDOMSnaptshotPublisher";
 
 /**
  * This type extracts the union of all events types so that external modules
@@ -57,6 +58,7 @@ export type InitOptions = Types.Options<
     surfaceVisibilityPublisher?: PublicInitOptions<ALSurfaceVisibilityPublisher.InitOptions> | null;
     network?: PublicInitOptions<ALNetworkPublisher.InitOptions> | null;
     triggerFlowlet?: PublicInitOptions<ALTriggerFlowlet.InitOptions> | null;
+    domSnapshotPublisher?: PublicInitOptions<ALDOMSnapshotPublisher.InitOptions> | null;
   }
 >;
 
@@ -180,6 +182,13 @@ export function init(options: InitOptions): boolean {
       ...sharedOptions,
       ...options.network
     });
+  }
+
+  if (options.domSnapshotPublisher) {
+    ALDOMSnapshotPublisher.publish({
+      ...sharedOptions,
+      ...options.domSnapshotPublisher
+    })
   }
 
   cachedResults = {

--- a/packages/hyperion-autologging/test/ALDOMSnapshotPublisher.test.ts
+++ b/packages/hyperion-autologging/test/ALDOMSnapshotPublisher.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved.
+ *
+ * @jest-environment jsdom
+ */
+
+import "jest";
+
+import { Channel } from "@hyperion/hyperion-channel/src/Channel";
+import { ALFlowletManager } from "../src/ALFlowletManager";
+import * as ALUIEventPublisher from "../src/ALUIEventPublisher";
+import * as DomFragment from "./DomFragment";
+import * as  ALDOMSnapshotPublisher from "../src/ALDOMSnaptshotPublisher";
+import { ALChannelCustomEvent } from "../src/ALCustomEvent";
+
+describe("dom snapshot publisher", () => {
+  test("dom snapshot taken for clicks", (done) => {
+    const flowletManager = new ALFlowletManager();
+
+    const channel = new Channel<ALDOMSnapshotPublisher.ALChannelDOMSnapshotPublisherEvent>();
+
+    ALUIEventPublisher.publish({
+      flowletManager,
+      channel,
+      uiEvents: [
+        {
+          cacheElementReactInfo: true,
+          eventName: 'click',
+        }
+      ]
+    });
+    ALDOMSnapshotPublisher.publish({
+      flowletManager,
+      channel,
+      eventConfig: ['al_ui_event'],
+    })
+
+    let uiEventData;
+
+    channel.addListener('al_ui_event', event => {
+      uiEventData = event;
+    });
+
+    const dom = DomFragment.html(`
+  <div id='1' onclick="void 0;">
+    <span id='2'>"test2"</span>
+  </div>
+`);
+
+    channel.addListener('al_custom_event', eventData => {
+      if (eventData.metadata.event_name === 'dom_snapshot') {
+        const snapshot = eventData.metadata.snapshot;
+        expect(snapshot).toMatch(/div id=.1/);
+        expect(snapshot).toMatch(/span id=.2/);
+        done();
+      }
+    });
+
+
+    const event = new MouseEvent('click', { bubbles: true });
+    document.getElementById("2")?.dispatchEvent(event);
+
+  });
+});

--- a/packages/hyperion-react-testapp/src/AutoLoggingWrapper.ts
+++ b/packages/hyperion-react-testapp/src/AutoLoggingWrapper.ts
@@ -113,6 +113,15 @@ export function init() {
           params.set('flowlet', flowlet.getFullName());
         }
       }
+    },
+    domSnapshotPublisher: {
+    }
+  });
+  channel.on('al_ui_event').add(eventData => {
+    if (eventData.event === 'click' && eventData.metadata.snapshot) {
+      const div = document.createElement('div');
+      div.innerHTML = eventData.metadata.snapshot;
+      document.body.appendChild(div);
     }
   });
 

--- a/packages/hyperion-react-testapp/src/AutoLoggingWrapper.ts
+++ b/packages/hyperion-react-testapp/src/AutoLoggingWrapper.ts
@@ -13,7 +13,7 @@ import * as ReactDOM from "react-dom";
 import ReactDev from "react/jsx-dev-runtime";
 import { SyncChannel } from "./Channel";
 import { FlowletManager } from "./FlowletManager";
-import { ALExtensibleEvent, ALMetadataEvent } from "@hyperion/hyperion-autologging/src/ALType";
+import { ALExtensibleEvent } from "@hyperion/hyperion-autologging/src/ALType";
 import { getEventExtension } from "@hyperion/hyperion-autologging/src/ALEventExtension";
 
 export let interceptionStatus = "disabled";

--- a/packages/hyperion-react-testapp/src/AutoLoggingWrapper.ts
+++ b/packages/hyperion-react-testapp/src/AutoLoggingWrapper.ts
@@ -13,6 +13,8 @@ import * as ReactDOM from "react-dom";
 import ReactDev from "react/jsx-dev-runtime";
 import { SyncChannel } from "./Channel";
 import { FlowletManager } from "./FlowletManager";
+import { ALExtensibleEvent, ALMetadataEvent } from "@hyperion/hyperion-autologging/src/ALType";
+import { getEventExtension } from "@hyperion/hyperion-autologging/src/ALEventExtension";
 
 export let interceptionStatus = "disabled";
 
@@ -115,14 +117,23 @@ export function init() {
       }
     },
     domSnapshotPublisher: {
+      eventConfig: [
+        'al_ui_event',
+        'al_surface_visibility_event'
+      ]
     }
   });
-  channel.on('al_ui_event').add(eventData => {
-    if (eventData.event === 'click' && eventData.metadata.snapshot) {
+
+  // Temp code to test snapshot
+  function showEventSnapshot(eventData: ALExtensibleEvent) {
+    const snapshot = getEventExtension(eventData, 'autologging')?.snapshot;
+    if (typeof snapshot === 'string') {
       const div = document.createElement('div');
-      div.innerHTML = eventData.metadata.snapshot;
+      div.innerHTML = snapshot;
       document.body.appendChild(div);
     }
-  });
+  }
+  channel.on('al_ui_event').add(showEventSnapshot);
+  channel.on('al_surface_visibility_event').add(showEventSnapshot);
 
 }

--- a/packages/hyperion-util/src/Types.ts
+++ b/packages/hyperion-util/src/Types.ts
@@ -13,3 +13,4 @@ export type Options<Options extends [...any[]] | {}> = Beautify<
 >;
 
 export type Writeable<T> = { -readonly [P in keyof T]: T[P] };
+export type Nullable<T> = { readonly [P in keyof T]: T[P] | null };

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -70,6 +70,7 @@ export default defineConfig({
         "@hyperion/hyperion-react/src/IReactComponent",
       ],
       "hyperionAutoLogging": [
+        "@hyperion/hyperion-autologging/src/ALEventExtension",
         "@hyperion/hyperion-autologging/src/ALCustomEvent",
         "@hyperion/hyperion-autologging/src/ALFlowletManager",
         "@hyperion/hyperion-autologging/src/ALSurface",

--- a/src/index.ts
+++ b/src/index.ts
@@ -73,3 +73,4 @@ export { ALSurfaceCapability } from "@hyperion/hyperion-autologging/src/ALSurfac
 export * as ALSurfaceUtils from "@hyperion/hyperion-autologging/src/ALSurfaceUtils";
 export * as ALCustomEvent from '@hyperion/hyperion-autologging/src/ALCustomEvent';
 export { getCurrentUIEventData } from "@hyperion/hyperion-autologging/src/ALUIEventPublisher";
+export * as ALEventExtension from "@hyperion/hyperion-autologging/src/ALEventExtension";


### PR DESCRIPTION
Added logic to add the snapshot of the DOM node that user clicked on. This can be used by tools to have a visual representation of the UI element clicked on.