### PR TITLE
Domain session

### DIFF
--- a/packages/hyperion-autologging/src/ALSessionFlowID.ts
+++ b/packages/hyperion-autologging/src/ALSessionFlowID.ts
@@ -1,0 +1,100 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved.
+ */
+
+'use strict';
+
+import { assert } from "@hyperion/hyperion-global";
+import { guid } from "@hyperion/hyperion-util/src/guid";
+import performanceAbsoluteNow from "@hyperion/hyperion-util/src/performanceAbsoluteNow";
+import { CookiePersistentData } from "@hyperion/hyperion-util/src/PersistentData";
+import { ALChannelUIEvent } from "./ALUIEventPublisher";
+import { Channel } from "@hyperion/hyperion-channel";
+import { ALChannelHeartbeatEvent, ALHeartbeatType } from "./ALHeartbeat";
+import { ALTimedEvent } from "./ALType";
+
+export interface SessionFlowID {
+  id: string;
+  timestamp: number;
+}
+
+let sessionFlowID: CookiePersistentData<SessionFlowID>;
+
+export type InitOptions = {
+  channel: Channel<ALChannelUIEvent & ALChannelHeartbeatEvent>;
+  cookieName?: string;
+  domain: string;
+  maxAge?: number;
+  path?: string;
+}
+
+export function init(options: InitOptions) {
+  const currentHostname = window.location.hostname;
+  assert(currentHostname.endsWith(options.domain), "invalid top level domain for this page");
+
+  const maxAge = options.maxAge || 10;
+
+  sessionFlowID = new CookiePersistentData<SessionFlowID>(
+    options.cookieName ?? 'alsfid',
+    () => ({
+      id: guid(),
+      timestamp: performanceAbsoluteNow(),
+    }),
+    v => JSON.stringify(v),
+    v => JSON.parse(v),
+    `; max-age=${maxAge}; path=${options.path ?? '/'}; domain=${options.domain}`
+  );
+
+  // Even if the cookie did not work, we just check the time difference ouselves
+  const now = performanceAbsoluteNow();
+  if ((now - sessionFlowID.getValue().timestamp) > maxAge) {
+    // Too much time has elapsed since last session, so start a new one
+    sessionFlowID.setValue({
+      id: guid(),
+      timestamp: now
+    });
+  }
+
+  // We use any activity that might be the last before moving to next page to update the value.
+  function refershCookie(eventData: ALTimedEvent) {
+    sessionFlowID.setValue({
+      id: sessionFlowID.getValue().id,
+      timestamp: eventData.eventTimestamp
+    });
+  }
+  options.channel.addListener('al_ui_event', refershCookie);
+
+  options.channel.addListener('al_heartbeat_event', eventData => {
+    if (eventData.heartbeatType === ALHeartbeatType.STOP) {
+      refershCookie(eventData);
+    }
+  });
+
+}
+
+export function getSessionFlowID(): SessionFlowID {
+  assert(sessionFlowID != null, `Calling getSessionID before initialization`);
+  return sessionFlowID.getValue();
+}
+
+let domainSessionId: CookiePersistentData<string> | null = null;
+export function getDomainSessionID(topLevelDomain?: string, cookieName?: string): string {
+
+  if (!domainSessionId) {
+    const currentHostname = window.location.hostname;
+    if (topLevelDomain) {
+      assert(currentHostname.endsWith(topLevelDomain), "invalid top level domain for this page");
+    } else {
+      topLevelDomain = currentHostname;
+    }
+
+    domainSessionId = new CookiePersistentData<string>(
+      cookieName ?? 'aldsid',
+      guid,
+      v => v,
+      v => v,
+      `;domain=${topLevelDomain}; path=/`
+    );
+  }
+  return domainSessionId.getValue();
+}

--- a/packages/hyperion-autologging/src/ALSessionFlowID.ts
+++ b/packages/hyperion-autologging/src/ALSessionFlowID.ts
@@ -47,7 +47,8 @@ export function init(options: InitOptions) {
 
   // Even if the cookie did not work, we just check the time difference ouselves
   const now = performanceAbsoluteNow();
-  if ((now - sessionFlowID.getValue().timestamp) > maxAge) {
+  const age =  (now - sessionFlowID.getValue().timestamp) / 1000; // msec to sec
+  if (age > maxAge) {
     // Too much time has elapsed since last session, so start a new one
     sessionFlowID.setValue({
       id: guid(),
@@ -72,9 +73,8 @@ export function init(options: InitOptions) {
 
 }
 
-export function getSessionFlowID(): SessionFlowID {
-  assert(sessionFlowID != null, `Calling getSessionID before initialization`);
-  return sessionFlowID.getValue();
+export function getSessionFlowID(): SessionFlowID | null {
+  return sessionFlowID?.getValue();
 }
 
 let domainSessionId: CookiePersistentData<string> | null = null;

--- a/packages/hyperion-autologging/src/ALSessionFlowID.ts
+++ b/packages/hyperion-autologging/src/ALSessionFlowID.ts
@@ -4,12 +4,12 @@
 
 'use strict';
 
-import { assert } from "@hyperion/hyperion-global";
-import { guid } from "@hyperion/hyperion-util/src/guid";
-import performanceAbsoluteNow from "@hyperion/hyperion-util/src/performanceAbsoluteNow";
-import { CookiePersistentData } from "@hyperion/hyperion-util/src/PersistentData";
+import { assert } from "hyperion-globals";
+import { guid } from "hyperion-util/src/guid";
+import performanceAbsoluteNow from "hyperion-util/src/performanceAbsoluteNow";
+import { CookiePersistentData } from "hyperion-util/src/PersistentData";
 import { ALChannelUIEvent } from "./ALUIEventPublisher";
-import { Channel } from "@hyperion/hyperion-channel";
+import { Channel } from "hyperion-channel";
 import { ALChannelHeartbeatEvent, ALHeartbeatType } from "./ALHeartbeat";
 import { ALTimedEvent } from "./ALType";
 
@@ -63,6 +63,7 @@ export function init(options: InitOptions) {
       timestamp: eventData.eventTimestamp
     });
   }
+  options.channel.addListener('al_ui_event_capture', refershCookie);
   options.channel.addListener('al_ui_event', refershCookie);
 
   options.channel.addListener('al_heartbeat_event', eventData => {
@@ -75,26 +76,4 @@ export function init(options: InitOptions) {
 
 export function getSessionFlowID(): SessionFlowID | null {
   return sessionFlowID?.getValue();
-}
-
-let domainSessionId: CookiePersistentData<string> | null = null;
-export function getDomainSessionID(topLevelDomain?: string, cookieName?: string): string {
-
-  if (!domainSessionId) {
-    const currentHostname = window.location.hostname;
-    if (topLevelDomain) {
-      assert(currentHostname.endsWith(topLevelDomain), "invalid top level domain for this page");
-    } else {
-      topLevelDomain = currentHostname;
-    }
-
-    domainSessionId = new CookiePersistentData<string>(
-      cookieName ?? 'aldsid',
-      guid,
-      v => v,
-      v => v,
-      `;domain=${topLevelDomain}; path=/`
-    );
-  }
-  return domainSessionId.getValue();
 }

--- a/packages/hyperion-autologging/src/AutoLogging.ts
+++ b/packages/hyperion-autologging/src/AutoLogging.ts
@@ -11,12 +11,15 @@ import global from "hyperion-globals/src/global";
 import * as IReactComponent from "hyperion-react/src/IReactComponent";
 import * as Types from "hyperion-util/src/Types";
 import * as ALCustomEvent from "./ALCustomEvent";
+import * as ALDOMSnapshotPublisher from "./ALDOMSnaptshotPublisher";
 import * as ALElementValuePublisher from "./ALElementValuePublisher";
 import * as ALFlowletPublisher from "./ALFlowletPublisher";
 import * as ALHeartbeat from "./ALHeartbeat";
+import * as ALHoverPublisher from "./ALHoverPublisher";
 import * as ALInteractableDOMElement from "./ALInteractableDOMElement";
 import * as ALNetworkPublisher from "./ALNetworkPublisher";
 import { ComponentNameValidator, setComponentNameValidator } from "./ALReactUtils";
+import * as ALSessionFlowID from "./ALSessionFlowID";
 import * as ALSurface from "./ALSurface";
 import * as ALSurfaceMutationPublisher from "./ALSurfaceMutationPublisher";
 import * as ALSurfaceVisibilityPublisher from "./ALSurfaceVisibilityPublisher";
@@ -24,8 +27,6 @@ import * as ALTriggerFlowlet from "./ALTriggerFlowlet";
 import { ALSharedInitOptions } from "./ALType";
 import * as ALUIEventGroupPublishers from "./ALUIEventGroupPublisher";
 import * as ALUIEventPublisher from "./ALUIEventPublisher";
-import * as ALDOMSnapshotPublisher from "./ALDOMSnaptshotPublisher";
-import * as ALHoverPublisher from "./ALHoverPublisher";
 
 /**
  * This type extracts the union of all events types so that external modules
@@ -39,6 +40,7 @@ export type ALChannelEvent = ChannelEventType<
   ALSurfaceMutationPublisher.InitOptions['channel'] &
   ALSurfaceVisibilityPublisher.InitOptions['channel'] &
   ALNetworkPublisher.InitOptions['channel'] &
+  ALSessionFlowID.InitOptions['channel'] &
   ALCustomEvent.ALCustomEventChannel
 >;
 
@@ -63,6 +65,7 @@ export type InitOptions = Types.Options<
     triggerFlowlet?: PublicInitOptions<ALTriggerFlowlet.InitOptions> | null;
     domSnapshotPublisher?: PublicInitOptions<ALDOMSnapshotPublisher.InitOptions> | null;
     plugins?: (null | undefined | PluginInit)[];
+    sessionFlowID?: PublicInitOptions<ALSessionFlowID.InitOptions> | null;
   }
 >;
 
@@ -149,6 +152,13 @@ export function init(options: InitOptions): boolean {
     reactOptions.enableInterceptFunctionComponentRender
   ) {
     IReactComponent.init(options.react);
+  }
+
+  if (options.sessionFlowID) {
+    ALSessionFlowID.init({
+      ...sharedOptions,
+      ...options.sessionFlowID
+    });
   }
 
   if (options.elementText) {

--- a/packages/hyperion-autologging/src/index.ts
+++ b/packages/hyperion-autologging/src/index.ts
@@ -14,3 +14,4 @@ export * as ALSurfaceUtils from "./ALSurfaceUtils";
 export * as ALCustomEvent from './ALCustomEvent';
 export { getCurrentUIEventData } from "./ALUIEventPublisher";
 export * as ALEventExtension from "./ALEventExtension";
+export { getSessionFlowID } from "./ALSessionFlowID";

--- a/packages/hyperion-react-testapp/src/AutoLoggingWrapper.ts
+++ b/packages/hyperion-react-testapp/src/AutoLoggingWrapper.ts
@@ -18,6 +18,7 @@ import { getEventExtension } from "hyperion-autologging/src/ALEventExtension";
 import * as Flags from "hyperion-globals/src/Flags";
 import "hyperion-autologging/src/reference";
 import * as PluginEventHash from "hyperion-autologging-plugin-eventhash/src/index";
+import { getSessionFlowID } from "hyperion-autologging/src/ALSessionFlowID";
 
 export let interceptionStatus = "disabled";
 
@@ -82,6 +83,10 @@ export function init() {
     },
     surface: {
       enableReactDomPropsExtension: false,
+    },
+    sessionFlowID: {
+      domain: 'localhost',
+      cookieName: 'axaxax',
     },
     elementText: {
       updateText(elementText: ExtendedElementText, domSource) {
@@ -158,4 +163,8 @@ export function init() {
   });
 
   console.log('AutoLogging.init options:', AutoLogging.getInitOptions());
+  // console.log('dsid', getDomainSessionID('localhost'));
+  // console.log('dsid', getDomainSessionID());
+  console.log('sfid', getSessionFlowID());
+
 }

--- a/packages/hyperion-react-testapp/src/AutoLoggingWrapper.ts
+++ b/packages/hyperion-react-testapp/src/AutoLoggingWrapper.ts
@@ -7,7 +7,7 @@ import { ALElementText } from "hyperion-autologging/src/ALInteractableDOMElement
 import * as AutoLogging from "hyperion-autologging/src/AutoLogging";
 import * as IReact from "hyperion-react/src/IReact";
 import * as IReactDOM from "hyperion-react/src/IReactDOM";
-import { ClientSessionID } from "hyperion-util/src/ClientSessionID";
+import { ClientSessionID, getDomainSessionID } from "hyperion-util/src/ClientSessionID";
 import React from 'react';
 import * as ReactDOM from "react-dom";
 import ReactDev from "react/jsx-dev-runtime";
@@ -49,6 +49,8 @@ export function init() {
   const testCompValidator = (name: string) => !name.match(/(^Surface(Proxy)?)/);
 
   console.log('csid:', ClientSessionID);
+  console.log('dsid', getDomainSessionID('localhost'));
+  console.log('dsid', getDomainSessionID());
 
   // Better to first setup listeners before initializing AutoLogging so we don't miss any events (e.g. Heartbeat(START))
 

--- a/packages/hyperion-util/src/ClientSessionID.ts
+++ b/packages/hyperion-util/src/ClientSessionID.ts
@@ -4,7 +4,8 @@
 
 'use strict';
 
-import { SessionPersistentData } from "./PersistentData";
+import { assert } from "hyperion-globals";
+import { CookiePersistentData, SessionPersistentData } from "./PersistentData";
 import { guid } from "./guid";
 
 export const ClientSessionID: string = new SessionPersistentData<string>(
@@ -14,3 +15,26 @@ export const ClientSessionID: string = new SessionPersistentData<string>(
   v => v,
   true, //In case page is immediately reloaded, we don't want to wait for the scheduler to save
 ).getValue();
+
+
+let domainSessionId: CookiePersistentData<string> | null = null;
+export function getDomainSessionID(topLevelDomain?: string, cookieName?: string): string {
+
+  if (!domainSessionId) {
+    const currentHostname = window.location.hostname;
+    if (topLevelDomain) {
+      assert(currentHostname.endsWith(topLevelDomain), "invalid top level domain for this page");
+    } else {
+      topLevelDomain = currentHostname;
+    }
+
+    domainSessionId = new CookiePersistentData<string>(
+      cookieName ?? 'aldsid',
+      guid,
+      v => v,
+      v => v,
+      `;domain=${topLevelDomain}; path=/`
+    );
+  }
+  return domainSessionId.getValue();
+}

--- a/packages/hyperion-util/src/PersistentData.ts
+++ b/packages/hyperion-util/src/PersistentData.ts
@@ -138,3 +138,30 @@ export class LocalStoragePersistentData<T> extends PersistentData<T> {
   }
 }
 
+export class CookieStorage implements IStorage {
+  constructor(private readonly cookieAttributes: string = "") { }
+
+  getItem(key: string): string | null {
+    const cookie = document.cookie.match(new RegExp(`${key}==([^;]*)(?:;|$)`));
+    if (cookie && cookie.length > 1) {
+      return cookie[1];
+    }
+    return null;
+  }
+
+  setItem(key: string, value: string): void {
+    document.cookie = `${key}=${value}${this.cookieAttributes}`;
+  }
+}
+
+export class CookiePersistentData<T> extends PersistentData<T> {
+  constructor(
+    fieldName: string,
+    missingValueInitializer: () => T,
+    stringify: (value: T) => string,
+    parser: (persistedValue: string) => T,
+    cookieAttributes?: string,
+  ) {
+    super(fieldName, missingValueInitializer, stringify, parser, true, new CookieStorage(cookieAttributes));
+  }
+}

--- a/packages/hyperion-util/src/PersistentData.ts
+++ b/packages/hyperion-util/src/PersistentData.ts
@@ -89,7 +89,11 @@ class PersistentData<T> {
       data = missingValueInitializer();
       this.setValue(data);
     } else {
-      data = parser(persistedData);
+      try {
+        data = parser(persistedData);
+      } catch {
+        data = missingValueInitializer();
+      }
     }
     this._data = data;
   }
@@ -142,7 +146,7 @@ export class CookieStorage implements IStorage {
   constructor(private readonly cookieAttributes: string = "") { }
 
   getItem(key: string): string | null {
-    const cookie = document.cookie.match(new RegExp(`${key}==([^;]*)(?:;|$)`));
+    const cookie = document.cookie.match(new RegExp(`${key}=([^;]*)(?:;|$)`));
     if (cookie && cookie.length > 1) {
       return cookie[1];
     }

--- a/packages/hyperion-util/src/index.ts
+++ b/packages/hyperion-util/src/index.ts
@@ -3,5 +3,5 @@
  */
 
 'use strict';
-export { ClientSessionID } from "./ClientSessionID";
-export { SessionPersistentData, LocalStoragePersistentData } from "./PersistentData";
+export { ClientSessionID, getDomainSessionID } from "./ClientSessionID";
+export { SessionPersistentData, LocalStoragePersistentData, CookiePersistentData, CookieStorage } from "./PersistentData";

--- a/packages/hyperion-util/src/index.ts
+++ b/packages/hyperion-util/src/index.ts
@@ -3,5 +3,5 @@
  */
 
 'use strict';
-export { ClientSessionID, getDomainSessionID } from "./ClientSessionID";
+export { ClientSessionID } from "./ClientSessionID";
 export { SessionPersistentData, LocalStoragePersistentData, CookiePersistentData, CookieStorage } from "./PersistentData";

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -100,6 +100,7 @@ export default defineConfig({
         "hyperion-autologging/src/ALInteractableDOMElement",
         "hyperion-autologging/src/AutoLogging",
         "hyperion-autologging/src/ALUIEventPublisher",
+        "hyperion-autologging/src/ALSessionFlowID",
         "hyperion-autologging/src/index",
       ],
       "hyperionAutoLoggingVisualizer": [


### PR DESCRIPTION
We need a mechanism to stitch together sessions that are part of one workflow, but may happen across various subdomains. The browser_session_id only works for apps on the same domain openned in the same tab.

assigning a session id to the top domain means that all tabs and apps on  the same domain will get the same value. Instead, trying another approach in which a short lived cookie  is set on the domain and then immediately picked up by the next  application that is openned.
In this way, we can stitch together flows between applications, and can  continue to rely on ClientSessionID for 'per tab' session identification.