### PR TITLE
Cache element text

### DIFF
--- a/packages/hyperion-autologging/src/ALElementValuePublisher.ts
+++ b/packages/hyperion-autologging/src/ALElementValuePublisher.ts
@@ -64,7 +64,7 @@ export function publish(options: InitOptions): void {
       reactComponentData = elementInfo.getReactComponentData();
     }
 
-    const elementText = getElementTextEvent(element, surface, tryInteractiveParentTextEventName);
+    const elementText = getElementTextEvent(element, surface, tryInteractiveParentTextEventName, true);
     const callFlowlet = options.flowletManager.top();
 
     channel.emit('al_ui_event', {

--- a/packages/hyperion-autologging/src/ALInteractableDOMElement.ts
+++ b/packages/hyperion-autologging/src/ALInteractableDOMElement.ts
@@ -338,7 +338,7 @@ export type ALElementTextOptions = Types.Options<
     maxDepth?: number;
     updateText?: <T extends ALElementText>(elementText: T, domSource: ALDOMTextSource) => void;
     getText?: <T extends ALElementText>(elementTexts: T[]) => ALElementText;
-    cacheText?: boolean;
+    enableElementTextCache?: boolean;
   }
 >;
 
@@ -353,7 +353,7 @@ let ElementTextCache: WeakMap<HTMLElement, CachedALElementResults> | null = null
 export function init(options: ALElementTextOptions) {
   _options = options;
   MaxDepth = _options.maxDepth ?? MaxDepth;
-  if (options.cacheText) {
+  if (options.enableElementTextCache) {
     ElementTextCache = new WeakMap<HTMLElement, CachedALElementResults>();
   }
 }
@@ -535,7 +535,7 @@ export function getElementTextEvent(
   // Event name to utilize when attempting to resolve text from a parent interactable
   // Some interactable elements may have no text to extract, in those cases we want to move up the tree to attempt from parent interactable.
   tryInteractableParentEventName?: UIEventConfig['eventName'] | null,
-  skipCache?: boolean
+  useCachedElementText?: boolean
 ): ALElementTextEvent {
   if (!element) {
     return {
@@ -544,7 +544,7 @@ export function getElementTextEvent(
     }
   }
 
-  if (!skipCache) {
+  if (useCachedElementText) {
     const cached = ElementTextCache?.get(element);
     if (cached && cached.surface === surface) {
       return cached.result;

--- a/packages/hyperion-autologging/src/ALInteractableDOMElement.ts
+++ b/packages/hyperion-autologging/src/ALInteractableDOMElement.ts
@@ -353,7 +353,7 @@ let ElementTextCache: WeakMap<HTMLElement, CachedALElementResults> | null = null
 export function init(options: ALElementTextOptions) {
   _options = options;
   MaxDepth = _options.maxDepth ?? MaxDepth;
-  if (options.cacheText){
+  if (options.cacheText) {
     ElementTextCache = new WeakMap<HTMLElement, CachedALElementResults>();
   }
 }
@@ -534,7 +534,8 @@ export function getElementTextEvent(
   surface: string | null,
   // Event name to utilize when attempting to resolve text from a parent interactable
   // Some interactable elements may have no text to extract, in those cases we want to move up the tree to attempt from parent interactable.
-  tryInteractableParentEventName?: UIEventConfig['eventName'] | null
+  tryInteractableParentEventName?: UIEventConfig['eventName'] | null,
+  skipCache?: boolean
 ): ALElementTextEvent {
   if (!element) {
     return {
@@ -543,9 +544,11 @@ export function getElementTextEvent(
     }
   }
 
-  const cached = ElementTextCache?.get(element);
-  if (cached && cached.surface === surface){
-    return cached.result;
+  if (!skipCache) {
+    const cached = ElementTextCache?.get(element);
+    if (cached && cached.surface === surface) {
+      return cached.result;
+    }
   }
 
   const results: ALElementText[] = [];
@@ -594,6 +597,7 @@ export function getElementTextEvent(
     elementText,
   };
 
+  // even if skipCache is set, we update the cache, this way, certain events can be used to keep the cache uptodate
   ElementTextCache?.set(element, {
     surface,
     result: finalResult,

--- a/packages/hyperion-autologging/src/ALUIEventPublisher.ts
+++ b/packages/hyperion-autologging/src/ALUIEventPublisher.ts
@@ -232,6 +232,13 @@ export function publish(options: InitOptions): void {
       return;
     }
 
+    /**
+    * Some events may trigger a change in the UI, which means using cached text is no longer safe
+    * We use this to both skip the text cache, and also recompute the value.
+    * Also, we compute the value per event type, so we can do it once outside of the event handlers
+    */
+    const skipTextCache = /click|change|input|key/.test(eventName);
+
     // Track event in the capturing phase
     const captureHandler = (event: Event): void => {
       const uiEventData = getCommonEventData(eventConfig, eventName, event);
@@ -268,7 +275,7 @@ export function publish(options: InitOptions): void {
         const elementInfo = ALElementInfo.getOrCreate(targetElement);
         reactComponentData = elementInfo.getReactComponentData();
       }
-      let elementText = getElementTextEvent(element, surface, eventName);
+      let elementText = getElementTextEvent(element, surface, eventName, skipTextCache);
 
       const eventData: ALUIEventCaptureData = {
         ...uiEventData,


### PR DESCRIPTION
To avoid recalculation of the element text, added an optional cache that can be enabled via options flags.
