### PR TITLE
Improve innerText extraction with separate text parts

### DIFF
--- a/packages/hyperion-autologging/test/ALInteractableDOMElement.test.ts
+++ b/packages/hyperion-autologging/test/ALInteractableDOMElement.test.ts
@@ -187,7 +187,7 @@ describe("Test various element text options", () => {
     expect(getText(`3`)).toBe("test3");
     expect(getText(`4`)).toBe("test3");
     expect(getText(`5`)).toBe("test3");
-    expect(getText(`6`)).toBe("test3test8");
+    expect(getText(`6`)).toBe("test3 test8");
     expect(getText(`7`)).toBe("test7");
     expect(getText(`8`)).toBe("test8");
     expect(getText(`9`)).toBe("test9");
@@ -218,8 +218,8 @@ describe("Test various element text options", () => {
   test('labelable element label', () => {
     const badId = "ain't(good)";
     const dom = DomFragment.html(`
-      <input id='1'></input><label for='1'>test1</lablel>
-      <label><input id='2'></input>test2</lablel>
+      <input id='1'></input><label for='1'>test1</label>
+      <label><input id='2'></input>test2</label>
       <input id="${badId}"></input>
       <label for="${badId}">correct!</label>
     `);
@@ -232,6 +232,30 @@ describe("Test various element text options", () => {
     dom.cleanup();
   });
 
+  test('complex element label', () => {
+    const dom = DomFragment.html(`
+      <label data-clickable="1" data-keydownable="1"><div><div><input
+        aria-checked="true" aria-disabled="false"
+        aria-describedby="js_1p" aria-labelledby="js_1q"
+        id="js_1o" type="radio" value="SINGLE" checked="" name="js_1j"
+      ><div><div id="js_1q">Single image or video </div></div>
+ <div>One image or video, or a slideshow with multiple images</div></div></div></label>
+`);
+
+    expect(getText('js_1o')).toBe('Single image or video One image or video, or a slideshow with multiple images');
+    dom.cleanup();
+  });
+
+  test('element with repeated label id', () => {
+    const dom = DomFragment.html(`
+      <span id='3'>test3</span>
+      <span id='4' aria-labelledby="3 3 8 3"></span>
+      <span id='8'>test8</span>
+    `);
+
+    expect(getText('4')).toBe('test3 test8');
+    dom.cleanup();
+  });
 
   test("element text callbacks", () => {
     const dom = createTestDom();
@@ -267,7 +291,7 @@ describe("Test various element text options", () => {
       }
     });
     const text = ALInteractableDOMElement.getElementTextEvent(dom.root, null);
-    expect(text.elementName).toBe("  test1  test2  test3  test3  test3  test3test*  test7  test*  test*  test10  ");
+    expect(text.elementName).toBe("  test1  test2  test3  test3  test3  test3 test*  test7  test*  test*  test10  ");
     console.log(text);
     dom.cleanup();
   });

--- a/packages/hyperion-react-testapp/src/App.tsx
+++ b/packages/hyperion-react-testapp/src/App.tsx
@@ -50,12 +50,12 @@ const Modes = {
     <div>
       <PortalBodyContainerComponent message="Portal outside of Surface"></PortalBodyContainerComponent>
     </div>
-    <div>
-      <ElementNameComponent />
-    </div>
-    <TextComponent />
     <RecursiveFuncComponent i={3}></RecursiveFuncComponent>
   </>,
+  'ElementText': () => <div>
+    <ElementNameComponent />
+    <TextComponent />
+  </div>,
 };
 type ModeNames = keyof typeof Modes;
 const PersistedOptionValue = new LocalStoragePersistentData<ModeNames>(
@@ -77,6 +77,10 @@ const PersistedToolOptionValue = new LocalStoragePersistentData<ToolNames>(
   value => value in Tools ? value as ToolNames : 'alGraph'
 );
 
+function isValidMode(mode: string): mode is ModeNames {
+  return mode in Modes;
+}
+
 function App() {
 
   const [mode, setMode] = useState<ModeNames>(PersistedOptionValue.getValue());
@@ -84,7 +88,7 @@ function App() {
 
   const onModeChange = useCallback<ChangeEventHandler<HTMLSelectElement>>((event) => {
     const value = event.target.value;
-    if (value === 'mutationOnlySurface' || value === 'network' || value === 'nested') {
+    if (isValidMode(value)) {
       PersistedOptionValue.setValue(value);
       setMode(value);
     }

--- a/packages/hyperion-react-testapp/src/component/ElementNameComponent.tsx
+++ b/packages/hyperion-react-testapp/src/component/ElementNameComponent.tsx
@@ -75,6 +75,12 @@ export default function (/* props: Props */) {
           <option value='_v3' >V3</option>
         </select>
       </div>
+      <label data-clickable="1" data-keydownable="1"><div><div><input
+        aria-checked="true" aria-disabled="false"
+        aria-describedby="js_1p" aria-labelledby="js_1q"
+        id="js_1o" type="radio" value="SINGLE" checked={true} name="js_1j"
+      /><div><div id="js_1q">Single image or video </div></div>
+        <div>One image or video, or a slideshow with multiple images</div></div></div></label>
     </div>
   </SurfaceComp>;
 }


### PR DESCRIPTION
Sometimes applications might need to process individual parts of the text separately (e.g. compare against an internal translation table). To facilitate this, replace previous implementation `getTextFromInnerText` to explicitly walk the sub-tree and extract the text.

Along the way, also enhanced the aria-* algorithm to be more standard compliant.