### PR TITLE
Fix for badly formed IDs when looking up.

### DIFF
--- a/packages/hyperion-autologging/src/ALInteractableDOMElement.ts
+++ b/packages/hyperion-autologging/src/ALInteractableDOMElement.ts
@@ -451,14 +451,16 @@ function getElementName(element: HTMLElement, surface: string | null, results: A
      * If we find such a label, we won't need to check the inner text anymore.
      */
     if (element.id) {
-      const labels = document.querySelectorAll<HTMLLabelElement>(`label[for='${element.id}']`);
-      if (labels.length > 0) {
-        for (let i = 0, len = labels.length; i < len; ++i) {
-          const label = labels[i];
-          getTextFromInnerText({ element: label, surface }, 'label', results);
+      try {
+        const labels = document.querySelectorAll<HTMLLabelElement>(`label[for='${element.id}']`);
+        if (labels.length > 0) {
+          for (let i = 0, len = labels.length; i < len; ++i) {
+            const label = labels[i];
+            getTextFromInnerText({ element: label, surface }, 'label', results);
+          }
+          return;
         }
-        return;
-      }
+      } catch { }
     }
     /**
      * Now we recurse into the children to find other text candidates.


### PR DESCRIPTION
In some cases, the id of an element my be in a form that breaks the selector expression .

This quick fix for now ensures we don't break the application, will better fix it later.