### PR TITLE
Enable split view between graph and graph info

### DIFF
--- a/packages/hyperion-autologging-visualizer/src/component/ALGraphInfo.react.tsx
+++ b/packages/hyperion-autologging-visualizer/src/component/ALGraphInfo.react.tsx
@@ -7,6 +7,7 @@ import cytoscape from 'cytoscape';
 import React, { useState } from "react";
 import * as ALGraph from "./ALGraph";
 import { LocalStoragePersistentData } from "@hyperion/hyperion-util/src/PersistentData";
+import ResizableSplitViewReact from "./ResizableSplitView.react";
 
 const StyleCss = `
 .al-graph-grid-container {
@@ -17,8 +18,9 @@ const StyleCss = `
     'events events edges edges edges'
     'filter filter filter filter filter'
     'control control control control control'
-    'main main main main info';
+    'main main main main main';
   grid-template-columns: 20% 20% 20% 20% 20%;
+  grid-template-rows: repeat(5, fit-content(40%)) auto;
   gap: 10px;
   padding: 10px;
   height: 100%;
@@ -37,6 +39,8 @@ const StyleCss = `
 .al-graph-control { grid-area: control; display: flex; justify-content: space-around; }
 .al-graph-main { grid-area: main; }
 .al-graph-info { grid-area: info; }
+.al-graph-main-content { width: 100%; height: 100%}
+.al-graph-main-info { height: 100%}
 
 .al-graph-filter > input {width: 80%;}
 `;
@@ -242,7 +246,7 @@ export function ALGraphInfo(props: {
   return (
     <div ref={gridContainer} style={{
       width: props.width || "99%",
-      // height: props.height || "1000px",
+      height: props.height || "1000px",
     }}>
       <style>{StyleCss}</style>
       <div className="al-graph-grid-container">
@@ -339,8 +343,10 @@ export function ALGraphInfo(props: {
             Take Graph Snapshot
           </button>
         </div>
-        <div className="al-graph-main" ref={graphContainer} style={{ height: props.height }}></div>
-        <div className="al-graph-info">{eventInfo != null ? renderer(eventInfo) : null}</div>
+        <ResizableSplitViewReact direction="horizontal" className="al-graph-main" style={{ height: "95%" }}
+          content1={<div className="al-graph-main-content" ref={graphContainer}></div>}
+          content2={<div className="al-graph-main-info">{eventInfo != null ? renderer(eventInfo) : null}</div>}
+        />
       </div>
     </div>
   );

--- a/packages/hyperion-autologging-visualizer/src/component/CytoscapeLayoutConfigDagre.ts
+++ b/packages/hyperion-autologging-visualizer/src/component/CytoscapeLayoutConfigDagre.ts
@@ -25,7 +25,7 @@ const CONFIG: dagre.DagreLayoutOptions = {
   padding: 30, // fit padding
   spacingFactor: undefined, // Applies a multiplicative factor (>0) to expand or compress the overall area that the nodes take up
   nodeDimensionsIncludeLabels: false, // whether labels should be included in determining the space used by a node
-  animate: true, // whether to transition the node positions
+  animate: false, // whether to transition the node positions
   animateFilter: function (_node: any, _i: number) { return true; }, // whether to animate specific nodes when animation is on; non-animated nodes immediately go to their final positions
   animationDuration: 500, // duration of animation in ms if enabled
   animationEasing: undefined, // easing of animation if enabled

--- a/packages/hyperion-autologging-visualizer/src/component/ResizableSplitView.react.tsx
+++ b/packages/hyperion-autologging-visualizer/src/component/ResizableSplitView.react.tsx
@@ -1,0 +1,145 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved.
+ */
+import React from "react";
+
+export default function (props: {
+  direction: "horizontal" | "vertical";
+  className?: string;
+  style?: React.CSSProperties;
+  // children: [React.ReactNode, React.ReactNode]
+  content1: React.ReactNode;
+  content2: React.ReactNode;
+  resizerThickness?: number;
+}): React.ReactNode {
+
+  const containerRef = React.useRef<HTMLDivElement>(null);
+  const content1Ref = React.useRef<HTMLDivElement>(null);
+  const resizerRef = React.useRef<HTMLDivElement>(null);
+  const content2Ref = React.useRef<HTMLDivElement>(null);
+  const isHorizontalDirection = props.direction === 'horizontal';
+
+  React.useEffect(() => {
+    const container = containerRef.current;
+    const content1 = content1Ref.current;
+    const resizer = resizerRef.current;
+    const contend2 = content2Ref.current;
+
+    if (!container || !resizer || !content1 || !contend2) {
+      return;
+    }
+
+    // The current position of mouse
+    let x = 0;
+    let y = 0;
+    let prevSiblingHeight = 0;
+    let prevSiblingWidth = 0;
+
+    // Handle the mousedown event
+    // that's triggered when user drags the resizer
+    const mouseDownHandler = function (e) {
+      // Get the current mouse position
+      x = e.clientX;
+      y = e.clientY;
+
+      const rect = content1.getBoundingClientRect();
+      prevSiblingHeight = rect.height;
+      prevSiblingWidth = rect.width;
+
+      // Attach the listeners to document
+      container.addEventListener('mousemove', mouseMoveHandler);
+      container.addEventListener('mouseup', mouseUpHandler);
+    };
+
+    const mouseMoveHandler = function (e) {
+      // How far the mouse has been moved
+      const dx = e.clientX - x;
+      const dy = e.clientY - y;
+      const containerRect = container.getBoundingClientRect();
+      let cursor: string;
+
+      if (isHorizontalDirection) {
+        const w = ((prevSiblingWidth + dx) * 100) / containerRect.width;
+        content1.style.width = w + '%';
+        cursor = 'col-resize';
+      } else {
+        const h = ((prevSiblingHeight + dy) * 100) / containerRect.height;
+        content1.style.height = h + '%';
+        cursor = 'row-resize';
+      }
+
+      resizer.style.cursor = cursor;
+      document.body.style.cursor = cursor;
+
+      content1.style.userSelect = 'none';
+      content1.style.pointerEvents = 'none';
+
+      contend2.style.userSelect = 'none';
+      contend2.style.pointerEvents = 'none';
+    };
+
+    const mouseUpHandler = function () {
+      const cursor = isHorizontalDirection ? 'ew-resize' : 'ns-resize';
+      resizer.style.cursor = cursor;
+      // resizer.style.removeProperty('cursor');
+      document.body.style.removeProperty('cursor');
+
+      content1.style.removeProperty('user-select');
+      content1.style.removeProperty('pointer-events');
+
+      contend2.style.removeProperty('user-select');
+      contend2.style.removeProperty('pointer-events');
+
+      // Remove the handlers of mousemove and mouseup
+      container.removeEventListener('mousemove', mouseMoveHandler);
+      container.removeEventListener('mouseup', mouseUpHandler);
+    };
+
+    // Attach the handler
+    resizer.addEventListener('mousedown', mouseDownHandler);
+  }, [isHorizontalDirection, containerRef, content1Ref, resizerRef, content2Ref]);
+
+  const contentStyle: React.CSSProperties = {
+    display: "flex",
+    // alignItems: "center",
+    // justifyContent: "center",
+  }
+
+  const resizerThickness = props.resizerThickness ?? '5px';
+
+  return <div ref={containerRef} className={props.className} style={{
+    border: "1px solid #cbd5e0",
+    height: "100%",
+    width: "100%",
+    ...props.style,
+    display: 'flex',
+    flexDirection: isHorizontalDirection ? "row" : "column",
+  }}
+  >
+    <div ref={content1Ref} style={{
+      ...contentStyle,
+      width: "75%",
+    }}>{props.content1}</div>
+
+    <div ref={resizerRef} style={{
+      backgroundColor: "#cbd5e0",
+      ...isHorizontalDirection
+        ? {
+          cursor: "ew-resize",
+          height: "100%",
+          width: resizerThickness,
+        }
+        : {
+          cursor: "ns-resize",
+          height: resizerThickness,
+          width: "100%",
+        }
+    }}
+    ></div>
+
+    <div ref={content2Ref} style={{
+      ...contentStyle,
+      flex: "1 1 0%"
+    }}>{props.content2}</div>
+  </div>
+}

--- a/packages/hyperion-autologging-visualizer/src/component/ResizableSplitView.react.tsx
+++ b/packages/hyperion-autologging-visualizer/src/component/ResizableSplitView.react.tsx
@@ -37,7 +37,7 @@ export default function (props: {
 
     // Handle the mousedown event
     // that's triggered when user drags the resizer
-    const mouseDownHandler = function (e) {
+    const mouseDownHandler = function (e: MouseEvent) {
       // Get the current mouse position
       x = e.clientX;
       y = e.clientY;
@@ -51,7 +51,7 @@ export default function (props: {
       container.addEventListener('mouseup', mouseUpHandler);
     };
 
-    const mouseMoveHandler = function (e) {
+    const mouseMoveHandler = function (e: MouseEvent) {
       // How far the mouse has been moved
       const dx = e.clientX - x;
       const dy = e.clientY - y;

--- a/packages/hyperion-react-testapp/src/App.css
+++ b/packages/hyperion-react-testapp/src/App.css
@@ -4,6 +4,29 @@
 
 .App {
   text-align: center;
+  height: 100%;
+  
+  display: flex;
+  flex-direction: row;
+  align-items: stretch;
+  /* background-color: DodgerBlue; */
+  height: 100%;
+}
+
+
+.AppContent {
+  flex: 0 1 80%;
+  /* The above is shorthand for:
+  flex-grow: 0,
+  flex-shrink: 1,
+  flex-basis: auto
+  */
+}
+
+.AppInfo {
+  flex: 1 1 auto;
+  resize: horizontal;
+  overflow: auto;
 }
 
 .App-logo {

--- a/packages/hyperion-react-testapp/src/App.tsx
+++ b/packages/hyperion-react-testapp/src/App.tsx
@@ -2,18 +2,21 @@
  * Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved.
  */
 
-import { LocalStoragePersistentData } from '@hyperion/hyperion-util/src/PersistentData';
 import React, { ChangeEventHandler, useCallback, useState } from 'react';
 import './App.css';
-import ALGraphView from './component/ALGraphView';
 import DynamicSvgComponent from './component/DynamicSvgComponent';
 import ElementNameComponent from './component/ElementNameComponent';
 import LargeComp from './component/LargeComponent';
 import NestedComponent from './component/NestedComponent';
 import NonInteractiveSurfaceComponent from './component/NonInteractiveSurfaceComponent';
+import ALEventLogger from './component/ALEventLogger';
+import { LocalStoragePersistentData } from '@hyperion/hyperion-util/src/PersistentData';
+import TestDivGrid from './component/TestDivGrid';
+import ALGraphView from './component/ALGraphView';
+import ResizableSplitView from "@hyperion/hyperion-autologging-visualizer/src/component/ResizableSplitView.react";
 import { PortalBodyContainerComponent } from './component/PortalComponent';
-import RecursiveRuncComponent from "./component/RecursiveFuncComponent";
 import TextComponent from './component/TextComponent';
+import RecursiveFuncComponent from './component/RecursiveFuncComponent';
 
 function InitComp() {
   const [count, setCount] = React.useState(0);
@@ -52,7 +55,7 @@ const Modes = {
       <ElementNameComponent />
     </div>
     <TextComponent />
-    <RecursiveRuncComponent i={3}></RecursiveRuncComponent>
+    <RecursiveFuncComponent i={3}></RecursiveFuncComponent>
   </>,
 };
 type ModeNames = keyof typeof Modes;
@@ -75,16 +78,26 @@ function App() {
     }
   }, []);
 
-  return (
-    <div className="App">
+  return (<ResizableSplitView direction='horizontal'
+    content1={
+      <div className='AppContent'>
+        <label htmlFor='testSelector'>Select a mode:</label>
+        <select onChange={onChange} value={mode} id='testSelector' aria-label='Mode Selector'>
+          {Object.keys(Modes).map(key => <option key={key} value={key}>{key}</option>)}
+        </select>
+        {Modes[mode]()}
+      </div>
+    }
+
+    content2={
+      // <ResizableSplitView direction='vertical' content1="T2" content2="T3" style={{ backgroundColor: 'red' }}></ResizableSplitView>
       <ALGraphView />
-      <label htmlFor='testSelector'>Select a mode:</label>
-      <select onChange={onChange} value={mode} id='testSelector' aria-label='Mode Selector'>
-        {Object.keys(Modes).map(key => <option key={key} value={key}>{key}</option>)}
-      </select>
-      {Modes[mode]()}
-    </div>
-  );
+      // <TestDivGrid />s
+      // <ALEventLogger />
+    }
+  />);
+
+
 }
 
 export default App;

--- a/packages/hyperion-react-testapp/src/App.tsx
+++ b/packages/hyperion-react-testapp/src/App.tsx
@@ -2,21 +2,18 @@
  * Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved.
  */
 
+import { LocalStoragePersistentData } from '@hyperion/hyperion-util/src/PersistentData';
 import React, { ChangeEventHandler, useCallback, useState } from 'react';
 import './App.css';
-import LargeComp from './component/LargeComponent';
-import Counter from "./component/Counter";
-import NestedComponent from './component/NestedComponent';
-import { PortalBodyContainerComponent } from './component/PortalComponent';
+import ALGraphView from './component/ALGraphView';
 import DynamicSvgComponent from './component/DynamicSvgComponent';
 import ElementNameComponent from './component/ElementNameComponent';
-import TextComponent from './component/TextComponent';
-import RecursiveRuncComponent from "./component/RecursiveFuncComponent";
-import { ElementTextTooltip } from "@hyperion/hyperion-autologging-visualizer/src/component/ElementTextTooltip.react";
-import { SyncChannel } from './Channel';
+import LargeComp from './component/LargeComponent';
+import NestedComponent from './component/NestedComponent';
 import NonInteractiveSurfaceComponent from './component/NonInteractiveSurfaceComponent';
-import ALEventLogger from './component/ALEventLogger';
-import { LocalStoragePersistentData } from '@hyperion/hyperion-util/src/PersistentData';
+import { PortalBodyContainerComponent } from './component/PortalComponent';
+import RecursiveRuncComponent from "./component/RecursiveFuncComponent";
+import TextComponent from './component/TextComponent';
 
 function InitComp() {
   const [count, setCount] = React.useState(0);
@@ -80,7 +77,7 @@ function App() {
 
   return (
     <div className="App">
-      <ALEventLogger />
+      <ALGraphView />
       <label htmlFor='testSelector'>Select a mode:</label>
       <select onChange={onChange} value={mode} id='testSelector' aria-label='Mode Selector'>
         {Object.keys(Modes).map(key => <option key={key} value={key}>{key}</option>)}

--- a/packages/hyperion-react-testapp/src/component/ALGraphView.tsx
+++ b/packages/hyperion-react-testapp/src/component/ALGraphView.tsx
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved.
+ */
+
+import * as React from "react";
+import { SyncChannel } from "../Channel";
+import { ALChannelEvent } from "@hyperion/hyperion-autologging/src/AutoLogging";
+import { ALSessionGraph } from "@hyperion/hyperion-autologging-visualizer/src/component/ALSessionGraph.react";
+import { ALGraphInfo } from "@hyperion/hyperion-autologging-visualizer/src/component/ALGraphInfo.react";
+import { LocalStoragePersistentData } from "@hyperion/hyperion-util/src/PersistentData";
+import { ALFlowletEvent } from "@hyperion/hyperion-autologging/src/ALType";
+import * as  ALGraph from "@hyperion/hyperion-autologging-visualizer/src/component/ALGraph";
+import { getEventExtension } from "@hyperion/hyperion-autologging/src/ALEventExtension";
+
+function EventInfoViewer(props: { eventInfo: ALGraph.EventInfos }): React.ReactNode {
+  const { eventInfo } = props;
+  const ref = React.useRef<HTMLDivElement | null>(null);
+  React.useEffect(() => {
+    if (ref.current) {
+      const snapshot = getEventExtension<{ snapshot: string }>(eventInfo.eventData, 'autologging')?.snapshot;
+      if (snapshot) {
+        ref.current.innerHTML = snapshot;
+      }
+    }
+  }, [eventInfo]);
+
+  return <table>
+    <thead>
+      <tr>
+        <th colSpan={2}>{eventInfo.eventName}[{eventInfo.eventData.event}]</th>
+      </tr>
+    </thead>
+    <tbody>
+      {
+        Object.entries(eventInfo.eventData).map(prop => {
+          const [key, value] = prop;
+          return <tr key={key}><th>{key}</th><td>{String(value)}</td></tr>
+        })
+      }
+    </tbody>
+    <tfoot >
+      <tr>
+        <th>Snapshot</th>
+        <td>
+          <div ref={ref}></div>
+        </td>
+      </tr>
+    </tfoot>
+  </table>
+}
+
+export default function () {
+  // Better to first setup listeners before initializing AutoLogging so we don't miss any events (e.g. Heartbeat(START))
+
+  return <ALGraphInfo
+    channel={SyncChannel}
+    width="99%"
+    height="1000px"
+    renderer={eventInfo => <EventInfoViewer eventInfo={eventInfo} />}
+  // graphFilter='edge, node[label !^= "al_surface"]'
+  />
+}

--- a/packages/hyperion-react-testapp/src/component/ALGraphView.tsx
+++ b/packages/hyperion-react-testapp/src/component/ALGraphView.tsx
@@ -55,7 +55,7 @@ export default function () {
   return <ALGraphInfo
     channel={SyncChannel}
     width="99%"
-    height="1000px"
+    height="100%"
     renderer={eventInfo => <EventInfoViewer eventInfo={eventInfo} />}
   // graphFilter='edge, node[label !^= "al_surface"]'
   />

--- a/packages/hyperion-react-testapp/src/index.css
+++ b/packages/hyperion-react-testapp/src/index.css
@@ -2,6 +2,10 @@
  * Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved.
  */
 
+ html, body, #root {
+   height: 100%;
+ }
+
 body {
   margin: 0;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',


### PR DESCRIPTION
Enabled a split view between the graph and its info so that we can resize each view and see the info.
Also, used the same mechanism in the test app. The new graph view was getting to big and pushing down the main application itself. The new setup better resembles actual usages as well as multi window uses. 