### PR TITLE
Create a central place to keep track of all surfaces

### DIFF
--- a/packages/hyperion-autologging/src/ALElementValuePublisher.ts
+++ b/packages/hyperion-autologging/src/ALElementValuePublisher.ts
@@ -21,6 +21,7 @@ import { getAncestralSurfaceNode, getSurfacePath } from "./ALSurfaceUtils";
 import { ALElementEvent, ALSharedInitOptions } from "./ALType";
 import * as ALUIEventPublisher from "./ALUIEventPublisher";
 import { getCurrMainPageUrl } from "./MainPageUrl";
+import { ALSurfaceData } from "./ALSurfaceData";
 
 
 export type InitOptions = Types.Options<
@@ -130,7 +131,7 @@ export function publish(options: InitOptions): void {
       return;
     }
 
-    const relatedEventIndex = ALSurfaceMutationPublisher.getSurfaceMountInfo(surface)?.eventIndex;
+    const relatedEventIndex = ALSurfaceData.get(surface)?.mutationEvent?.eventIndex;
 
     for (let i = 0; i < elements.length; ++i) {
       const element = elements[i];

--- a/packages/hyperion-autologging/src/ALElementValuePublisher.ts
+++ b/packages/hyperion-autologging/src/ALElementValuePublisher.ts
@@ -131,7 +131,7 @@ export function publish(options: InitOptions): void {
       return;
     }
 
-    const relatedEventIndex = surfaceData.mutationEvent?.eventIndex;
+    const relatedEventIndex = surfaceData.getMutationEvent()?.eventIndex;
 
     for (let i = 0; i < elements.length; ++i) {
       const element = elements[i];

--- a/packages/hyperion-autologging/src/ALSurface.ts
+++ b/packages/hyperion-autologging/src/ALSurface.ts
@@ -344,7 +344,7 @@ export function init(options: InitOptions): ALSurfaceHOC {
 
       const surfaceData = ALSurfaceData.get(domAttributeValue);
       __DEV__ && assert(
-        !surfaceData.mutationEvent && !surfaceData.visibilityEvent,
+        !surfaceData.getMutationEvent() && !surfaceData.getVisibilityEvent(),
         `Invalid surface setup for ${surfaceData.surface}. Didn't expect mutation and visibility events`
       )
 

--- a/packages/hyperion-autologging/src/ALSurface.ts
+++ b/packages/hyperion-autologging/src/ALSurface.ts
@@ -20,14 +20,18 @@ import * as ALSurfaceContext from "./ALSurfaceContext";
 import type { SurfacePropsExtension } from "./ALSurfacePropsExtension";
 import * as SurfaceProxy from "./ALSurfaceProxy";
 import { ALFlowletEvent, ALMetadataEvent, ALSharedInitOptions } from "./ALType";
+import { ALSurfaceData, ALSurfaceEvent } from "./ALSurfaceData";
 
 
-export type ALSurfaceEventData = ALMetadataEvent & ALFlowletEvent & Readonly<{
-  surface: string;
-  element: Element;
-  isProxy: boolean;
-  capability: ALSurfaceCapability | null | undefined;
-}>;
+export type ALSurfaceEventData =
+  ALMetadataEvent &
+  ALFlowletEvent &
+  ALSurfaceEvent &
+  Readonly<{
+    element: Element;
+    isProxy: boolean;
+    capability: ALSurfaceCapability | null | undefined;
+  }>;
 
 export interface ALSurfaceCapability {
   /**
@@ -271,7 +275,7 @@ export function init(options: InitOptions): ALSurfaceHOC {
       }
     } else {
       surfacePath = proxiedContext.surface;
-      nonInteractiveSurfacePath = proxiedContext.nonInteractiveSurface;      
+      nonInteractiveSurfacePath = proxiedContext.nonInteractiveSurface;
       domAttributeName = AUTO_LOGGING_SURFACE
       domAttributeValue = surfacePath;
       if (proxiedContext.container instanceof Element) {
@@ -338,8 +342,15 @@ export function init(options: InitOptions): ALSurfaceHOC {
       element.setAttribute(domAttributeName, domAttributeValue);
       __DEV__ && assert(element != null, "Invalid surface effect without an element: " + surface);
 
+      const surfaceData = ALSurfaceData.get(domAttributeValue);
+      __DEV__ && assert(
+        !surfaceData.mutationEvent && !surfaceData.visibilityEvent,
+        `Invalid surface setup for ${surfaceData.surface}. Didn't expect mutation and visibility events`
+      )
+
       const event: ALSurfaceEventData = {
         surface: domAttributeValue,
+        surfaceData,
         callFlowlet,
         triggerFlowlet,
         metadata,

--- a/packages/hyperion-autologging/src/ALSurfaceData.ts
+++ b/packages/hyperion-autologging/src/ALSurfaceData.ts
@@ -17,8 +17,6 @@ export type ALSurfaceEvent = Readonly<{
 
 const surfacesData = new Map<string, ALSurfaceData>();
 
-const PARENT_SURFACE_REMOVEd_PROP = 'parentSurfaceRemoved';
-
 export class ALSurfaceData {
 
   static get(surface: string): ALSurfaceData {
@@ -34,14 +32,16 @@ export class ALSurfaceData {
       data = new ALSurfaceData(surface, parentData);
       parentData?.children.push(data);
       surfacesData.set(surface, data);
+      console.log(`Added surface: ${surface}`);
     }
     return data;
   }
 
   private __ext: { [namespace: string]: any; };
   readonly children: ALSurfaceData[] = [];
-  mutationEvent: ALSurfaceMutationEventData | null = null;
-  visibilityEvent: ALSurfaceVisibilityEventData | null = null;
+  #mutationEvent: ALSurfaceMutationEventData | null = null;
+  #visibilityEvent: ALSurfaceVisibilityEventData | null = null;
+  #locked: boolean = false; // allow removal by default
 
   constructor(
     public readonly surface: string,
@@ -50,35 +50,65 @@ export class ALSurfaceData {
     this.__ext = Object.create(this.parent?.__ext ?? null);
   }
 
-  remove() {
+  getMutationEvent(): ALSurfaceMutationEventData | null {
+    return this.#mutationEvent;
+  }
+  setMutationEvent(event: ALSurfaceMutationEventData): ALSurfaceMutationEventData {
+    if (event === null) {
+      __DEV__ && assert(this.#mutationEvent?.event === "unmount_component", "Deactivating surface without unmouting it first");
+      this.#visibilityEvent = null;
+    }
+    this.#mutationEvent = event;
+    return event;
+  }
+
+  getVisibilityEvent(): ALSurfaceVisibilityEventData | null {
+    return this.#visibilityEvent;
+  }
+  setVisibilityEvent(event: ALSurfaceVisibilityEventData): ALSurfaceVisibilityEventData {
+    return this.#visibilityEvent = event;
+  }
+
+  remove(): boolean {
     /**
      * While mount event happens bottom-up, the unmount event (may) happens top down.
-     * We can remove the parent surface that still has childern from the map, and let the
-     * data to be GCed later. But we mark these just incase later we need to debug what is
-     * happeneing.
+     * We can remove the parent node once all its children are removed. Also, since the
+     * application might have associated surface data, we would want to keep those surfaces
+     * around. So, as soon as we reach a leaf node that has data, we should stop. 
      */
-    const isChildless = this.children.length === 0
 
-    if (__DEV__ && !isChildless) {
-      // console.debug(`Children of surface ${this.surface} will be orphan!`);
-      this.setInheritedPropery(PARENT_SURFACE_REMOVEd_PROP, true);
+    console.log(`Removing surface: ${this.surface}`);
+
+    // If this method is called explicitly, we are done with the surface and can remove it, so first cleanup state
+    this.#mutationEvent = null;
+    this.#visibilityEvent = null;
+
+    const isChildless = this.children.length === 0
+    if (!isChildless || this.#locked) {
+      // We cannot yet remove the node itself
+      return false;
     }
 
-    const parentsChildren = this.parent?.children;
-    if (parentsChildren) {
+    if (this.parent) {
+      const parentsChildren = this.parent.children;
+      // Remove this from parent's children
+
       // The following is a fast remove
       const index = parentsChildren.indexOf(this);
-      __DEV__ && assert(index > -1, `Invalid situation! surface ${this.surface} should be child of ${this.parent.surface}`);
       if (index > -1) {
         parentsChildren[index] = parentsChildren[parentsChildren.length - 1]; // move the last one to the found location
         parentsChildren.length -= 1;
-        if (__DEV__ && parentsChildren.length == 0 && this.parent.getInheritedPropery(PARENT_SURFACE_REMOVEd_PROP)) {
-          // console.debug(`Parent surface ${this.parent.surface} cleaned up`);
+        const canPropageUpwardRemove = parentsChildren.length === 0 && this.parent.#mutationEvent === null && this.parent.#visibilityEvent === null;
+        if (canPropageUpwardRemove) {
+          this.parent.remove();
         }
+      } else {
+        __DEV__ && assert(index > -1, `Invalid situation! surface ${this.surface} should be child of ${this.parent.surface}`);
       }
     }
 
     surfacesData.delete(this.surface);
+    return true;
   }
 
   getInheritedPropery<T>(propName: string): T | undefined | null {
@@ -87,6 +117,9 @@ export class ALSurfaceData {
 
   setInheritedPropery<T>(propName: string, propValue: T): T {
     this.__ext[propName] = propValue;
+
+    this.#locked = true; // now that this node has data, it should never be removed
+
     return propValue;
   }
 

--- a/packages/hyperion-autologging/src/ALSurfaceData.ts
+++ b/packages/hyperion-autologging/src/ALSurfaceData.ts
@@ -1,0 +1,77 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved.
+ */
+
+'use strict';
+
+import { assert } from "hyperion-globals/src/assert";
+import { SURFACE_SEPARATOR } from "./ALSurfaceConsts";
+import type { ALSurfaceMutationEventData } from "./ALSurfaceMutationPublisher";
+import type { ALSurfaceVisibilityEventData } from "./ALSurfaceVisibilityPublisher";
+import type { ALExtensibleEventData } from "./ALType";
+
+
+const surfacesData = new Map<string, ALSurfaceData>();
+
+export class ALSurfaceData {
+
+  static get(surface: string): ALSurfaceData {
+    let data = surfacesData.get(surface);
+    if (!data) {
+      const parentNameLength = surface.lastIndexOf(SURFACE_SEPARATOR);
+      let parentData: ALSurfaceData | null = null;
+      if (parentNameLength > 0) {
+        let parentSurfaceName = surface.substring(0, parentNameLength);
+        parentData = ALSurfaceData.get(parentSurfaceName);
+
+      }
+      data = new ALSurfaceData(surface, parentData);
+      parentData?.children.push(data);
+      surfacesData.set(surface, data);
+    }
+    return data;
+  }
+
+  private __ext: { [namespace: string]: ALExtensibleEventData; };
+  readonly children: ALSurfaceData[] = [];
+  mutationEvent?: ALSurfaceMutationEventData;
+  visibilityEvent?: ALSurfaceVisibilityEventData;
+
+  constructor(
+    public readonly surface: string,
+    readonly parent: ALSurfaceData | null,
+  ) {
+    this.__ext = Object.create(this.parent?.__ext ?? null);
+  }
+
+  remove() {
+    const isChildless = this.children.length === 0
+    assert(isChildless, "Cannot remove surface that still has children");
+    if (!isChildless) {
+      return;
+    }
+
+    const parentsChildren = this.parent?.children;
+    if (parentsChildren) {
+      // The following is a fast remove
+      const index = parentsChildren.indexOf(this);
+      if (index > -1) {
+        parentsChildren[index] = parentsChildren[parentsChildren.length - 1]; // move the last one to the found location
+        parentsChildren.length -= 1;
+      }
+    }
+
+    surfacesData.delete(this.surface);
+
+  }
+
+  getExtension<T extends ALExtensibleEventData = ALExtensibleEventData>(namespace: string): T | undefined | null {
+    return this.__ext[namespace] as T;
+  }
+
+  setExtension<T extends ALExtensibleEventData = ALExtensibleEventData>(namespace: string, data: T): void {
+    const namespaceData = this.__ext[namespace] ??= {};
+    Object.assign(namespaceData, data);
+  }
+
+}

--- a/packages/hyperion-autologging/src/ALSurfaceData.ts
+++ b/packages/hyperion-autologging/src/ALSurfaceData.ts
@@ -16,21 +16,24 @@ export type ALSurfaceEvent = Readonly<{
 }>;
 
 const surfacesData = new Map<string, ALSurfaceData>();
-
 export class ALSurfaceData {
+  static root = (() => {
+    const root = new ALSurfaceData('', null);
+    root.#locked = true; // We never want this to be removed.
+    return root;
+  })();
 
   static get(surface: string): ALSurfaceData {
     let data = surfacesData.get(surface);
     if (!data) {
       const parentNameLength = surface.lastIndexOf(SURFACE_SEPARATOR);
-      let parentData: ALSurfaceData | null = null;
+      let parentData: ALSurfaceData = ALSurfaceData.root;
       if (parentNameLength > 0) {
         let parentSurfaceName = surface.substring(0, parentNameLength);
         parentData = ALSurfaceData.get(parentSurfaceName);
-
       }
       data = new ALSurfaceData(surface, parentData);
-      parentData?.children.push(data);
+      parentData.children.push(data);
       surfacesData.set(surface, data);
       console.log(`Added surface: ${surface}`);
     }
@@ -45,7 +48,7 @@ export class ALSurfaceData {
 
   constructor(
     public readonly surface: string,
-    readonly parent: ALSurfaceData | null,
+    public readonly parent: ALSurfaceData | null,
   ) {
     this.__ext = Object.create(this.parent?.__ext ?? null);
   }

--- a/packages/hyperion-autologging/src/ALSurfaceData.ts
+++ b/packages/hyperion-autologging/src/ALSurfaceData.ts
@@ -8,10 +8,11 @@ import { assert } from "hyperion-globals/src/assert";
 import { SURFACE_SEPARATOR } from "./ALSurfaceConsts";
 import type { ALSurfaceMutationEventData } from "./ALSurfaceMutationPublisher";
 import type { ALSurfaceVisibilityEventData } from "./ALSurfaceVisibilityPublisher";
-import type { ALExtensibleEventData } from "./ALType";
 
 
 const surfacesData = new Map<string, ALSurfaceData>();
+
+const PARENT_SURFACE_REMOVEd_PROP = 'parentSurfaceRemoved';
 
 export class ALSurfaceData {
 
@@ -32,7 +33,7 @@ export class ALSurfaceData {
     return data;
   }
 
-  private __ext: { [namespace: string]: ALExtensibleEventData; };
+  private __ext: { [namespace: string]: any; };
   readonly children: ALSurfaceData[] = [];
   mutationEvent?: ALSurfaceMutationEventData;
   visibilityEvent?: ALSurfaceVisibilityEventData;
@@ -45,33 +46,43 @@ export class ALSurfaceData {
   }
 
   remove() {
+    /**
+     * While mount event happens bottom-up, the unmount event (may) happens top down.
+     * We can remove the parent surface that still has childern from the map, and let the
+     * data to be GCed later. But we mark these just incase later we need to debug what is
+     * happeneing.
+     */
     const isChildless = this.children.length === 0
-    assert(isChildless, "Cannot remove surface that still has children");
-    if (!isChildless) {
-      return;
+
+    if (__DEV__ && !isChildless) {
+      // console.debug(`Children of surface ${this.surface} will be orphan!`);
+      this.setInheritedPropery(PARENT_SURFACE_REMOVEd_PROP, true);
     }
 
     const parentsChildren = this.parent?.children;
     if (parentsChildren) {
       // The following is a fast remove
       const index = parentsChildren.indexOf(this);
+      __DEV__ && assert(index > -1, `Invalid situation! surface ${this.surface} should be child of ${this.parent.surface}`);
       if (index > -1) {
         parentsChildren[index] = parentsChildren[parentsChildren.length - 1]; // move the last one to the found location
         parentsChildren.length -= 1;
+        if (__DEV__ && parentsChildren.length == 0 && this.parent.getInheritedPropery(PARENT_SURFACE_REMOVEd_PROP)) {
+          // console.debug(`Parent surface ${this.parent.surface} cleaned up`);
+        }
       }
     }
 
     surfacesData.delete(this.surface);
-
   }
 
-  getExtension<T extends ALExtensibleEventData = ALExtensibleEventData>(namespace: string): T | undefined | null {
-    return this.__ext[namespace] as T;
+  getInheritedPropery<T>(propName: string): T | undefined | null {
+    return this.__ext[propName] as T;
   }
 
-  setExtension<T extends ALExtensibleEventData = ALExtensibleEventData>(namespace: string, data: T): void {
-    const namespaceData = this.__ext[namespace] ??= {};
-    Object.assign(namespaceData, data);
+  setInheritedPropery<T>(propName: string, propValue: T): T {
+    this.__ext[propName] = propValue;
+    return propValue;
   }
 
 }

--- a/packages/hyperion-autologging/src/ALSurfaceData.ts
+++ b/packages/hyperion-autologging/src/ALSurfaceData.ts
@@ -35,7 +35,6 @@ export class ALSurfaceData {
       data = new ALSurfaceData(surface, parentData);
       parentData.children.push(data);
       surfacesData.set(surface, data);
-      console.log(`Added surface: ${surface}`);
     }
     return data;
   }
@@ -79,9 +78,6 @@ export class ALSurfaceData {
      * application might have associated surface data, we would want to keep those surfaces
      * around. So, as soon as we reach a leaf node that has data, we should stop. 
      */
-
-    console.log(`Removing surface: ${this.surface}`);
-
     // If this method is called explicitly, we are done with the surface and can remove it, so first cleanup state
     this.#mutationEvent = null;
     this.#visibilityEvent = null;

--- a/packages/hyperion-autologging/src/ALSurfaceData.ts
+++ b/packages/hyperion-autologging/src/ALSurfaceData.ts
@@ -10,6 +10,11 @@ import type { ALSurfaceMutationEventData } from "./ALSurfaceMutationPublisher";
 import type { ALSurfaceVisibilityEventData } from "./ALSurfaceVisibilityPublisher";
 
 
+export type ALSurfaceEvent = Readonly<{
+  surface: string;
+  surfaceData: ALSurfaceData;
+}>;
+
 const surfacesData = new Map<string, ALSurfaceData>();
 
 const PARENT_SURFACE_REMOVEd_PROP = 'parentSurfaceRemoved';
@@ -35,8 +40,8 @@ export class ALSurfaceData {
 
   private __ext: { [namespace: string]: any; };
   readonly children: ALSurfaceData[] = [];
-  mutationEvent?: ALSurfaceMutationEventData;
-  visibilityEvent?: ALSurfaceVisibilityEventData;
+  mutationEvent: ALSurfaceMutationEventData | null = null;
+  visibilityEvent: ALSurfaceVisibilityEventData | null = null;
 
   constructor(
     public readonly surface: string,

--- a/packages/hyperion-autologging/src/ALSurfaceMutationPublisher.ts
+++ b/packages/hyperion-autologging/src/ALSurfaceMutationPublisher.ts
@@ -17,7 +17,9 @@ import { ALSurfaceEvent } from "./ALSurfaceData";
 import { ALElementEvent, ALFlowletEvent, ALLoggableEvent, ALMetadataEvent, ALPageEvent, ALReactElementEvent, ALSharedInitOptions } from "./ALType";
 import { getCurrMainPageUrl } from "./MainPageUrl";
 
-type ALMutationEvent =
+export type ALSurfaceMutationEventData =
+  ALLoggableEvent &
+  ALPageEvent &
   ALReactElementEvent &
   ALElementTextEvent &
   ALFlowletEvent &
@@ -41,12 +43,6 @@ type ALMutationEvent =
       }
     )
   >;
-
-export type ALSurfaceMutationEventData = Readonly<
-  ALLoggableEvent &
-  ALPageEvent &
-  ALMutationEvent
->;
 
 export type ALChannelSurfaceMutationEvent = Readonly<{
   al_surface_mutation_event: [ALSurfaceMutationEventData],

--- a/packages/hyperion-autologging/src/ALSurfaceMutationPublisher.ts
+++ b/packages/hyperion-autologging/src/ALSurfaceMutationPublisher.ts
@@ -109,7 +109,7 @@ export function publish(options: InitOptions): void {
             pageURI: getCurrMainPageUrl(),
           };
           surfaceData.mutationEvent = mutationEvent;
-          surfaceData.setExtension('surface_mutation', { addTime: timestamp });
+          surfaceData.setInheritedPropery('surface_mutation_add_time', timestamp);
 
           channel.emit('al_surface_mutation_event', mutationEvent);
 

--- a/packages/hyperion-autologging/src/ALSurfaceVisibilityPublisher.ts
+++ b/packages/hyperion-autologging/src/ALSurfaceVisibilityPublisher.ts
@@ -16,16 +16,15 @@ import { ALChannelSurfaceEvent } from "./ALSurface";
 import { ALSurfaceData, ALSurfaceEvent } from "./ALSurfaceData";
 
 export type ALSurfaceVisibilityEventData =
-  ALFlowletEvent &
-  ALMetadataEvent &
-  ALExtensibleEvent &
   ALElementEvent &
-  ALPageEvent &
+  ALExtensibleEvent &
+  ALFlowletEvent &
   ALLoggableEvent &
+  ALMetadataEvent &
+  ALPageEvent &
   ALSurfaceEvent &
   Readonly<
     {
-      // surface: string;
       intersectionEntry: IntersectionObserverEntry;
     } &
     (
@@ -157,10 +156,10 @@ export function publish(options: InitOptions): void {
                 console.warn("Don't know yet how to merge entries!");
               }
 
-              const  mutationEvent  = surfaceData.getMutationEvent();
+              const mutationEvent = surfaceData.getMutationEvent();
               assert(mutationEvent != null, "Invalid situation! Surface visibility change without mutation event first");
               const isIntersecting = entry.isIntersecting;
-              
+
               // update surfaceData before emitting the event.
               channel.emit('al_surface_visibility_event', surfaceData.setVisibilityEvent({
                 ...isIntersecting

--- a/packages/hyperion-autologging/src/ALSurfaceVisibilityPublisher.ts
+++ b/packages/hyperion-autologging/src/ALSurfaceVisibilityPublisher.ts
@@ -61,7 +61,7 @@ export function publish(options: InitOptions): void {
   const observers = new Map<number, IntersectionObserver>();
 
   channel.addListener('al_surface_mutation_event', event => {
-    __DEV__ && assert(event.surfaceData.mutationEvent === event, 'Invalid situation for surface mutation event');
+    __DEV__ && assert(event.surfaceData.getMutationEvent() === event, 'Invalid situation for surface mutation event');
     switch (event.event) {
       case 'mount_component': {
         if (event.capability?.trackVisibilityThreshold) {
@@ -157,12 +157,12 @@ export function publish(options: InitOptions): void {
                 console.warn("Don't know yet how to merge entries!");
               }
 
-              const { mutationEvent } = surfaceData;
+              const  mutationEvent  = surfaceData.getMutationEvent();
               assert(mutationEvent != null, "Invalid situation! Surface visibility change without mutation event first");
               const isIntersecting = entry.isIntersecting;
               
               // update surfaceData before emitting the event.
-              surfaceData.visibilityEvent = {
+              channel.emit('al_surface_visibility_event', surfaceData.setVisibilityEvent({
                 ...isIntersecting
                   ? { event: 'surface_visible', isIntersecting }
                   : { event: 'surface_hidden', isIntersecting },
@@ -180,8 +180,7 @@ export function publish(options: InitOptions): void {
                 triggerFlowlet: mutationEvent.triggerFlowlet,
                 intersectionEntry: entry,
                 pageURI: mutationEvent.pageURI,
-              };
-              channel.emit('al_surface_visibility_event', surfaceData.visibilityEvent);
+              }));
             }
           },
           { threshold }

--- a/packages/hyperion-autologging/src/ALSurfaceVisibilityPublisher.ts
+++ b/packages/hyperion-autologging/src/ALSurfaceVisibilityPublisher.ts
@@ -13,7 +13,7 @@ import { ALElementEvent, ALExtensibleEvent, ALFlowletEvent, ALLoggableEvent, ALM
 import * as ALEventIndex from './ALEventIndex';
 import { assert } from "hyperion-globals";
 import { ALChannelSurfaceEvent } from "./ALSurface";
-import * as ALSurfaceMutationPublisher from "./ALSurfaceMutationPublisher";
+import { ALSurfaceData } from "./ALSurfaceData";
 
 export type ALSurfaceVisibilityEventData =
   ALFlowletEvent &
@@ -144,8 +144,8 @@ export function publish(options: InitOptions): void {
                 continue;
               }
               const surfaceEvent = activeSurfaces.get(surface);
-              const otherSurfaceInfo = ALSurfaceMutationPublisher.getSurfaceMountInfo(surface);
-              assert(surfaceEvent === otherSurfaceInfo, "Unexpcted mismatch between the two surface event caches! ");
+              const otherSurfaceInfo = ALSurfaceData.get(surface);
+              assert(surfaceEvent === otherSurfaceInfo.mutationEvent, "Unexpcted mismatch between the two surface event caches! ");
 
               if (surfaceEvent) {
                 let entries = visibleSet.get(surfaceEvent);

--- a/packages/hyperion-autologging/src/ALUIEventPublisher.ts
+++ b/packages/hyperion-autologging/src/ALUIEventPublisher.ts
@@ -20,6 +20,7 @@ import { ALElementEvent, ALExtensibleEvent, ALFlowletEvent, ALLoggableEvent, ALM
 import * as ALUIEventGroupPublisher from "./ALUIEventGroupPublisher";
 import * as Flags from "hyperion-globals/src/Flags";
 import { getCurrMainPageUrl } from "./MainPageUrl";
+import { ALSurfaceData, ALSurfaceEvent } from "./ALSurfaceData";
 
 
 /**
@@ -65,8 +66,9 @@ export type ALUIEventCaptureData = Readonly<
   ALReactElementEvent &
   ALElementTextEvent &
   CommonEventData &
+  Types.Nullable<ALSurfaceEvent> &
   {
-    surface: string | null;
+    // surface: string | null;
     value?: string;
   }
 >;
@@ -272,9 +274,11 @@ export function publish(options: InitOptions): void {
        */
       let flowletName = eventName + `(`;
       let separator = '';
+      let surfaceData: ALSurfaceData | null = null;
       if (surface) {
         flowletName += `${separator}surface=${surface}`;
         separator = '&';
+        surfaceData = ALSurfaceData.get(surface);
       }
       if (autoLoggingID) {
         flowletName += `${separator}element=${autoLoggingID}`;
@@ -298,6 +302,7 @@ export function publish(options: InitOptions): void {
         callFlowlet,
         triggerFlowlet,
         surface,
+        surfaceData,
         ...elementText,
         reactComponentName: reactComponentData?.name,
         reactComponentStack: reactComponentData?.stack,

--- a/packages/hyperion-autologging/src/ALUIEventPublisher.ts
+++ b/packages/hyperion-autologging/src/ALUIEventPublisher.ts
@@ -39,10 +39,10 @@ type ALUIEventMap = {
 };
 
 type ALUIEvent =
-  ALTimedEvent &
-  ALMetadataEvent &
   ALExtensibleEvent &
+  ALMetadataEvent &
   ALPageEvent &
+  ALTimedEvent &
   Types.Nullable<ALElementEvent> &
   {
     /**
@@ -61,10 +61,10 @@ type ALUIEvent =
 
 
 export type ALUIEventCaptureData = Readonly<
-  ALUIEvent &
+  ALElementTextEvent &
   ALFlowletEvent &
   ALReactElementEvent &
-  ALElementTextEvent &
+  ALUIEvent &
   CommonEventData &
   Types.Nullable<ALSurfaceEvent> &
   {

--- a/packages/hyperion-autologging/src/index.ts
+++ b/packages/hyperion-autologging/src/index.ts
@@ -3,15 +3,16 @@
  */
 
 'use strict';
-export { ALFlowlet, ALFlowletManager } from "./ALFlowletManager";
-export { useALSurfaceContext } from "./ALSurfaceContext";
-export * as ALEventIndex from "./ALEventIndex";
-export { default as ALElementInfo } from "./ALElementInfo";
-export * as ALInteractableDOMElement from "./ALInteractableDOMElement";
-export * as AutoLogging from "./AutoLogging";
-export { ALSurfaceCapability } from "./ALSurface";
-export * as ALSurfaceUtils from "./ALSurfaceUtils";
 export * as ALCustomEvent from './ALCustomEvent';
-export { getCurrentUIEventData } from "./ALUIEventPublisher";
+export { default as ALElementInfo } from "./ALElementInfo";
 export * as ALEventExtension from "./ALEventExtension";
+export * as ALEventIndex from "./ALEventIndex";
+export { ALFlowlet, ALFlowletManager } from "./ALFlowletManager";
+export * as ALInteractableDOMElement from "./ALInteractableDOMElement";
 export { getSessionFlowID } from "./ALSessionFlowID";
+export { ALSurfaceCapability } from "./ALSurface";
+export { useALSurfaceContext } from "./ALSurfaceContext";
+export { ALSurfaceData } from "./ALSurfaceData";
+export * as ALSurfaceUtils from "./ALSurfaceUtils";
+export { getCurrentUIEventData } from "./ALUIEventPublisher";
+export * as AutoLogging from "./AutoLogging";

--- a/packages/hyperion-react-testapp/src/AutoLoggingWrapper.ts
+++ b/packages/hyperion-react-testapp/src/AutoLoggingWrapper.ts
@@ -22,6 +22,8 @@ import { getSessionFlowID } from "hyperion-autologging/src/ALSessionFlowID";
 
 export let interceptionStatus = "disabled";
 
+globalThis.__DEV__ = true;
+
 export function init() {
   Flags.setFlags({
     preciseTriggerFlowlet: true,

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -94,6 +94,7 @@ export default defineConfig({
         "hyperion-autologging/src/ALFlowletManager",
         "hyperion-autologging/src/ALSurface",
         "hyperion-autologging/src/ALSurfaceContext",
+        "hyperion-autologging/src/ALSurfaceData",
         "hyperion-autologging/src/ALSurfaceUtils",
         "hyperion-autologging/src/ALEventIndex",
         "hyperion-autologging/src/ALElementInfo",


### PR DESCRIPTION
There were several features that needed a central place to keep track of surfaces
- mutation and visibility publishers were tracking active surfaces on their own separately.
- we need to report the surface metadata for visibility events as well
- we want to know if the same surface name is used with a different element, i.e. want to enforice unique surface names and warn about it.

So, created a module to track the active surfacea and will gradually migration all parts of the code to it in next commits.