### PR TITLE
Improve stability of ClientSessionID and EventIndex

### DIFF
--- a/packages/hyperion-util/src/ClientSessionID.ts
+++ b/packages/hyperion-util/src/ClientSessionID.ts
@@ -12,15 +12,5 @@ export const ClientSessionID: string = new SessionPersistentData<string>(
   guid,
   v => v,
   v => v,
+  true, //In case page is immediately reloaded, we don't want to wait for the scheduler to save
 ).getValue();
-
-
-// (() => {
-//   const storage = getStorage();
-//   let id = storage?.getItem(CLIENT_SESSION_ID_FIELD);
-//   if (!id) {
-//     id = guid();
-//     storage?.setItem(CLIENT_SESSION_ID_FIELD, id);
-//   }
-//   return id;
-// })();

--- a/packages/hyperion-util/src/guid.ts
+++ b/packages/hyperion-util/src/guid.ts
@@ -7,6 +7,38 @@
 
 export type GUID = string;
 
+const getRandomIntString = (() => {
+  /**
+   * If possible we use the cryto api to give us better random
+   * values, and also avoid the conversion of random value to integer
+   */
+  if (typeof globalThis === "object" && globalThis.crypto) {
+    class EntropyPool {
+      #entropy: Uint32Array;
+      #index: number;
+      constructor(poolSize = 1024) {
+        this.#entropy = new Uint32Array(poolSize);
+        this.#index = 0;
+        crypto.getRandomValues(this.#entropy);
+      }
+      next() {
+        const value = this.#entropy[this.#index++];
+        if (this.#index === this.#entropy.length) {
+          crypto.getRandomValues(this.#entropy);
+          this.#index = 0;
+        }
+        return value;
+      }
+    }
+
+    const pool = new EntropyPool(50);
+
+    return () => pool.next().toString(16);
+  } else {
+    return () => (Math.random() * (1 << 30)).toString(16).replace('.', '');
+  }
+})()
+
 export function guid(): GUID {
-  return 'f' + (Math.random() * (1 << 30)).toString(16).replace('.', '');
+  return 'f' + getRandomIntString();
 }


### PR DESCRIPTION
We noticed that some of the event indexes at the end of a session overlap with event indexes of the next session.
We have a scheduller for PersistentData class to lazily write back updated values to storage. This scheduler may miss the final write specially if page is busy during logging and then is unloaded (reload or move to another page).

The new code does a few things to solve this:
- The timer is reduced from 100ms to 20ms. This is still better than constantly writing the value back (specially for event index)
- The scheduller is updated to handle page unload and turn go into immediate write mode.

I also updated the guid logic to generate better random data with lower overhead (T164417895).

Hopefully all of these changes reduces the chance of event index overlaps.