### PR TITLE
Allow disabling elementText extraction per event.

### DIFF
--- a/packages/hyperion-autologging/src/ALElementValuePublisher.ts
+++ b/packages/hyperion-autologging/src/ALElementValuePublisher.ts
@@ -42,7 +42,7 @@ export function publish(options: InitOptions): void {
     return;
   }
 
-  const { cacheElementReactInfo, includeInitialDefaultState = true, includeInitialDefaultDisabledState = false } = changeEvent;
+  const { cacheElementReactInfo, includeInitialDefaultState = true, includeInitialDefaultDisabledState = false, enableElementTextExtraction = false } = changeEvent;
 
   /**
    * In most cases, the application may not have 'change' listener. We mainly want to track
@@ -64,7 +64,7 @@ export function publish(options: InitOptions): void {
       reactComponentData = elementInfo.getReactComponentData();
     }
 
-    const elementText = getElementTextEvent(element, surface, tryInteractiveParentTextEventName, true);
+    const elementText = enableElementTextExtraction ? getElementTextEvent(element, surface, tryInteractiveParentTextEventName, true) : getElementTextEvent(null, null);
     const callFlowlet = options.flowletManager.top();
 
     channel.emit('al_ui_event', {

--- a/packages/hyperion-autologging/src/ALSurfaceMutationPublisher.ts
+++ b/packages/hyperion-autologging/src/ALSurfaceMutationPublisher.ts
@@ -65,11 +65,16 @@ export type InitOptions = Types.Options<
   ALSharedInitOptions<ALChannelSurfaceMutationEvent & ALChannelSurfaceEvent & ALCustomEvent.ALChannelCustomEvent> &
   {
     cacheElementReactInfo: boolean;
+    /**
+     * Whether to include elementName, and elementText extraction and fields in the published events.
+     * Element text extraction can be expensive depending on the event,  and for mutations may not be relevant.
+     */
+    enableElementTextExtraction?: boolean;
   }
 >;
 
 export function publish(options: InitOptions): void {
-  const { channel, flowletManager, cacheElementReactInfo } = options;
+  const { channel, flowletManager, cacheElementReactInfo, enableElementTextExtraction = false } = options;
 
   function processNode(event: ALSurfaceEventData, action: 'added' | 'removed') {
     const timestamp = performanceAbsoluteNow();
@@ -87,14 +92,12 @@ export function publish(options: InitOptions): void {
         let info = activeSurfaces.get(surface);
         if (!info) {
           let reactComponentData: ReactComponentData | null = null;
-          let elementText: ALElementTextEvent;
           if (cacheElementReactInfo) {
             const elementInfo = ALElementInfo.getOrCreate(element);
             reactComponentData = elementInfo.getReactComponentData();
-            elementText = getElementTextEvent(element, surface);
-          } else {
-            elementText = getElementTextEvent(null, surface);
           }
+          const elementText = enableElementTextExtraction ? getElementTextEvent(element, surface) : getElementTextEvent(null, null);
+
           if (callFlowlet) {
             metadata.add_call_flowlet = callFlowlet?.getFullName();
           }

--- a/packages/hyperion-autologging/src/ALType.ts
+++ b/packages/hyperion-autologging/src/ALType.ts
@@ -36,7 +36,7 @@ export type ALMetadataEvent = Readonly<{
 export type ALExtensibleEventData = { [key: string]: any };
 export type ALExtensibleEvent = {
   /**
-   * Temporary data that application might want to attach to 
+   * Temporary data that application might want to attach to
    * event payload but will be dropped when logging or serializing.
    * The data must be organized with namespaces to avoid collision
    */

--- a/packages/hyperion-autologging/src/ALUIEventPublisher.ts
+++ b/packages/hyperion-autologging/src/ALUIEventPublisher.ts
@@ -108,7 +108,6 @@ type UIEventConfigMap = {
     interactableElementsOnly?: boolean;
     // Whether to cache element's react information on capture, defaults to false.
     cacheElementReactInfo?: boolean;
-
     /**
     * Some events may trigger a change in the UI, which means using cached text is not safe.
     * We always update the cache after text extraction (if cache is enabled), it is only safe
@@ -116,6 +115,12 @@ type UIEventConfigMap = {
     * This field allows controlling this behavior. It is on by default for all events except /click|change|input|key/
     */
     useCachedElementText?: boolean;
+    /**
+     * Whether to include elementName, and elementText extraction and fields in the published events.
+     * Element text extraction can be expensive depending on the event,  and may not be needed in some cases.
+     * Defaults to false behavior.
+     */
+    enableElementTextExtraction?: boolean;
   }>
 };
 
@@ -247,7 +252,8 @@ export function publish(options: InitOptions): void {
     const {
       eventName,
       cacheElementReactInfo = false,
-      useCachedElementText = !/click|change|input|key/.test(eventName) // by default we skipt cache for these value
+      useCachedElementText = !/click|change|input|key/.test(eventName), // by default we skipt cache for these value
+      enableElementTextExtraction = false,
     } = eventConfig;
 
 
@@ -291,7 +297,7 @@ export function publish(options: InitOptions): void {
         const elementInfo = ALElementInfo.getOrCreate(targetElement);
         reactComponentData = elementInfo.getReactComponentData();
       }
-      let elementText = getElementTextEvent(element, surface, eventName, useCachedElementText);
+      let elementText = enableElementTextExtraction ? getElementTextEvent(element, surface, eventName, useCachedElementText) : getElementTextEvent(null, null);
 
       const eventData: ALUIEventCaptureData = {
         ...uiEventData,

--- a/packages/hyperion-react-testapp/src/App.tsx
+++ b/packages/hyperion-react-testapp/src/App.tsx
@@ -11,7 +11,6 @@ import NestedComponent from './component/NestedComponent';
 import NonInteractiveSurfaceComponent from './component/NonInteractiveSurfaceComponent';
 import ALEventLogger from './component/ALEventLogger';
 import { LocalStoragePersistentData } from '@hyperion/hyperion-util/src/PersistentData';
-import TestDivGrid from './component/TestDivGrid';
 import ALGraphView from './component/ALGraphView';
 import ResizableSplitView from "@hyperion/hyperion-autologging-visualizer/src/component/ResizableSplitView.react";
 import { PortalBodyContainerComponent } from './component/PortalComponent';
@@ -66,11 +65,24 @@ const PersistedOptionValue = new LocalStoragePersistentData<ModeNames>(
   value => value in Modes ? value as ModeNames : 'mutationOnlySurface'
 );
 
+const Tools = {
+  'alGraph': () => <ALGraphView />,
+  'alConsoleEventLogger': () => <ALEventLogger />
+};
+type ToolNames = keyof typeof Tools;
+const PersistedToolOptionValue = new LocalStoragePersistentData<ToolNames>(
+  'tool_drop_down',
+  () => 'alGraph',
+  value => String(value),
+  value => value in Tools ? value as ToolNames : 'alGraph'
+);
+
 function App() {
 
   const [mode, setMode] = useState<ModeNames>(PersistedOptionValue.getValue());
+  const [tool, setTool] = useState<ToolNames>(PersistedToolOptionValue.getValue());
 
-  const onChange = useCallback<ChangeEventHandler<HTMLSelectElement>>((event) => {
+  const onModeChange = useCallback<ChangeEventHandler<HTMLSelectElement>>((event) => {
     const value = event.target.value;
     if (value === 'mutationOnlySurface' || value === 'network' || value === 'nested') {
       PersistedOptionValue.setValue(value);
@@ -78,11 +90,19 @@ function App() {
     }
   }, []);
 
+  const onToolChange = useCallback<ChangeEventHandler<HTMLSelectElement>>((event) => {
+    const value = event.target.value;
+    if (value === 'alGraph' || value === 'alConsoleEventLogger') {
+      PersistedToolOptionValue.setValue(value);
+      setTool(value);
+    }
+  }, []);
+
   return (<ResizableSplitView direction='horizontal'
     content1={
       <div className='AppContent'>
         <label htmlFor='testSelector'>Select a mode:</label>
-        <select onChange={onChange} value={mode} id='testSelector' aria-label='Mode Selector'>
+        <select onChange={onModeChange} value={mode} id='testSelector' aria-label='Mode Selector'>
           {Object.keys(Modes).map(key => <option key={key} value={key}>{key}</option>)}
         </select>
         {Modes[mode]()}
@@ -90,12 +110,13 @@ function App() {
     }
 
     content2={
-      // <ResizableSplitView direction='vertical' content1="T2" content2="T3" style={{ backgroundColor: 'red' }}></ResizableSplitView>
-      <>
-      <ALGraphView />
-      {/* <TestDivGrid /> */}
-      {/* <ALEventLogger /> */}
-      </>
+      <div className='ToolContent'>
+        <label htmlFor='toolSelector'>Select a mode:</label>
+        <select onChange={onToolChange} value={tool} id='toolSelector' aria-label='Tool Selector'>
+          {Object.keys(Tools).map(key => <option key={key} value={key}>{key}</option>)}
+        </select>
+        {Tools[tool]()}
+      </div>
     }
   />);
 

--- a/packages/hyperion-react-testapp/src/AutoLoggingWrapper.ts
+++ b/packages/hyperion-react-testapp/src/AutoLoggingWrapper.ts
@@ -81,29 +81,40 @@ export function init() {
         {
           eventName: 'click',
           cacheElementReactInfo: true,
+          enableElementTextExtraction: true,
+          eventFilter: (domEvent) => domEvent.isTrusted
+        },
+        {
+          eventName: 'mousedown',
+          cacheElementReactInfo: true,
+          enableElementTextExtraction: false,
           eventFilter: (domEvent) => domEvent.isTrusted
         },
         {
           eventName: 'keydown',
           cacheElementReactInfo: true,
           interactableElementsOnly: false,
+          enableElementTextExtraction: false,
           eventFilter: (domEvent) => domEvent.code === 'Enter',
         },
         {
           eventName: 'keyup',
           cacheElementReactInfo: true,
           interactableElementsOnly: false,
+          enableElementTextExtraction: false,
           eventFilter: (domEvent) => domEvent.code === 'Enter',
         },
         {
           eventName: 'change',
           cacheElementReactInfo: true,
+          enableElementTextExtraction: true,
           interactableElementsOnly: false,
         },
         {
           eventName: 'mouseover',
           cacheElementReactInfo: true,
           interactableElementsOnly: false,
+          enableElementTextExtraction: true,
           durationThresholdToEmitHoverEvent: 1000,
         },
       ]
@@ -113,6 +124,7 @@ export function init() {
     },
     surfaceMutationPublisher: {
       cacheElementReactInfo: true,
+      enableElementTextExtraction: false,
     },
     surfaceVisibilityPublisher: {},
     network: {


### PR DESCRIPTION
There are some events where the elementText extraction can be potentially expensive, and when it is not needed or relevant.

Added an option to disable this on a per event basis.
- UI Events & Mutation Events
- Defaults to on for backwards compatibility


Text disabled/enabled where expected
<img width="1279" alt="image" src="https://github.com/facebook/hyperion/assets/6064408/c21c1208-2923-4329-82ca-080018c9ac09">



In addition I want to still use the console logger for cases like this so added a dropdown in test app similar to the other mode dropdown.
<img width="1970" alt="image" src="https://github.com/facebook/hyperion/assets/6064408/50a232a4-8ad3-494d-a39c-78e227203ced">
