### PR TITLE
Fix trigger flowlet propagation

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -29,10 +29,10 @@
       // "cwd": "${workspaceRoot}/packages/hyperion-global",
       // "cwd": "${workspaceRoot}/packages/hyperion-hook",
       // "cwd": "${workspaceRoot}/packages/hyperion-channel",
-      "cwd": "${workspaceRoot}/packages/hyperion-autologging",
+      // "cwd": "${workspaceRoot}/packages/hyperion-autologging",
       // "cwd": "${workspaceRoot}/packages/hyperion-core",
       // "cwd": "${workspaceRoot}/packages/hyperion-dom",
-      // "cwd": "${workspaceRoot}/packages/hyperion-flowlet",
+      "cwd": "${workspaceRoot}/packages/hyperion-flowlet",
       // "cwd": "${workspaceRoot}/packages/hyperion-react",
       // "cwd": "${workspaceRoot}/packages/hyperion-util",
       "runtimeArgs": [

--- a/packages/hyperion-autologging/src/ALType.ts
+++ b/packages/hyperion-autologging/src/ALType.ts
@@ -3,6 +3,7 @@
  */
 
 'use strict';
+import "./reference";
 
 import type { BaseChannelEventType, Channel } from "@hyperion/hyperion-channel/src/Channel";
 import * as Types from "@hyperion/hyperion-util/src/Types";

--- a/packages/hyperion-autologging/src/global.d.ts
+++ b/packages/hyperion-autologging/src/global.d.ts
@@ -1,0 +1,9 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved.
+ */
+
+// / <reference path="@hyperion/hyperion-global/src/global.d.ts" />
+
+interface GlobalFlags {
+  preciseTriggerFlowlet?: boolean;
+}

--- a/packages/hyperion-autologging/src/reference.ts
+++ b/packages/hyperion-autologging/src/reference.ts
@@ -2,5 +2,4 @@
  * Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved.
  */
 
-export * from "./assert";
-export * from "./Flags";
+/// <reference path="./global.d.ts" />

--- a/packages/hyperion-flowlet/src/Flowlet.ts
+++ b/packages/hyperion-flowlet/src/Flowlet.ts
@@ -1,7 +1,7 @@
 /**
  * Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved.
  */
-
+import "./reference";
 import { assert } from "@hyperion/hyperion-global";
 import { Hook } from "@hyperion/hyperion-hook";
 

--- a/packages/hyperion-flowlet/src/global.d.ts
+++ b/packages/hyperion-flowlet/src/global.d.ts
@@ -1,0 +1,9 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved.
+ */
+
+// / <reference path="@hyperion/hyperion-global/src/global.d.ts" />
+
+interface GlobalFlags {
+  preciseTriggerFlowlet?: boolean;
+}

--- a/packages/hyperion-flowlet/src/reference.ts
+++ b/packages/hyperion-flowlet/src/reference.ts
@@ -2,5 +2,4 @@
  * Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved.
  */
 
-export * from "./assert";
-export * from "./Flags";
+/// <reference path="./global.d.ts" />

--- a/packages/hyperion-global/src/Flags.ts
+++ b/packages/hyperion-global/src/Flags.ts
@@ -1,0 +1,15 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved.
+ */
+
+import "./reference";
+
+let _globalFlags: GlobalFlags = {};
+
+export function getFlags(): GlobalFlags {
+  return _globalFlags;
+}
+
+export function setFlags(flags: GlobalFlags): void {
+  _globalFlags = flags;
+}

--- a/packages/hyperion-global/src/global.d.ts
+++ b/packages/hyperion-global/src/global.d.ts
@@ -3,3 +3,12 @@
  */
 
 declare var __DEV__: boolean;
+
+/**
+ * We use TypeScripts interface merging feature to allow
+ * each package define its own global flags locally
+ * and use them, but have an api that read/write the
+ * global flags in an opaque way
+ */
+interface GlobalFlags {
+}

--- a/packages/hyperion-react-testapp/src/AutoLoggingWrapper.ts
+++ b/packages/hyperion-react-testapp/src/AutoLoggingWrapper.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved.
  */
 
-import * as Visualizer from "@hyperion/hyperion-autologging-visualizer/src/index";
+import * as Visualizer from "@hyperion/hyperion-autologging-visualizer/src/Visualizer";
 import { ALElementText } from "@hyperion/hyperion-autologging/src/ALInteractableDOMElement";
 import * as AutoLogging from "@hyperion/hyperion-autologging/src/AutoLogging";
 import * as IReact from "@hyperion/hyperion-react/src/IReact";
@@ -15,10 +15,15 @@ import { SyncChannel } from "./Channel";
 import { FlowletManager } from "./FlowletManager";
 import { ALExtensibleEvent } from "@hyperion/hyperion-autologging/src/ALType";
 import { getEventExtension } from "@hyperion/hyperion-autologging/src/ALEventExtension";
+import * as Flags from "@hyperion/hyperion-global/src/Flags";
+import "@hyperion/hyperion-autologging/src/reference";
+
 
 export let interceptionStatus = "disabled";
 
 export function init() {
+  Flags.setFlags({ preciseTriggerFlowlet: true });
+
   interceptionStatus = "enabled";
   const flowletManager = FlowletManager;
 


### PR DESCRIPTION
 Fix Trigger Flowlet logic

    A few changes in this commit:
    - Added a generic mechanism to add global flags, useful for when we want
      to add some temporary flags to test rollout of a fix/feature
    - I noticed that when we wrap the callbacks, we always delete the
      triggerFlowlet of the top of the stack. The correct logic is that we
      should only do this if we have a `getTriggerFlowlet` function and may
      change the value in every invokation based on some argument of the
      function. Otherwise we should not touch the value.
    - For UI event, we are not setting the callFlowlet correctly (based on
      how the callback was installed). This is mostly a noop since we don't
      use the callFlowlet of the UI event, but just wanted to make it more
      consistent.