### PR TITLE
Package index

### DIFF
--- a/packages/hyperion-async-counter/src/index.ts
+++ b/packages/hyperion-async-counter/src/index.ts
@@ -2,5 +2,5 @@
  * Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved.
  */
 
-export * from "./assert";
-// export { setAssertLoggerOptions } from "./assert";
+'use strict';
+export { AsyncCounter } from "./AsyncCounter";

--- a/packages/hyperion-autologging-visualizer/src/Visualizer.ts
+++ b/packages/hyperion-autologging-visualizer/src/Visualizer.ts
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved.
+ */
+
+'use strict';
+import * as Types from "@hyperion/hyperion-util/src/Types";
+import * as AutoLogging from "@hyperion/hyperion-autologging/src/AutoLogging";
+import { Channel } from "@hyperion/hyperion-channel/src/Channel";
+import * as ElementTextTooltip from "./component/ElementTextTooltip.react";
+
+export type InitOptions = Types.Options<
+  Pick<AutoLogging.InitOptions, 'flowletManager'> &
+  {
+    channel: Channel<AutoLogging.ALChannelEvent>
+  }
+>;
+
+ export function init(options: InitOptions) {
+  ElementTextTooltip.init(options);
+}

--- a/packages/hyperion-autologging-visualizer/src/index.ts
+++ b/packages/hyperion-autologging-visualizer/src/index.ts
@@ -3,18 +3,5 @@
  */
 
 'use strict';
-import * as Types from "@hyperion/hyperion-util/src/Types";
-import * as AutoLogging from "@hyperion/hyperion-autologging/src/AutoLogging";
-import { Channel } from "@hyperion/hyperion-channel/src/Channel";
-import * as ElementTextTooltip from "./component/ElementTextTooltip.react";
-
-export type InitOptions = Types.Options<
-  Pick<AutoLogging.InitOptions, 'flowletManager'> &
-  {
-    channel: Channel<AutoLogging.ALChannelEvent>
-  }
->;
-
-export function init(options: InitOptions) {
-  ElementTextTooltip.init(options);
-}
+export { ALGraph, AL_GRAPH_SCRATCH_NAMESPACE, ALGraphDefaultDynamicOptions } from "./component/ALGraph";
+export { ALGraphInfo } from "./component/ALGraphInfo.react";

--- a/packages/hyperion-autologging/src/ALUIEventPublisher.ts
+++ b/packages/hyperion-autologging/src/ALUIEventPublisher.ts
@@ -12,7 +12,6 @@ import { TimedTrigger } from "@hyperion/hyperion-timed-trigger/src/TimedTrigger"
 import performanceAbsoluteNow from "@hyperion/hyperion-util/src/performanceAbsoluteNow";
 import ALElementInfo from './ALElementInfo';
 import * as ALEventIndex from "./ALEventIndex";
-import { IALFlowlet } from "./ALFlowletManager";
 import { ALID, getOrSetAutoLoggingID } from "./ALID";
 import { ALElementTextEvent, TrackEventHandlerConfig, enableUIEventHandlers, getElementTextEvent, getInteractable, isTrackedEvent } from "./ALInteractableDOMElement";
 import { ReactComponentData } from "./ALReactUtils";
@@ -159,14 +158,6 @@ export function trackAndEnableUIEventHandlers(eventName: UIEventConfig['eventNam
   enableUIEventHandlers(eventName, eventHandlerConfig);
 }
 
-/**
- *
- * @param event - the event to check whether it's valid and we want to push/pop it on the flowlet stack
- * @returns boolean indicating if flowlet should be added/removed from stack
- * Whether to push/pop this event's flowlet via FlowletManager
- */
-const shouldPushPopFlowlet = (event: Event) => event.bubbles && event.isTrusted;
-
 function getCommonEventData<T extends keyof DocumentEventMap>(eventConfig: UIEventConfig, eventName: T, event: DocumentEventMap[T]): CommonEventData | null {
   const eventTimestamp = performanceAbsoluteNow();
 
@@ -289,9 +280,6 @@ export function publish(options: InitOptions): void {
       }
       flowletName += ')';
       let callFlowlet = new flowletManager.flowletCtor(flowletName, ALUIEventGroupPublisher.getGroupRootFlowlet(event));
-      if (shouldPushPopFlowlet(event)) {
-        callFlowlet = flowletManager.push(callFlowlet);
-      }
       let reactComponentData: ReactComponentData | null = null;
       if (targetElement && cacheElementReactInfo) {
         const elementInfo = ALElementInfo.getOrCreate(targetElement);
@@ -350,11 +338,6 @@ export function publish(options: InitOptions): void {
           Object.assign(data.metadata, uiEventData.metadata);
           timedEmitter.run();
         }
-      }
-
-      let callFlowlet: IALFlowlet | undefined;
-      if (shouldPushPopFlowlet(event)) {
-        flowletManager.pop(callFlowlet);
       }
     };
 

--- a/packages/hyperion-autologging/src/index.ts
+++ b/packages/hyperion-autologging/src/index.ts
@@ -1,0 +1,16 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved.
+ */
+
+'use strict';
+export { ALFlowlet, ALFlowletManager } from "./ALFlowletManager";
+export { useALSurfaceContext } from "./ALSurfaceContext";
+export * as ALEventIndex from "./ALEventIndex";
+export { default as ALElementInfo } from "./ALElementInfo";
+export * as ALInteractableDOMElement from "./ALInteractableDOMElement";
+export * as AutoLogging from "./AutoLogging";
+export { ALSurfaceCapability } from "./ALSurface";
+export * as ALSurfaceUtils from "./ALSurfaceUtils";
+export * as ALCustomEvent from './ALCustomEvent';
+export { getCurrentUIEventData } from "./ALUIEventPublisher";
+export * as ALEventExtension from "./ALEventExtension";

--- a/packages/hyperion-channel/src/index.ts
+++ b/packages/hyperion-channel/src/index.ts
@@ -2,5 +2,5 @@
  * Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved.
  */
 
-export * from "./assert";
-// export { setAssertLoggerOptions } from "./assert";
+'use strict';
+export { PipeableEmitter, Channel, PausableChannel } from "./Channel";

--- a/packages/hyperion-core/src/index.ts
+++ b/packages/hyperion-core/src/index.ts
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved.
+ */
+
+'use strict';
+export { intercept, getVirtualPropertyValue, setVirtualPropertyValue, getOwnShadowPrototypeOf, registerShadowPrototype } from "./intercept";
+export { interceptFunction, getFunctionInterceptor } from "./FunctionInterceptor";
+export { interceptMethod } from "./MethodInterceptor";
+export { interceptConstructor, interceptConstructorMethod } from "./ConstructorInterceptor";
+export * as IRequire from "./IRequire";
+export * as IPromise from "./IPromise";
+export * as IGlobalThis from "./IGlobalThis";

--- a/packages/hyperion-devtools/src/index.ts
+++ b/packages/hyperion-devtools/src/index.ts
@@ -1,6 +1,3 @@
 /**
  * Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved.
  */
-
-export * from "./assert";
-// export { setAssertLoggerOptions } from "./assert";

--- a/packages/hyperion-docs/src/index.ts
+++ b/packages/hyperion-docs/src/index.ts
@@ -1,6 +1,3 @@
 /**
  * Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved.
  */
-
-export * from "./assert";
-// export { setAssertLoggerOptions } from "./assert";

--- a/packages/hyperion-dom/src/index.ts
+++ b/packages/hyperion-dom/src/index.ts
@@ -1,0 +1,15 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved.
+ */
+
+'use strict';
+export * as IEvent from "./IEvent";
+export * as IEventTarget from "./IEventTarget";
+// export * as INode from "./INode";
+export * as IElement from "./IElement";
+export * as IHTMLElement from "./IHTMLElement";
+export * as IHTMLInputElement from "./IHTMLInputElement";
+export * as ICSSStyleDeclaration from "./ICSSStyleDeclaration";
+// export * as IGlobalEventHandlers from "./IGlobalEventHandlers";
+export * as IWindow from "./IWindow";
+// export * as IXMLHttpRequest from "./IXMLHttpRequest";

--- a/packages/hyperion-flowlet/src/index.ts
+++ b/packages/hyperion-flowlet/src/index.ts
@@ -1,0 +1,9 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved.
+ */
+
+'use strict';
+export { Flowlet, onFlowletInit } from "./Flowlet";
+export { FlowletManager } from "./FlowletManager";
+export { getTriggerFlowlet, setTriggerFlowlet } from "./TriggerFlowlet";
+export { initFlowletTrackers } from "./FlowletWrappers";

--- a/packages/hyperion-hook/src/index.ts
+++ b/packages/hyperion-hook/src/index.ts
@@ -2,5 +2,5 @@
  * Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved.
  */
 
-export * from "./assert";
-// export { setAssertLoggerOptions } from "./assert";
+'use strict';
+export { Hook } from "./Hook";

--- a/packages/hyperion-react-testapp/src/index.ts
+++ b/packages/hyperion-react-testapp/src/index.ts
@@ -1,6 +1,3 @@
 /**
  * Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved.
  */
-
-export * from "./assert";
-// export { setAssertLoggerOptions } from "./assert";

--- a/packages/hyperion-react/src/index.ts
+++ b/packages/hyperion-react/src/index.ts
@@ -1,0 +1,8 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved.
+ */
+
+'use strict';
+export * as IReact from "./IReact";
+export * as IReactDOM from "./IReactDOM";
+export * as IReactComponent from "./IReactComponent"

--- a/packages/hyperion-test-and-set/src/index.ts
+++ b/packages/hyperion-test-and-set/src/index.ts
@@ -2,5 +2,5 @@
  * Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved.
  */
 
-export * from "./assert";
-// export { setAssertLoggerOptions } from "./assert";
+'use strict';
+export { default as TestAndSet } from "./TestAndSet";

--- a/packages/hyperion-timed-trigger/src/index.ts
+++ b/packages/hyperion-timed-trigger/src/index.ts
@@ -2,5 +2,5 @@
  * Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved.
  */
 
-export * from "./assert";
-// export { setAssertLoggerOptions } from "./assert";
+'use strict';
+export { TimedTrigger } from "./TimedTrigger";

--- a/packages/hyperion-util/src/index.ts
+++ b/packages/hyperion-util/src/index.ts
@@ -1,0 +1,7 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved.
+ */
+
+'use strict';
+export { ClientSessionID } from "./ClientSessionID";
+export { SessionPersistentData, LocalStoragePersistentData } from "./PersistentData";

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -12,23 +12,31 @@ export default defineConfig({
     // file: './dist/hyperion.js',
     dir: './dist',
     manualChunks: {
+      "hyperionGlobal": [
+        "@hyperion/hyperion-global/src/assert",
+        "@hyperion/hyperion-global/src/index",
+      ],
       "hyperionHook": [
         "@hyperion/hyperion-hook/src/Hook",
+        "@hyperion/hyperion-hook/src/index",
       ],
       "hyperionChannel": [
         "@hyperion/hyperion-channel/src/Channel",
+        "@hyperion/hyperion-channel/src/index",
       ],
       "hyperionAsyncCounter": [
         "@hyperion/hyperion-async-counter/src/AsyncCounter",
+        "@hyperion/hyperion-async-counter/src/index",
       ],
       "hyperionTimedTrigger": [
         "@hyperion/hyperion-timed-trigger/src/TimedTrigger",
+        "@hyperion/hyperion-timed-trigger/src/index",
       ],
       "hyperionTestAndSet": [
         "@hyperion/hyperion-test-and-set/src/TestAndSet",
+        "@hyperion/hyperion-test-and-set/src/index",
       ],
       "hyperionCore": [
-        "@hyperion/hyperion-global/src/assert",
         "@hyperion/hyperion-core/src/FunctionInterceptor",
         "@hyperion/hyperion-core/src/ConstructorInterceptor",
         "@hyperion/hyperion-core/src/AttributeInterceptor",
@@ -36,6 +44,7 @@ export default defineConfig({
         "@hyperion/hyperion-core/src/IRequire",
         "@hyperion/hyperion-core/src/IPromise",
         "@hyperion/hyperion-core/src/IGlobalThis",
+        "@hyperion/hyperion-core/src/index",
       ],
       "hyperionDOM": [
         "@hyperion/hyperion-dom/src/IEvent",
@@ -49,6 +58,7 @@ export default defineConfig({
         "@hyperion/hyperion-dom/src/IXMLHttpRequest",
         "@hyperion/hyperion-dom/src/ICSSStyleDeclaration",
         "@hyperion/hyperion-dom/src/IGlobalEventHandlers",
+        "@hyperion/hyperion-dom/src/index",
       ],
       "hyperionTrackElementsWithAttributes": [
         "@hyperion/hyperion-util/src/trackElementsWithAttributes",
@@ -59,6 +69,7 @@ export default defineConfig({
       "hyperionUtil": [
         "@hyperion/hyperion-util/src/ClientSessionID",
         "@hyperion/hyperion-util/src/PersistentData",
+        "@hyperion/hyperion-util/src/index",
       ],
       "hyperionFlowletCore": [
         "@hyperion/hyperion-flowlet/src/Flowlet",
@@ -67,11 +78,13 @@ export default defineConfig({
       ],
       "hyperionFlowlet": [
         "@hyperion/hyperion-flowlet/src/FlowletWrappers",
+        "@hyperion/hyperion-flowlet/src/index",
       ],
       "hyperionReact": [
         "@hyperion/hyperion-react/src/IReact",
         "@hyperion/hyperion-react/src/IReactDOM",
         "@hyperion/hyperion-react/src/IReactComponent",
+        "@hyperion/hyperion-react/src/index",
       ],
       "hyperionAutoLogging": [
         "@hyperion/hyperion-autologging/src/ALEventExtension",
@@ -85,10 +98,12 @@ export default defineConfig({
         "@hyperion/hyperion-autologging/src/ALInteractableDOMElement",
         "@hyperion/hyperion-autologging/src/AutoLogging",
         "@hyperion/hyperion-autologging/src/ALUIEventPublisher",
+        "@hyperion/hyperion-autologging/src/index",
       ],
       "hyperionAutoLoggingVisualizer": [
         "@hyperion/hyperion-autologging-visualizer/src/component/ALGraph",
         "@hyperion/hyperion-autologging-visualizer/src/component/ALGraphInfo.react",
+        "@hyperion/hyperion-autologging-visualizer/src/index",
       ]
     },
     chunkFileNames: "[name].js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,42 +2,31 @@
  * Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved.
  */
 
+'use strict';
+
+// hyperionGlobal
+export * from "@hyperion/hyperion-global/src/index";
+
 // hyperionAsyncCounter
-export { AsyncCounter } from "@hyperion/hyperion-async-counter/src/AsyncCounter";
+export * from "@hyperion/hyperion-async-counter/src/index";
 
 // hyperionHook
-export { Hook } from "@hyperion/hyperion-hook/src/Hook";
+export * from "@hyperion/hyperion-hook/src/index";
 
 // hyperionChannel
-export { PipeableEmitter, Channel, PausableChannel } from "@hyperion/hyperion-channel/src/Channel";
+export * from "@hyperion/hyperion-channel/src/index";
 
 // hyperionTimedTrigger
-export { TimedTrigger } from "@hyperion/hyperion-timed-trigger/src/TimedTrigger";
+export * from  "@hyperion/hyperion-timed-trigger/src/index";
 
 // hyperionTestAndSet
-export { default as TestAndSet } from "@hyperion/hyperion-test-and-set/src/TestAndSet";
+export * from "@hyperion/hyperion-test-and-set/src/index";
 
 // hyperionCore
-export { setAssertLoggerOptions } from "@hyperion/hyperion-global/src/assert";
-export { intercept, getVirtualPropertyValue, setVirtualPropertyValue, getOwnShadowPrototypeOf, registerShadowPrototype } from "@hyperion/hyperion-core/src/intercept";
-export { interceptFunction, getFunctionInterceptor } from "@hyperion/hyperion-core/src/FunctionInterceptor";
-export { interceptMethod } from "@hyperion/hyperion-core/src/MethodInterceptor";
-export { interceptConstructor, interceptConstructorMethod } from "@hyperion/hyperion-core/src/ConstructorInterceptor";
-export * as IRequire from "@hyperion/hyperion-core/src/IRequire";
-export * as IPromise from "@hyperion/hyperion-core/src/IPromise";
-export * as IGlobalThis from "@hyperion/hyperion-core/src/IGlobalThis";
+export * from "@hyperion/hyperion-core/src/index";
 
 // hyperionDOM
-export * as IEvent from "@hyperion/hyperion-dom/src/IEvent";
-export * as IEventTarget from "@hyperion/hyperion-dom/src/IEventTarget";
-// export * as INode from "@hyperion/hyperion-dom/src/INode";
-export * as IElement from "@hyperion/hyperion-dom/src/IElement";
-export * as IHTMLElement from "@hyperion/hyperion-dom/src/IHTMLElement";
-export * as IHTMLInputElement from "@hyperion/hyperion-dom/src/IHTMLInputElement";
-export * as ICSSStyleDeclaration from "@hyperion/hyperion-dom/src/ICSSStyleDeclaration";
-// export * as IGlobalEventHandlers from "@hyperion/hyperion-dom/src/IGlobalEventHandlers";
-export * as IWindow from "@hyperion/hyperion-dom/src/IWindow";
-// export * as IXMLHttpRequest from "@hyperion/hyperion-dom/src/IXMLHttpRequest";
+export * from "@hyperion/hyperion-dom/src/index";
 
 // hyperionTrackElementsWithAttributes
 export { trackElementsWithAttributes } from "@hyperion/hyperion-util/src/trackElementsWithAttributes";
@@ -46,35 +35,22 @@ export { trackElementsWithAttributes } from "@hyperion/hyperion-util/src/trackEl
 export * as SyncMutationObserver from "@hyperion/hyperion-util/src/SyncMutationObserver";
 
 // hyperionUtil
-export { ClientSessionID } from "@hyperion/hyperion-util/src/ClientSessionID";
-export { SessionPersistentData, LocalStoragePersistentData } from "@hyperion/hyperion-util/src/PersistentData";
+export * from "@hyperion/hyperion-util/src/index";
 
 // hyperionFlowletCore
-export { Flowlet, onFlowletInit } from "@hyperion/hyperion-flowlet/src/Flowlet";
-export { FlowletManager } from "@hyperion/hyperion-flowlet/src/FlowletManager";
-export { getTriggerFlowlet, setTriggerFlowlet } from "@hyperion/hyperion-flowlet/src/TriggerFlowlet";
+// export { Flowlet, onFlowletInit } from "@hyperion/hyperion-flowlet/src/Flowlet";
+// export { FlowletManager } from "@hyperion/hyperion-flowlet/src/FlowletManager";
+// export { getTriggerFlowlet, setTriggerFlowlet } from "@hyperion/hyperion-flowlet/src/TriggerFlowlet";
 
 // hyperionFlowlet
-export { initFlowletTrackers } from "@hyperion/hyperion-flowlet/src/FlowletWrappers";
+// export { initFlowletTrackers } from "@hyperion/hyperion-flowlet/src/FlowletWrappers";
+export * from "@hyperion/hyperion-flowlet/src/index";
 
 // hyperionReact
-export * as IReact from "@hyperion/hyperion-react/src/IReact";
-export * as IReactDOM from "@hyperion/hyperion-react/src/IReactDOM";
-export * as IReactComponent from "@hyperion/hyperion-react/src/IReactComponent"
+export *  from "@hyperion/hyperion-react/src/index";
 
 // hyperionAutoLogging
-export { ALFlowlet, ALFlowletManager } from "@hyperion/hyperion-autologging/src/ALFlowletManager";
-export { useALSurfaceContext } from "@hyperion/hyperion-autologging/src/ALSurfaceContext";
-export * as ALEventIndex from "@hyperion/hyperion-autologging/src/ALEventIndex";
-export { default as ALElementInfo } from "@hyperion/hyperion-autologging/src/ALElementInfo";
-export * as ALInteractableDOMElement from "@hyperion/hyperion-autologging/src/ALInteractableDOMElement";
-export * as AutoLogging from "@hyperion/hyperion-autologging/src/AutoLogging";
-export { ALSurfaceCapability } from "@hyperion/hyperion-autologging/src/ALSurface";
-export * as ALSurfaceUtils from "@hyperion/hyperion-autologging/src/ALSurfaceUtils";
-export * as ALCustomEvent from '@hyperion/hyperion-autologging/src/ALCustomEvent';
-export { getCurrentUIEventData } from "@hyperion/hyperion-autologging/src/ALUIEventPublisher";
-export * as ALEventExtension from "@hyperion/hyperion-autologging/src/ALEventExtension";
+export *  from "@hyperion/hyperion-autologging/src/index";
 
 // hyperionAutoLoggingVisualizer
-export { ALGraph, AL_GRAPH_SCRATCH_NAMESPACE, ALGraphDefaultDynamicOptions } from "@hyperion/hyperion-autologging-visualizer/src/component/ALGraph";
-export { ALGraphInfo } from "@hyperion/hyperion-autologging-visualizer/src/component/ALGraphInfo.react";
+export * from "@hyperion/hyperion-autologging-visualizer/src/index";


### PR DESCRIPTION
 Separated exported files of each package

    Instead of listing what each package exports in the main index.ts, I
    created one index per package to have all the data local. This is easier
    to track what each package exports. This is also more compatible with
    the npm convention.
    I needed to export the new global flags feature in another diff and
    realized it is hard to to manage these.

    This change also add a new hyperionGlobal chunk that matches the
    hyperion-global packages.