### PR TITLE
Fixing lint setup

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,22 @@
+// @ts-check
+
+import eslint from '@eslint/js';
+import tseslint from 'typescript-eslint';
+
+export default tseslint.config(
+  {
+    files: ["**/*.ts", "**/*.tsx"],
+    ignores: ["**/*.js", "**/*.jsx"],
+    extends: [
+      eslint.configs.recommended,
+      tseslint.configs.strict,
+      tseslint.configs.stylistic,
+    ],
+    rules: {
+      '@typescript-eslint/array-type': 'error',
+      '@typescript-eslint/consistent-type-imports': 'error',
+    }
+
+
+  }
+);

--- a/package.json
+++ b/package.json
@@ -11,13 +11,13 @@
     "src"
   ],
   "scripts": {
-    "_start": "tsdx watch",
-    "_build": "tsdx build",
+    "start": "npm run watch",
+    "watch": "tsc --watch",
     "install-packages": "npm install --workspaces",
     "build": "tsc && npm run build --workspaces && rollup -c",
     "test": "npm test --workspaces",
-    "_lint": "tsdx lint",
-    "_prepare": "tsdx build",
+    "lint": "eslint .",
+    "prepare": "npm run build",
     "_size": "size-limit",
     "_analyze": "size-limit --why"
   },
@@ -87,17 +87,22 @@
     "@babel/plugin-proposal-class-properties": "^7.18.6",
     "@babel/preset-env": "^7.26.0",
     "@babel/preset-typescript": "^7.26.0",
-    "hyperion-react-testapp": "*",
+    "@eslint/js": "^9.20.0",
     "@types/jest": "^29.5.14",
     "@types/node": "^22.10.7",
+    "@typescript-eslint/eslint-plugin": "^8.21.0",
+    "@typescript-eslint/parser": "^8.21.0",
     "babel-jest": "^29.7.0",
+    "eslint": "^9.20.1",
+    "hyperion-react-testapp": "*",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
     "md5": "^2.3.0",
     "rollup": "^4.30.1",
-    "rollup-plugin-node-resolve": "^5.2.0",
     "rollup-plugin-commonjs": "^10.1.0",
+    "rollup-plugin-node-resolve": "^5.2.0",
     "tslib": "^2.8.1",
-    "typescript": "^5.7.3"
+    "typescript": "^5.7.3",
+    "typescript-eslint": "^8.24.0"
   }
 }


### PR DESCRIPTION
Instead of using tsdx, just use latest eslint to perform linting checks with typescript plugin.

This should address: https://github.com/facebook/hyperion/issues/182