### PR TITLE
Surface visibility fix1

### DIFF
--- a/packages/hyperion-autologging/src/ALSurface.ts
+++ b/packages/hyperion-autologging/src/ALSurface.ts
@@ -306,6 +306,7 @@ export function init(options: InitOptions): ALSurfaceHOC {
       callFlowlet = new flowletManager.flowletCtor(surface, surfaceCtx.callFlowlet ?? flowletManager.root);
       callFlowlet.data.surface = nonInteractiveSurfacePath;
       surfaceData = new ALSurfaceData(
+        surface,
         surfacePath,
         surfaceCtx,
         nonInteractiveSurfacePath,

--- a/packages/hyperion-autologging/src/ALSurfaceData.ts
+++ b/packages/hyperion-autologging/src/ALSurfaceData.ts
@@ -143,8 +143,12 @@ export class ALSurfaceData extends ALSurfaceDataCore {
     if (__DEV__) {
       assert(
         !surfacesData.get(nonInteractiveSurface),
-        `Surface ${surface} is already added to list`
+        `Surface ${nonInteractiveSurface} is already added to list`
       );
+      assert(
+        capability?.nonInteractive || !surfacesData.get(surface),
+        `Surface ${surface} is already added to list`
+      )
       assert(
         this.parent.surface === null || surfacesData.has(this.parent.nonInteractiveSurface),
         `Parent of surface ${surface} does not exist in the list`

--- a/packages/hyperion-autologging/src/ALSurfaceData.ts
+++ b/packages/hyperion-autologging/src/ALSurfaceData.ts
@@ -118,8 +118,15 @@ export class ALSurfaceData extends ALSurfaceDataCore {
   #visibilityEvent: ALSurfaceVisibilityEventData | null = null;
 
   constructor(
+    /** short name */
+    public readonly surfaceName: string,
+    
+    /** full interactive name */
     public readonly surface: string,
+    
     public readonly parent: ALSurfaceData | ALSurfaceDataRoot,
+    
+    /** full path to be also used key */
     public readonly nonInteractiveSurface: string,
     public readonly callFlowlet: IALFlowlet,
     public readonly capability: ALSurfaceCapability | null | undefined,

--- a/packages/hyperion-autologging/src/ALSurfaceVisibilityPublisher.ts
+++ b/packages/hyperion-autologging/src/ALSurfaceVisibilityPublisher.ts
@@ -154,7 +154,7 @@ export function publish(options: InitOptions): void {
                * that mutation events fire synchronously with react changes, while visibility events fire async.
                * We might want to track mutation event directly in this module.
                */
-              console.warn(`Surface ${surfaceData.surface} has visibility event but is already unmounted!`)
+              console.warn(`Surface ${surfaceData.nonInteractiveSurface} has visibility event but is already unmounted!`)
             }
           }
           for (const [surfaceData, entries] of visibleSet) {
@@ -178,7 +178,7 @@ export function publish(options: InitOptions): void {
               eventTimestamp: performanceAbsoluteNow.fromRelativeTime(entry.time),
               eventIndex: ALEventIndex.getNextEventIndex(),
               relatedEventIndex: mutationEvent.eventIndex,
-              surface: surfaceData.surface,
+              surface: surfaceData.nonInteractiveSurface,
               surfaceData,
               element: mutationEvent.element,
               autoLoggingID: mutationEvent.autoLoggingID, // same element, same ID

--- a/packages/hyperion-react-testapp/src/component/NonInteractiveSurfaceComponent.tsx
+++ b/packages/hyperion-react-testapp/src/component/NonInteractiveSurfaceComponent.tsx
@@ -4,7 +4,7 @@
 
 import * as React from 'react';
 import { useState, useRef } from 'react';
-import { SurfaceComp } from './Surface';
+import { SimpleSurface, SurfaceComp } from './Surface';
 
 export default function (_props: {}): React.ReactElement {
   console.log('Root render');
@@ -21,13 +21,13 @@ export default function (_props: {}): React.ReactElement {
           <div>/S1/S2</div>
           <SurfaceComp surface='R2' capability={{ nonInteractive: true }} nodeRef={refR2}>
             <div ref={refR2}>/S1/R1/S2/R2</div>
-            <SurfaceComp surface="S3">
-              <SurfaceComp surface="S4">
+            <SimpleSurface surface="S3">
+              <SimpleSurface surface="S4">
                 <SurfaceComp surface="R3" capability={{ nonInteractive: true }}>
                   <div>/S1/R1/S2/R2/S3/S4/R3</div>
                 </SurfaceComp>
-              </SurfaceComp>
-            </SurfaceComp>
+              </SimpleSurface>
+            </SimpleSurface>
           </SurfaceComp>
         </SurfaceComp>
       </SurfaceComp>

--- a/packages/hyperion-react-testapp/src/component/NonInteractiveSurfaceComponent.tsx
+++ b/packages/hyperion-react-testapp/src/component/NonInteractiveSurfaceComponent.tsx
@@ -2,7 +2,6 @@
  * Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved.
  */
 
-import { ALSurfaceCapability } from "hyperion-autologging/src/ALSurface";
 import * as React from 'react';
 import { useState, useRef } from 'react';
 import { SurfaceComp } from './Surface';
@@ -11,17 +10,24 @@ export default function (_props: {}): React.ReactElement {
   console.log('Root render');
   const [count, setCount] = useState(0);
   const refR2 = useRef(null)
-  const EMPTY_REF = {current: null};
+  const EMPTY_REF = { current: null };
 
   return (
     <SurfaceComp surface='S1'>
       <div>S1</div>
-      <SurfaceComp surface='R1' capability={{nonInteractive: true}} nodeRef={EMPTY_REF}>
+      <SurfaceComp surface='R1' capability={{ nonInteractive: true }} nodeRef={EMPTY_REF}>
         <div>R1 (will not be tracked)</div>
         <SurfaceComp surface='S2'>
           <div>/S1/S2</div>
-          <SurfaceComp surface='R2' capability={{nonInteractive: true}} nodeRef={refR2}>
+          <SurfaceComp surface='R2' capability={{ nonInteractive: true }} nodeRef={refR2}>
             <div ref={refR2}>/S1/R1/S2/R2</div>
+            <SurfaceComp surface="S3">
+              <SurfaceComp surface="S4">
+                <SurfaceComp surface="R3" capability={{ nonInteractive: true }}>
+                  <div>/S1/R1/S2/R2/S3/S4/R3</div>
+                </SurfaceComp>
+              </SurfaceComp>
+            </SurfaceComp>
           </SurfaceComp>
         </SurfaceComp>
       </SurfaceComp>

--- a/packages/hyperion-react-testapp/src/component/Surface.tsx
+++ b/packages/hyperion-react-testapp/src/component/Surface.tsx
@@ -37,3 +37,17 @@ export const Surface = (props: ALSurface.ALSurfaceProps) => {
 export function SurfaceComp(props: React.PropsWithChildren<ALSurface.ALSurfaceProps>) {
   return Surface(props)(props.children);
 }
+
+export function SimpleSurface(props: React.PropsWithChildren<ALSurface.ALSurfaceProps>) {
+  if (!props.capability?.trackVisibilityThreshold) {
+    props = {
+      ...props,
+      capability: {
+        trackVisibilityThreshold: .5,
+        ...props.capability,
+        // trackMutation: false,
+      }
+    }
+  }
+  return AutoLogging.getSurfaceRenderer(SurfaceRenderer)(props)(props.children);
+}

--- a/packages/hyperion-react-testapp/src/component/Surface.tsx
+++ b/packages/hyperion-react-testapp/src/component/Surface.tsx
@@ -12,15 +12,16 @@ export type Props = {
 };
 
 let SurfaceRenderer: ALSurface.ALSurfaceHOC = (props, render) => {
-  return children => render ? render(children) : <>children</>;
+  return children => render ? render(children) : <>{children}</>;
 }
 
 export const Surface = (props: ALSurface.ALSurfaceProps) => {
-  if (!props.capability) {
+  if (!props.capability?.trackVisibilityThreshold) {
     props = {
       ...props,
       capability: {
         trackVisibilityThreshold: .5,
+        ...props.capability,
         // trackMutation: false,
       }
     }


### PR DESCRIPTION
It is better to review the commit separately to understand the final fix.
This PR fixes two bugs in surface_visible event:
- fixes the current surface value for non-interactive surfaces
- handles multiple nested surfaces

![image](https://github.com/user-attachments/assets/a0372b58-fa19-4a1e-be7b-5a74802d712a)
