### PR TITLE
Enable local options for text extraction function

### DIFF
--- a/packages/hyperion-react-testapp/src/component/Surface.tsx
+++ b/packages/hyperion-react-testapp/src/component/Surface.tsx
@@ -21,7 +21,7 @@ export const Surface = (props: ALSurface.ALSurfaceProps) => {
       ...props,
       capability: {
         trackVisibilityThreshold: .5,
-        trackMutation: false,
+        // trackMutation: false,
       }
     }
   }


### PR DESCRIPTION
In some cases, we might want to call the text extraction function and by pass the global options for updating or joining the individual text elements.