### PR TITLE
Add surface capability to not track mutation.

### DIFF
--- a/packages/hyperion-autologging/src/ALSurface.ts
+++ b/packages/hyperion-autologging/src/ALSurface.ts
@@ -42,6 +42,13 @@ export interface ALSurfaceCapability {
   nonInteractive?: boolean;
 
   /**
+   * In many cases, we only need to have a surface to mark various events UI
+   * eith it. We may not need the mutation or visibility events for it.
+   * if this options is explicitly set to false, we won't generate the mutation events.
+   */
+  trackMutation?: boolean;
+
+  /**
    * When set, will track when the provided ratio [0,1] of the surface becomes visible
    */
   trackVisibilityThreshold?: number;
@@ -346,6 +353,10 @@ export function init(options: InitOptions): ALSurfaceHOC {
       //   !surfaceData.getMutationEvent() && !surfaceData.getVisibilityEvent(),
       //   `Invalid surface setup for ${surfaceData.surface}. Didn't expect mutation and visibility events`
       // )
+
+      if (capability?.trackMutation === false){
+        return;
+      }
 
       const event: ALSurfaceEventData = {
         surface: domAttributeValue,

--- a/packages/hyperion-autologging/src/ALSurface.ts
+++ b/packages/hyperion-autologging/src/ALSurface.ts
@@ -354,8 +354,12 @@ export function init(options: InitOptions): ALSurfaceHOC {
       //   `Invalid surface setup for ${surfaceData.surface}. Didn't expect mutation and visibility events`
       // )
 
-      if (capability?.trackMutation === false){
-        return;
+      surfaceData.elements.add(element);
+
+      if (capability?.trackMutation === false) {
+        return () => {
+          surfaceData.elements.delete(element);
+        };
       }
 
       const event: ALSurfaceEventData = {
@@ -379,6 +383,7 @@ export function init(options: InitOptions): ALSurfaceHOC {
           ...event,
           triggerFlowlet: callFlowlet.data.triggerFlowlet
         });
+        surfaceData.elements.delete(element);
       }
     }, [domAttributeName, domAttributeValue, nodeRef]);
 

--- a/packages/hyperion-autologging/src/ALSurfaceData.ts
+++ b/packages/hyperion-autologging/src/ALSurfaceData.ts
@@ -28,6 +28,7 @@ abstract class ALSurfaceDataCore {
   #locked: boolean = false; // allow removal by default
 
   readonly children: ALSurfaceData[] = [];
+  readonly elements: Set<Element> = new Set<Element>();
 
   constructor(
     public readonly surface: string | null,

--- a/packages/hyperion-react-testapp/src/component/Surface.tsx
+++ b/packages/hyperion-react-testapp/src/component/Surface.tsx
@@ -21,6 +21,7 @@ export const Surface = (props: ALSurface.ALSurfaceProps) => {
       ...props,
       capability: {
         trackVisibilityThreshold: .5,
+        trackMutation: false,
       }
     }
   }


### PR DESCRIPTION
In somecases, we may need to add surfaces just to mark the DOM and we don't care about the mutation or visiblity events.

Added this capability which will allow us to have a lot more surfaces in the DOM without regressing performance.