### PR TITLE
Surface metadata

### DIFF
--- a/packages/hyperion-autologging/src/ALSurface.ts
+++ b/packages/hyperion-autologging/src/ALSurface.ts
@@ -289,6 +289,9 @@ export function init(options: InitOptions): ALSurfaceHOC {
       }
     }
 
+    // Emit surface mutation events on mount/unmount
+    const metadata = props.metadata ?? {}; // Note that we want the same object to be shared between events to share the changes.
+
     let surfaceData = ALSurfaceData.tryGet(nonInteractiveSurfacePath);
     let callFlowlet: FlowletType;
     if (!surfaceData) {
@@ -307,6 +310,7 @@ export function init(options: InitOptions): ALSurfaceHOC {
         nonInteractiveSurfacePath,
         callFlowlet,
         capability,
+        metadata,
         domAttributeName,
         domAttributeValue,
       );
@@ -316,10 +320,9 @@ export function init(options: InitOptions): ALSurfaceHOC {
 
     const isProxy = proxiedContext != null;
 
-    // Emit surface mutation events on mount/unmount
-    const metadata = props.metadata ?? {}; // Note that we want the same object to be shared between events to share the changes.
     metadata.original_call_flowlet = callFlowlet.getFullName();
     metadata.surface_capability = surfaceCapabilityToString(capability);
+    surfaceData.metadata = metadata; // Want to make sure the tree always has the latest fresh version of metadata
 
     /**
      * We don't know when react decides to call effect callback, so to be safe make a copy

--- a/packages/hyperion-autologging/src/ALSurface.ts
+++ b/packages/hyperion-autologging/src/ALSurface.ts
@@ -20,7 +20,7 @@ import * as ALSurfaceContext from "./ALSurfaceContext";
 import type { SurfacePropsExtension } from "./ALSurfacePropsExtension";
 import * as SurfaceProxy from "./ALSurfaceProxy";
 import { ALFlowletEvent, ALMetadataEvent, ALSharedInitOptions } from "./ALType";
-import { ALSurfaceData, ALSurfaceEvent } from "./ALSurfaceData";
+import { ALSurfaceData, ALSurfaceEvent, EventMetadata } from "./ALSurfaceData";
 
 
 export type ALSurfaceEventData =
@@ -64,6 +64,7 @@ function surfaceCapabilityToString(capability?: ALSurfaceCapability | null): str
 export type ALSurfaceProps = Readonly<{
   surface: string;
   metadata?: ALMetadataEvent['metadata'];
+  eventMetadata?: EventMetadata,
   capability?: ALSurfaceCapability,
   nodeRef?: React.RefObject<Element | null | undefined>,
 }>;
@@ -291,7 +292,7 @@ export function init(options: InitOptions): ALSurfaceHOC {
 
     // Emit surface mutation events on mount/unmount
     const metadata = props.metadata ?? {}; // Note that we want the same object to be shared between events to share the changes.
-
+    const eventMetadata = props.eventMetadata;
     let surfaceData = ALSurfaceData.tryGet(nonInteractiveSurfacePath);
     let callFlowlet: FlowletType;
     if (!surfaceData) {
@@ -311,6 +312,7 @@ export function init(options: InitOptions): ALSurfaceHOC {
         callFlowlet,
         capability,
         metadata,
+        eventMetadata,
         domAttributeName,
         domAttributeValue,
       );

--- a/packages/hyperion-autologging/src/ALSurface.ts
+++ b/packages/hyperion-autologging/src/ALSurface.ts
@@ -64,7 +64,7 @@ function surfaceCapabilityToString(capability?: ALSurfaceCapability | null): str
 export type ALSurfaceProps = Readonly<{
   surface: string;
   metadata?: ALMetadataEvent['metadata'];
-  eventMetadata?: EventMetadata,
+  uiEventMetadata?: EventMetadata,
   capability?: ALSurfaceCapability,
   nodeRef?: React.RefObject<Element | null | undefined>,
 }>;
@@ -292,7 +292,7 @@ export function init(options: InitOptions): ALSurfaceHOC {
 
     // Emit surface mutation events on mount/unmount
     const metadata = props.metadata ?? {}; // Note that we want the same object to be shared between events to share the changes.
-    const eventMetadata = props.eventMetadata;
+    const eventMetadata = props.uiEventMetadata;
     let surfaceData = ALSurfaceData.tryGet(nonInteractiveSurfacePath);
     let callFlowlet: FlowletType;
     if (!surfaceData) {

--- a/packages/hyperion-autologging/src/ALSurfaceData.ts
+++ b/packages/hyperion-autologging/src/ALSurfaceData.ts
@@ -9,6 +9,7 @@ import type { ALSurfaceMutationEventData } from "./ALSurfaceMutationPublisher";
 import type { ALSurfaceVisibilityEventData } from "./ALSurfaceVisibilityPublisher";
 import { type IALFlowlet } from "./ALFlowletManager";
 import type { ALSurfaceCapability } from "./ALSurface";
+import { type Metadata } from "./ALType";
 
 
 export type ALSurfaceEvent = Readonly<{
@@ -116,6 +117,7 @@ export class ALSurfaceData extends ALSurfaceDataCore {
     public readonly nonInteractiveSurface: string,
     public readonly callFlowlet: IALFlowlet,
     public readonly capability: ALSurfaceCapability | null | undefined,
+    public metadata: Metadata,
     public readonly domAttributeName: string,
     public readonly domAttributeValue: string,
   ) {

--- a/packages/hyperion-autologging/src/ALSurfaceData.ts
+++ b/packages/hyperion-autologging/src/ALSurfaceData.ts
@@ -11,10 +11,13 @@ import { type IALFlowlet } from "./ALFlowletManager";
 import type { ALSurfaceCapability } from "./ALSurface";
 import { type Metadata } from "./ALType";
 
-
 export type ALSurfaceEvent = Readonly<{
   surface: string;
   surfaceData: ALSurfaceData;
+}>;
+
+export type EventMetadata = Readonly<{
+  [eventName in keyof DocumentEventMap]?: Metadata
 }>;
 
 /**
@@ -118,6 +121,7 @@ export class ALSurfaceData extends ALSurfaceDataCore {
     public readonly callFlowlet: IALFlowlet,
     public readonly capability: ALSurfaceCapability | null | undefined,
     public metadata: Metadata,
+    public eventMetadata: EventMetadata | null | undefined,
     public readonly domAttributeName: string,
     public readonly domAttributeValue: string,
   ) {

--- a/packages/hyperion-autologging/src/ALUIEventPublisher.ts
+++ b/packages/hyperion-autologging/src/ALUIEventPublisher.ts
@@ -279,8 +279,8 @@ export function publish(options: InitOptions): void {
         flowletName += `${separator}surface=${surface}`;
         separator = '&';
         surfaceData = ALSurfaceData.get(surface);
-        const eventMetadata = surfaceData?.eventMetadata?.[eventName]; 
-        if (eventMetadata){
+        const eventMetadata = surfaceData?.getInheriteUIEventMetadata(eventName);
+        if (eventMetadata) {
           Object.assign(uiEventData.metadata, eventMetadata);
         }
       }

--- a/packages/hyperion-autologging/src/ALUIEventPublisher.ts
+++ b/packages/hyperion-autologging/src/ALUIEventPublisher.ts
@@ -279,6 +279,10 @@ export function publish(options: InitOptions): void {
         flowletName += `${separator}surface=${surface}`;
         separator = '&';
         surfaceData = ALSurfaceData.get(surface);
+        const eventMetadata = surfaceData?.eventMetadata?.[eventName]; 
+        if (eventMetadata){
+          Object.assign(uiEventData.metadata, eventMetadata);
+        }
       }
       if (autoLoggingID) {
         flowletName += `${separator}element=${autoLoggingID}`;

--- a/packages/hyperion-react-testapp/src/AutoLoggingWrapper.ts
+++ b/packages/hyperion-react-testapp/src/AutoLoggingWrapper.ts
@@ -131,13 +131,13 @@ export function init() {
           enableElementTextExtraction: true,
           interactableElementsOnly: false,
         },
-        {
-          eventName: 'mouseover',
-          cacheElementReactInfo: true,
-          interactableElementsOnly: false,
-          enableElementTextExtraction: true,
-          durationThresholdToEmitHoverEvent: 1000,
-        },
+        // {
+        //   eventName: 'mouseover',
+        //   cacheElementReactInfo: true,
+        //   interactableElementsOnly: false,
+        //   enableElementTextExtraction: true,
+        //   durationThresholdToEmitHoverEvent: 1000,
+        // },
       ]
     },
     heartbeat: {

--- a/packages/hyperion-react-testapp/src/component/ElementNameComponent.tsx
+++ b/packages/hyperion-react-testapp/src/component/ElementNameComponent.tsx
@@ -59,10 +59,10 @@ export default function (/* props: Props */) {
         <label id='ch1'>Check box 1</label>
         <input type='checkbox' aria-labelledby="ch1" defaultChecked></input>
         <input type='checkbox' aria-label="Check box 2" ></input>
-        <SurfaceComp surface="inputs2" eventMetadata={{click: {test: "mt"}}}>
+        <SurfaceComp surface="inputs2" uiEventMetadata={{ click: { test1: "c2.1", test2: "c2.2" }, mousedown: { test1: "md2.1" } }}>
           <input type='radio' aria-label="Radio 1" name='radios1'></input>
           <input type="radio" aria-label="Radio 2" name='radios1' defaultChecked></input>
-          <SurfaceComp surface="inputs3">
+          <SurfaceComp surface="inputs3" uiEventMetadata={{ click: { test1: "c3.1" } }} >
             <input type='radio' aria-label="Radio 3" name='radios2'></input>
             <input type="radio" aria-label="Radio 4" name='radios2'></input>
             <input type="radio" name='radios2' id="radio5"></input>
@@ -82,5 +82,5 @@ export default function (/* props: Props */) {
       /><div><div id="js_1q">Single image or video </div></div>
         <div>One image or video, or a slideshow with multiple images</div></div></div></label>
     </div>
-  </SurfaceComp>;
+  </SurfaceComp >;
 }

--- a/packages/hyperion-react-testapp/src/component/ElementNameComponent.tsx
+++ b/packages/hyperion-react-testapp/src/component/ElementNameComponent.tsx
@@ -59,7 +59,7 @@ export default function (/* props: Props */) {
         <label id='ch1'>Check box 1</label>
         <input type='checkbox' aria-labelledby="ch1" defaultChecked></input>
         <input type='checkbox' aria-label="Check box 2" ></input>
-        <SurfaceComp surface="inputs2">
+        <SurfaceComp surface="inputs2" eventMetadata={{click: {test: "mt"}}}>
           <input type='radio' aria-label="Radio 1" name='radios1'></input>
           <input type="radio" aria-label="Radio 2" name='radios1' defaultChecked></input>
           <SurfaceComp surface="inputs3">


### PR DESCRIPTION
Add support for event specific metadata on surface. 
(it may make sense to have a `catch all` metadata for events as well. )

![image](https://github.com/user-attachments/assets/31d0b98c-d809-4d37-9463-99f0915c1ff0)
