### PR TITLE
Improve performance of interactive dom element detection

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -29,10 +29,10 @@
       // "cwd": "${workspaceRoot}/packages/hyperion-global",
       // "cwd": "${workspaceRoot}/packages/hyperion-hook",
       // "cwd": "${workspaceRoot}/packages/hyperion-channel",
-      // "cwd": "${workspaceRoot}/packages/hyperion-autologging",
+      "cwd": "${workspaceRoot}/packages/hyperion-autologging",
       // "cwd": "${workspaceRoot}/packages/hyperion-core",
       // "cwd": "${workspaceRoot}/packages/hyperion-dom",
-      "cwd": "${workspaceRoot}/packages/hyperion-flowlet",
+      // "cwd": "${workspaceRoot}/packages/hyperion-flowlet",
       // "cwd": "${workspaceRoot}/packages/hyperion-react",
       // "cwd": "${workspaceRoot}/packages/hyperion-util",
       "runtimeArgs": [

--- a/packages/hyperion-autologging-visualizer/src/component/ALGraph.ts
+++ b/packages/hyperion-autologging-visualizer/src/component/ALGraph.ts
@@ -3,7 +3,7 @@
  */
 // import React, {useState, useCallback, useRef, useEffect} from "react";
 import { SURFACE_SEPARATOR } from '@hyperion/hyperion-autologging/src/ALSurfaceConsts';
-import { ALExtensibleEvent, ALFlowletEvent } from '@hyperion/hyperion-autologging/src/ALType';
+import { ALExtensibleEvent, ALFlowletEvent, ALLoggableEvent } from '@hyperion/hyperion-autologging/src/ALType';
 import { ALChannelEvent } from '@hyperion/hyperion-autologging/src/AutoLogging';
 import { Channel, PausableChannel } from '@hyperion/hyperion-channel';
 import { Flowlet } from '@hyperion/hyperion-flowlet/src/Flowlet';
@@ -193,7 +193,7 @@ export type ALGraphDynamicOptionsType = {
 };
 
 type SupportedALEventNames = (keyof ALGraphDynamicOptionsType['events']) & (keyof ALChannelEvent); // & to filter out typos in the list
-type SupportedALEventData<T extends SupportedALEventNames> = ALChannelEvent[T][0] & Partial<Nullable<ALFlowletEvent>> & ALExtensibleEvent;
+type SupportedALEventData<T extends SupportedALEventNames> = ALChannelEvent[T][0] & Partial<Nullable<ALFlowletEvent>> & ALExtensibleEvent & ALLoggableEvent;
 export type EventInfo<T extends SupportedALEventNames> = {
   eventName: T,
   eventData: SupportedALEventData<T>,
@@ -383,13 +383,13 @@ export class ALGraph<DynamicOptionsType extends ALGraphDynamicOptionsType = ALGr
 
   // An optimization to avoid unnecessary relayout when no elements are added
   private _elements: cytoscape.CollectionReturnValue | null = null;
-  private reLayout() {
+  protected reLayout() {
     // this._elements?.layout(getCytoscapeLayoutConfig()).run();
     this.layout.stop();
     this.layout = this.cy.layout(getCytoscapeLayoutConfig());
     this.layout.run();
   }
-  private startBatch() {
+  protected startBatch() {
     assert(this._elements == null, "Should not call startBatch before ending previous batch");
     this._elements = this.cy.collection();
     this.cy.startBatch();

--- a/packages/hyperion-autologging/src/ALInteractableDOMElement.ts
+++ b/packages/hyperion-autologging/src/ALInteractableDOMElement.ts
@@ -50,7 +50,6 @@ const EventHandlerTrackerAttribute = `data-interactable`;
 export function getInteractable(
   node: EventTarget | null,
   eventName: UIEventConfig['eventName'],
-  returnInteractableNode: boolean = false,
   // Whether to require an actual handler is assigned to determine interactiveness, rather than including "interactive" element tags
   requireHandlerAssigned: boolean = false,
 ): HTMLElement | null {
@@ -62,7 +61,7 @@ export function getInteractable(
         if (ignoreInteractiveElement(element)) {
           continue;
         }
-        return returnInteractableNode ? element : node;
+        return element;
       }
     }
   }
@@ -618,7 +617,6 @@ export function getElementTextEvent(
     const parentInteractable = getInteractable(
       element.parentElement,
       tryInteractableParentEventName,
-      true,
       // Limit to elements with installed handlers for interactiveness check.
       true
     );

--- a/packages/hyperion-autologging/src/ALUIEventPublisher.ts
+++ b/packages/hyperion-autologging/src/ALUIEventPublisher.ts
@@ -180,7 +180,7 @@ function getCommonEventData<T extends keyof DocumentEventMap>(eventConfig: UIEve
      * We use that as the base of event to ensure the text, surface, ... for events
      * remain consistent no matter where the user actually clicked, hovered, ...
      */
-    element = getInteractable(event.target, eventName, true);
+    element = getInteractable(event.target, eventName);
     if (element == null) {
       return null;
     }

--- a/packages/hyperion-autologging/src/global.d.ts
+++ b/packages/hyperion-autologging/src/global.d.ts
@@ -6,4 +6,5 @@
 
 interface GlobalFlags {
   preciseTriggerFlowlet?: boolean;
+  optimizeInteractibiltyCheck?: boolean;
 }

--- a/packages/hyperion-autologging/test/ALInteractableDOMElement.test.ts
+++ b/packages/hyperion-autologging/test/ALInteractableDOMElement.test.ts
@@ -28,7 +28,7 @@ function createInteractableTestDom(): DomFragment.DomFragment {
   return DomFragment.html(`
     <div id='no-interactable'>No Interactable</div>
     <div>
-      <div id='atag-parent-clickable' data-clickable="1">
+      <div id='atag-parent-clickable' data-interactable="|click|">
         <a id='atag' href="#">Create metric</a>
         <a id='atag-nohref'>Create metric</a>
       </div>
@@ -39,7 +39,7 @@ function createInteractableTestDom(): DomFragment.DomFragment {
       <details id='details'>details</details>
       <dialog id='dialog'>dialog</dialog>
       <dialog id='summary'>summary</summary>
-      <div id="outer-clickable" aria-busy="false" class="test" role="button" tabindex="0" data-clickable="1" data-keydownable="1">
+      <div id="outer-clickable" aria-busy="false" class="test" role="button" tabindex="0" data-interactable="|click||keydown|">
         <span class="1">
           <div class="2">
             <div id="inner-clickable-assign-handler" class="3">
@@ -77,7 +77,7 @@ describe("Test interactable detection algorithm", () => {
   test("Detect interactable", () => {
     const dom = DomFragment.html(`
       <div id='1' onclick="return 1;"></div>
-      <div id="2" data-clickable="1">
+      <div id="2" data-interactable="|click|">
         <span id="3">Test</span>
       </div>
     `);
@@ -199,7 +199,7 @@ describe("Test various element text options", () => {
   test("text extraction from parent handler element coming from interactable element tag input", () => {
     const dom = DomFragment.html(`
     <div id="outer">
-      <div id="clickable" data-clickable="1">
+      <div id="clickable" data-interactable="|click|">
         <span id="text-label">Grab this text</span>
         <div>
           <input id="radio-nested-no-text" type="radio" name="contact" value="email" checked="true" />
@@ -234,7 +234,7 @@ describe("Test various element text options", () => {
 
   test('complex element label', () => {
     const dom = DomFragment.html(`
-      <label data-clickable="1" data-keydownable="1"><div><div><input
+      <label data-interactable="|click||keydown|"><div><div><input
         aria-checked="true" aria-disabled="false"
         aria-describedby="js_1p" aria-labelledby="js_1q"
         id="js_1o" type="radio" value="SINGLE" checked="" name="js_1j"
@@ -299,7 +299,7 @@ describe("Test various element text options", () => {
   test("Detect interactable", () => {
     const dom = DomFragment.html(`
       <div id='1' onclick="return 1;"></div>
-      <div id="2" data-clickable="1">
+      <div id="2" data-interactable="|click|">
         <span id="3">Test</span>
       </div>
     `);
@@ -344,7 +344,7 @@ describe("Test various element text options", () => {
     expect(node).not.toBeNull();
     if (node) {
       node.addEventListener("click", () => { });
-      expect(node.getAttribute("data-clickable")).toBe("1");
+      expect(node.getAttribute("data-interactable")).toContain("|click|");
     }
 
     trackAndEnableUIEventHandlers('mouseover', {
@@ -356,7 +356,7 @@ describe("Test various element text options", () => {
     expect(node).not.toBeNull();
     if (node) {
       node.addEventListener("mouseover", () => { });
-      expect(node.getAttribute("data-mouseoverable")).toBe("1");
+      expect(node.getAttribute("data-interactable")).toContain("|mouseover|");
     }
   });
 });

--- a/packages/hyperion-autologging/test/ALInteractableDOMElement.test.ts
+++ b/packages/hyperion-autologging/test/ALInteractableDOMElement.test.ts
@@ -70,8 +70,8 @@ function getTextFromParent(id: string, parentEvent: UIEventConfig['eventName'] |
 }
 
 describe("Test interactable detection algorithm", () => {
-  function interactable(node: HTMLElement | null, eventName: UIEventConfig['eventName'], interactableOnly: boolean = true): HTMLElement | null {
-    return ALInteractableDOMElement.getInteractable(node, eventName, interactableOnly);
+  function interactable(node: HTMLElement | null, eventName: UIEventConfig['eventName']): HTMLElement | null {
+    return ALInteractableDOMElement.getInteractable(node, eventName);
   }
 
   test("Detect interactable", () => {
@@ -97,8 +97,7 @@ describe("Test interactable detection algorithm", () => {
     const dom = createInteractableTestDom();
 
     const ni = document.getElementById("no-interactable");
-    expect(interactable(ni, "click", true)).toBeNull();
-    expect(interactable(ni, "click", false)).toBeNull();
+    expect(interactable(ni, "click")).toBeNull();
 
     dom.cleanup();
   })

--- a/packages/hyperion-react-testapp/src/AutoLoggingWrapper.ts
+++ b/packages/hyperion-react-testapp/src/AutoLoggingWrapper.ts
@@ -22,7 +22,10 @@ import "@hyperion/hyperion-autologging/src/reference";
 export let interceptionStatus = "disabled";
 
 export function init() {
-  Flags.setFlags({ preciseTriggerFlowlet: true });
+  Flags.setFlags({
+    preciseTriggerFlowlet: true,
+    optimizeInteractibiltyCheck: true,
+  });
 
   interceptionStatus = "enabled";
   const flowletManager = FlowletManager;


### PR DESCRIPTION
See individual commits for more info. 
Two important changes here:
- replace `data-*able=1` attributes for each event with a single `data-interactable="|*|"` attribute that captures all events. This will allow us in future to ignore the the event name and simply know that the element has some event handler.
- Added a caching mechanism to memoize the result of interactivity detection. 