### PR TITLE
Rename visibility events

### DIFF
--- a/packages/hyperion-autologging-visualizer/src/component/ALGraph.ts
+++ b/packages/hyperion-autologging-visualizer/src/component/ALGraph.ts
@@ -169,8 +169,8 @@ export type ALGraphDynamicOptionsType = {
     al_network_request: boolean;
     al_network_response: boolean;
     al_surface_visibility_event: {
-      component_visible: boolean;
-      component_hidden: boolean;
+      surface_visible: boolean;
+      surface_hidden: boolean;
     };
   };
   nodes: {

--- a/packages/hyperion-autologging-visualizer/src/component/ALGraphInfo.react.tsx
+++ b/packages/hyperion-autologging-visualizer/src/component/ALGraphInfo.react.tsx
@@ -59,8 +59,8 @@ const DefaultOptions: ALGraph.ALGraphDynamicOptionsType = {
     al_network_request: false,
     al_network_response: false,
     al_surface_visibility_event: {
-      component_visible: false,
-      component_hidden: false,
+      surface_visible: false,
+      surface_hidden: false,
     },
   },
   nodes: {

--- a/packages/hyperion-autologging/src/ALSurfaceVisibilityPublisher.ts
+++ b/packages/hyperion-autologging/src/ALSurfaceVisibilityPublisher.ts
@@ -29,12 +29,12 @@ export type ALSurfaceVisibilityEventData =
     } &
     (
       {
-        event: 'component_visible';
+        event: 'surface_visible';
         isIntersecting: true;
       }
       |
       {
-        event: 'component_hidden';
+        event: 'surface_hidden';
         isIntersecting: false;
       }
     )
@@ -168,8 +168,8 @@ export function publish(options: InitOptions): void {
               const isIntersecting = entry.isIntersecting;
               channel.emit('al_surface_visibility_event', {
                 ...isIntersecting
-                  ? { event: 'component_visible', isIntersecting }
-                  : { event: 'component_hidden', isIntersecting },
+                  ? { event: 'surface_visible', isIntersecting }
+                  : { event: 'surface_hidden', isIntersecting },
                 eventTimestamp: performanceAbsoluteNow.fromRelativeTime(entry.time),
                 eventIndex: ALEventIndex.getNextEventIndex(),
                 relatedEventIndex: surfaceEvent.eventIndex,


### PR DESCRIPTION
Renamed `component_visible` and `component_hidden` to `surface_visible` and `surface_hidden` to match the actual behavior of the logic.