### PR TITLE
Expoose ALGraph dynamic options

### DIFF
--- a/packages/hyperion-autologging-visualizer/src/component/ALGraph.ts
+++ b/packages/hyperion-autologging-visualizer/src/component/ALGraph.ts
@@ -237,9 +237,45 @@ export type ALGraphConstructorOptions = {
 
 export const AL_GRAPH_SCRATCH_NAMESPACE = '_algraph';
 
-export class ALGraph {
+export const ALGraphDefaultDynamicOptions: ALGraphDynamicOptionsType = {
+  version: 2,
+  events: {
+    al_ui_event: {
+      click: true,
+      change: false,
+      hover: false,
+    },
+    al_surface_mutation_event: {
+      mount_component: false,
+      unmount_component: false,
+    },
+    al_network_request: false,
+    al_network_response: false,
+    al_surface_visibility_event: {
+      surface_visible: false,
+      surface_hidden: false,
+    },
+  },
+  nodes: {
+    tuple: {
+      page_uri: false,
+      surface: false,
+      component: false,
+      text: false,
+    },
+    trigger_flowlet: false,
+  },
+  edges: {
+    trigger: false,
+    related_event_index: false,
+    tuple: false,
+  }
+};
+
+
+export class ALGraph<DynamicOptionsType extends ALGraphDynamicOptionsType = ALGraphDynamicOptionsType> {
   private readonly topContainer: Element | null;
-  private dynamicOptions?: ALGraphDynamicOptionsType;
+  private dynamicOptions?: DynamicOptionsType;
   private cy!: cytoscape.Core;
   private layout!: cytoscape.Layouts;
   private readonly onNodeClick?: (event: cytoscape.EventObject) => void;
@@ -705,7 +741,10 @@ export class ALGraph {
     return id;
   }
 
-  setDynamicOptions(dynamicOptions: ALGraphDynamicOptionsType): void {
+  getDynamicOptions(): DynamicOptionsType | undefined {
+    return this.dynamicOptions;
+  }
+  setDynamicOptions(dynamicOptions: DynamicOptionsType): void {
     this.dynamicOptions = dynamicOptions;
   }
 

--- a/packages/hyperion-autologging-visualizer/src/component/ALGraphInfo.react.tsx
+++ b/packages/hyperion-autologging-visualizer/src/component/ALGraphInfo.react.tsx
@@ -79,44 +79,9 @@ const StyleCss = `
 .al-graph-main-info { height: 100%}
 `;
 
-const DefaultOptions: ALGraph.ALGraphDynamicOptionsType = {
-  version: 2,
-  events: {
-    al_ui_event: {
-      click: true,
-      change: false,
-      hover: false,
-    },
-    al_surface_mutation_event: {
-      mount_component: false,
-      unmount_component: false,
-    },
-    al_network_request: false,
-    al_network_response: false,
-    al_surface_visibility_event: {
-      surface_visible: false,
-      surface_hidden: false,
-    },
-  },
-  nodes: {
-    tuple: {
-      page_uri: false,
-      surface: false,
-      component: false,
-      text: false,
-    },
-    trigger_flowlet: false,
-  },
-  edges: {
-    trigger: false,
-    related_event_index: false,
-    tuple: false,
-  }
-};
-
 const ALGraphOptions = new LocalStoragePersistentData<ALGraph.ALGraphDynamicOptionsType>(
   'alGraphOptions',
-  () => DefaultOptions,
+  () => ALGraph.ALGraphDefaultDynamicOptions,
   value => JSON.stringify(value),
   value => {
     /**
@@ -126,8 +91,8 @@ const ALGraphOptions = new LocalStoragePersistentData<ALGraph.ALGraphDynamicOpti
      */
     const options: ALGraph.ALGraphDynamicOptionsType = JSON.parse(value);
     const currentVersion = typeof options?.version === 'number' ? options.version : 0;
-    if (currentVersion < DefaultOptions.version) {
-      return DefaultOptions;
+    if (currentVersion < ALGraph.ALGraphDefaultDynamicOptions.version) {
+      return ALGraph.ALGraphDefaultDynamicOptions;
     } else {
       return options;
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -76,5 +76,5 @@ export { getCurrentUIEventData } from "@hyperion/hyperion-autologging/src/ALUIEv
 export * as ALEventExtension from "@hyperion/hyperion-autologging/src/ALEventExtension";
 
 // hyperionAutoLoggingVisualizer
-export { ALGraph, AL_GRAPH_SCRATCH_NAMESPACE} from "@hyperion/hyperion-autologging-visualizer/src/component/ALGraph";
+export { ALGraph, AL_GRAPH_SCRATCH_NAMESPACE, ALGraphDefaultDynamicOptions } from "@hyperion/hyperion-autologging-visualizer/src/component/ALGraph";
 export { ALGraphInfo } from "@hyperion/hyperion-autologging-visualizer/src/component/ALGraphInfo.react";


### PR DESCRIPTION
If a child class extends ALGraph, they might also want to extends its dynamic options.
This change makes the type a generic and exposes the function to get/set the value.