### PR TITLE
Attach surface and event name to trigger flowlet data

### DIFF
--- a/packages/hyperion-autologging/src/ALFlowletManager.ts
+++ b/packages/hyperion-autologging/src/ALFlowletManager.ts
@@ -15,6 +15,7 @@ import { Flowlet, FlowletDataType } from "hyperion-flowlet/src/Flowlet";
 export interface ALFlowletDataType extends FlowletDataType {
   surface?: string;
   triggerFlowlet?: IALFlowlet;
+  triggerUIEventName?: string;
 };
 
 export interface IALFlowlet<DataType extends ALFlowletDataType = ALFlowletDataType> extends Flowlet<DataType> { }

--- a/packages/hyperion-autologging/src/ALUIEventPublisher.ts
+++ b/packages/hyperion-autologging/src/ALUIEventPublisher.ts
@@ -286,6 +286,12 @@ export function publish(options: InitOptions): void {
       flowletName += ')';
 
       let triggerFlowlet = new flowletManager.flowletCtor(flowletName, ALUIEventGroupPublisher.getGroupRootFlowlet(event));
+
+      if (surface) {
+        triggerFlowlet.data.surface = surface;
+        triggerFlowlet.data.triggerUIEventName = eventName;
+      }
+
       let callFlowlet = Flags.getFlags().preciseTriggerFlowlet
         ? flowletManager.top()
         : triggerFlowlet;


### PR DESCRIPTION
We already include surface and eventName in the name of the trigger flowlet. We can also ensure this information is part of the corresponding flowlet.

This way, if a downstream process needs this data, they won't have to rely on calling `.toString` on the whole chain and then extracting the value from the string.