### PR TITLE
Added .npmignore to all packages and published

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,6 @@
+*.log
+.DS_Store
+coverage
+test/**/*.*
+jest.config.js
+babel.config.js

--- a/packages/hyperion-async-counter/.npmignore
+++ b/packages/hyperion-async-counter/.npmignore
@@ -1,0 +1,6 @@
+*.log
+.DS_Store
+coverage
+test/**/*.js
+jest.config.js
+babel.config.js

--- a/packages/hyperion-async-counter/package.json
+++ b/packages/hyperion-async-counter/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperion-async-counter",
   "description": "async counter utility",
-  "version": "0.3.1",
+  "version": "0.3.4",
   "license": "MIT",
   "author": "Mehrdad Reshadi",
   "main": "./src/AsyncCounter.js",

--- a/packages/hyperion-autologging-plugin-eventhash/.npmignore
+++ b/packages/hyperion-autologging-plugin-eventhash/.npmignore
@@ -1,0 +1,6 @@
+*.log
+.DS_Store
+coverage
+test/**/*.js
+jest.config.js
+babel.config.js

--- a/packages/hyperion-autologging-plugin-eventhash/package.json
+++ b/packages/hyperion-autologging-plugin-eventhash/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperion-autologging-plugin-eventhash",
   "description": "plugin for autologging to add a hash to each event",
-  "version": "0.3.1",
+  "version": "0.3.4",
   "license": "MIT",
   "scripts": {
     "build": "tsc",

--- a/packages/hyperion-autologging-visualizer/.npmignore
+++ b/packages/hyperion-autologging-visualizer/.npmignore
@@ -1,0 +1,6 @@
+*.log
+.DS_Store
+coverage
+test/**/*.js
+jest.config.js
+babel.config.js

--- a/packages/hyperion-autologging-visualizer/package.json
+++ b/packages/hyperion-autologging-visualizer/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperion-autologging-visualizer",
   "description": "visualizer tool for autologging",
-  "version": "0.3.1",
+  "version": "0.3.4",
   "license": "MIT",
   "scripts": {
     "build": "tsc",

--- a/packages/hyperion-autologging/.npmignore
+++ b/packages/hyperion-autologging/.npmignore
@@ -1,0 +1,6 @@
+*.log
+.DS_Store
+coverage
+test/**/*.js
+jest.config.js
+babel.config.js

--- a/packages/hyperion-autologging/package.json
+++ b/packages/hyperion-autologging/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperion-autologging",
   "description": "Automatically track features and their usage in a web or react application",
-  "version": "0.3.1",
+  "version": "0.3.4",
   "license": "MIT",
   "scripts": {
     "build": "tsc",

--- a/packages/hyperion-channel/.npmignore
+++ b/packages/hyperion-channel/.npmignore
@@ -1,0 +1,6 @@
+*.log
+.DS_Store
+coverage
+test/**/*.js
+jest.config.js
+babel.config.js

--- a/packages/hyperion-channel/package.json
+++ b/packages/hyperion-channel/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperion-channel",
   "description": "Channel utility to support 'aspects' in the framework",
-  "version": "0.3.1",
+  "version": "0.3.4",
   "license": "MIT",
   "author": "Mehrdad Reshadi",
   "main": "./src/Channel.js",

--- a/packages/hyperion-core/.npmignore
+++ b/packages/hyperion-core/.npmignore
@@ -1,0 +1,6 @@
+*.log
+.DS_Store
+coverage
+test/**/*.js
+jest.config.js
+babel.config.js

--- a/packages/hyperion-core/package.json
+++ b/packages/hyperion-core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperion-core",
   "description": "Core utility to intercept objects and add 'aspects' to them",
-  "version": "0.3.1",
+  "version": "0.3.4",
   "license": "MIT",
   "scripts": {
     "build": "tsc",

--- a/packages/hyperion-devtools/.npmignore
+++ b/packages/hyperion-devtools/.npmignore
@@ -1,0 +1,6 @@
+*.log
+.DS_Store
+coverage
+test/**/*.js
+jest.config.js
+babel.config.js

--- a/packages/hyperion-devtools/package.json
+++ b/packages/hyperion-devtools/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperion-devtools",
   "description": "set of configs and tools for development",
-  "version": "0.4.1",
+  "version": "0.4.4",
   "license": "MIT",
   "author": "Mehrdad Reshadi",
   "scripts": {

--- a/packages/hyperion-docs/.npmignore
+++ b/packages/hyperion-docs/.npmignore
@@ -1,0 +1,6 @@
+*.log
+.DS_Store
+coverage
+test/**/*.js
+jest.config.js
+babel.config.js

--- a/packages/hyperion-dom/.npmignore
+++ b/packages/hyperion-dom/.npmignore
@@ -1,0 +1,6 @@
+*.log
+.DS_Store
+coverage
+test/**/*.js
+jest.config.js
+babel.config.js

--- a/packages/hyperion-dom/package.json
+++ b/packages/hyperion-dom/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperion-dom",
   "description": "DOM utility to intercept DOM api and 'aspects' to them",
-  "version": "0.3.1",
+  "version": "0.3.4",
   "license": "MIT",
   "scripts": {
     "build": "tsc",

--- a/packages/hyperion-flowlet/.npmignore
+++ b/packages/hyperion-flowlet/.npmignore
@@ -1,0 +1,6 @@
+*.log
+.DS_Store
+coverage
+test/**/*.js
+jest.config.js
+babel.config.js

--- a/packages/hyperion-flowlet/package.json
+++ b/packages/hyperion-flowlet/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperion-flowlet",
   "description": "Tracking the async execution flow of the application",
-  "version": "0.3.1",
+  "version": "0.3.4",
   "license": "MIT",
   "scripts": {
     "build": "tsc",

--- a/packages/hyperion-globals/.npmignore
+++ b/packages/hyperion-globals/.npmignore
@@ -1,0 +1,6 @@
+*.log
+.DS_Store
+coverage
+test/**/*.js
+jest.config.js
+babel.config.js

--- a/packages/hyperion-globals/package.json
+++ b/packages/hyperion-globals/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperion-globals",
   "description": "global settings and utility functions",
-  "version": "0.3.1",
+  "version": "0.3.4",
   "license": "MIT",
   "author": "Mehrdad Reshadi",
   "main": "./src/index.js",

--- a/packages/hyperion-hook/.npmignore
+++ b/packages/hyperion-hook/.npmignore
@@ -1,0 +1,6 @@
+*.log
+.DS_Store
+coverage
+test/**/*.js
+jest.config.js
+babel.config.js

--- a/packages/hyperion-hook/package.json
+++ b/packages/hyperion-hook/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperion-hook",
   "description": "Hook utility to support 'aspects' in the framework",
-  "version": "0.3.1",
+  "version": "0.3.4",
   "license": "MIT",
   "author": "Mehrdad Reshadi",
   "main": "./src/Hook.js",

--- a/packages/hyperion-react-testapp/.npmignore
+++ b/packages/hyperion-react-testapp/.npmignore
@@ -1,0 +1,6 @@
+*.log
+.DS_Store
+coverage
+test/**/*.js
+jest.config.js
+babel.config.js

--- a/packages/hyperion-react-testapp/package.json
+++ b/packages/hyperion-react-testapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hyperion-react-testapp",
-  "version": "0.3.1",
+  "version": "0.3.4",
   "private": true,
   "workspaces": [
     "../hyperion-devtools",

--- a/packages/hyperion-react/.npmignore
+++ b/packages/hyperion-react/.npmignore
@@ -1,0 +1,6 @@
+*.log
+.DS_Store
+coverage
+test/**/*.js
+jest.config.js
+babel.config.js

--- a/packages/hyperion-react/package.json
+++ b/packages/hyperion-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperion-react",
   "description": "Utility to intercept React api and add 'aspects' to them",
-  "version": "0.3.1",
+  "version": "0.3.4",
   "license": "MIT",
   "scripts": {
     "build": "tsc",

--- a/packages/hyperion-test-and-set/.npmignore
+++ b/packages/hyperion-test-and-set/.npmignore
@@ -1,0 +1,6 @@
+*.log
+.DS_Store
+coverage
+test/**/*.js
+jest.config.js
+babel.config.js

--- a/packages/hyperion-test-and-set/package.json
+++ b/packages/hyperion-test-and-set/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperion-test-and-set",
   "description": "A simple utility to test and set values.",
-  "version": "0.3.1",
+  "version": "0.3.4",
   "license": "MIT",
   "scripts": {
     "build": "tsc",

--- a/packages/hyperion-timed-trigger/.npmignore
+++ b/packages/hyperion-timed-trigger/.npmignore
@@ -1,0 +1,6 @@
+*.log
+.DS_Store
+coverage
+test/**/*.js
+jest.config.js
+babel.config.js

--- a/packages/hyperion-timed-trigger/package.json
+++ b/packages/hyperion-timed-trigger/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperion-timed-trigger",
   "description": "Timed Trigger function to run one directly or based on a timer",
-  "version": "0.3.1",
+  "version": "0.3.4",
   "license": "MIT",
   "scripts": {
     "build": "tsc",

--- a/packages/hyperion-util/.npmignore
+++ b/packages/hyperion-util/.npmignore
@@ -1,0 +1,6 @@
+*.log
+.DS_Store
+coverage
+test/**/*.js
+jest.config.js
+babel.config.js

--- a/packages/hyperion-util/package.json
+++ b/packages/hyperion-util/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperion-util",
   "description": "Capabilities built using DOM interception",
-  "version": "0.3.1",
+  "version": "0.3.4",
   "license": "MIT",
   "scripts": {
     "build": "tsc",


### PR DESCRIPTION
Without .npmignore, npm will use the .gitignore to decide what to include in the uploaded packages.
We do want to include the .js files in the packages so that one can directly use them without needed to compiling them.

Hence added .npmignore everywhere.

published all packages with the new setup and tested by trying the following

`npm install hyperionjs`