### PR TITLE
Optimize trigger_flowlet for Promise.all etc.

### DIFF
--- a/packages/hyperion-autologging/src/ALUIEventPublisher.ts
+++ b/packages/hyperion-autologging/src/ALUIEventPublisher.ts
@@ -41,6 +41,7 @@ type ALUIEvent =
   ALTimedEvent &
   ALMetadataEvent &
   ALExtensibleEvent &
+  ALPageEvent &
   Types.Nullable<ALElementEvent> &
   {
     /**
@@ -63,7 +64,6 @@ export type ALUIEventCaptureData = Readonly<
   ALFlowletEvent &
   ALReactElementEvent &
   ALElementTextEvent &
-  ALPageEvent &
   CommonEventData &
   {
     surface: string | null;
@@ -81,7 +81,6 @@ export type ALLoggableUIEvent = Readonly<
 >;
 
 export type ALUIEventData = Readonly<
-  ALPageEvent &
   ALLoggableUIEvent
 >;
 


### PR DESCRIPTION
The trigger flowlet logic for static methods of Promise with an array as input could become expensive for large arrays.

This change applies the following optimizations:
- If the input argument includes just one element, pass the trigger_flowlet of the input argument to the output itself.
- Instead of an array, use a Set to account for repeat trigger_flowlet values. This can happen if a lot of Promises are created from the same call stack.
- If we find more than 5 distinct trigger_flowlets, we skip the rest of them and add `...` at the end of resulting trigger flowlet to indicate so. That should put an upper bound on the cost of the logic.