### PR TITLE
Ensure visibility events can access mutation events

### DIFF
--- a/packages/hyperion-autologging/src/ALSurfaceVisibilityPublisher.ts
+++ b/packages/hyperion-autologging/src/ALSurfaceVisibilityPublisher.ts
@@ -160,18 +160,27 @@ export function publish(options: InitOptions): void {
               continue;
             }
             if (!optimizeSurfaceMaps) {
-              const {surface} = surfaceData;
+              const { surface } = surfaceData;
               const surfaceEvent = activeSurfaces.get(surface);
               const otherSurfaceInfo = getSurfaceMountInfo(surface);
               assert(surfaceEvent === otherSurfaceInfo, "Unexpcted mismatch between the two surface event caches! ");
             }
 
-            let entries = visibleSet.get(surfaceData);
-            if (!entries) {
-              entries = [];
-              visibleSet.set(surfaceData, entries);
+            if (surfaceData.getMutationEvent()) {
+              let entries = visibleSet.get(surfaceData);
+              if (!entries) {
+                entries = [];
+                visibleSet.set(surfaceData, entries);
+              }
+              entries.push(entry);
+            } else {
+              /**
+               * Not clear why this situation is happening sometimes. It might be because of proxy surfaces, or the fact
+               * that mutation events fire synchronously with react changes, while visibility events fire async.
+               * We might want to track mutation event directly in this module.
+               */
+              console.warn(`Surface ${surfaceData.surface} has visibility event but is already unmounted!`)
             }
-            entries.push(entry);
           }
           for (const [surfaceData, entries] of visibleSet) {
             let entry = entries[0];


### PR DESCRIPTION
In the previous logic, we were storing MutationEvents in a map and fire visiblity events according to those. There was a condition that if a surface didn't have mutation event, we would not event try to emit visibility event.

In the previous commit for merging the maps, this condition was dropped. Adding it back.
This should also address the internal task (T215187690) that has captured some null access exceptions.