### PR TITLE
 Added more api to monitor for SyncMutationObserver

### DIFF
--- a/packages/hyperion-dom/src/IElement.ts
+++ b/packages/hyperion-dom/src/IElement.ts
@@ -10,18 +10,14 @@ import { interceptElementAttribute } from "./ElementAttributeInterceptor";
 import * as IElememt_ from "./IElement_";
 export * from "./IElement_";
 
-// export const IElementtPrototype = new DOMShadowPrototype(
-//   Element,
-//   INodePrototype,
-//   {
-//     sampleObject: sampleHTMLElement,
-//     nodeType: document.ELEMENT_NODE
-//   }
-// );
+/**
+ * See IElement_ for details.
+ */
 export const IElementtPrototype = IElememt_.IElementtPrototype;
 
-// export const getAttribute = interceptMethod('getAttribute', IElementtPrototype);
-// export const getAttributeNS = interceptMethod('getAttributeNS', IElementtPrototype);
+export const after = interceptMethod('after', IElementtPrototype);
+export const append = interceptMethod('append', IElementtPrototype);
+export const before = interceptMethod('before', IElementtPrototype);
 export const getAttributeNames = interceptMethod('getAttributeNames', IElementtPrototype);
 export const getAttributeNode = interceptMethod('getAttributeNode', IElementtPrototype, true);
 export const getAttributeNodeNS = interceptMethod('getAttributeNodeNS', IElementtPrototype, true);
@@ -36,13 +32,13 @@ export const hasAttributes = interceptMethod('hasAttributes', IElementtPrototype
 export const insertAdjacentElement = interceptMethod('insertAdjacentElement', IElementtPrototype);
 export const insertAdjacentHTML = interceptMethod('insertAdjacentHTML', IElementtPrototype);
 export const insertAdjacentText = interceptMethod('insertAdjacentText', IElementtPrototype);
+export const prepend = interceptMethod('prepend', IElementtPrototype);
+export const remove = interceptMethod('remove', IElementtPrototype);
 export const removeAttribute = interceptMethod('removeAttribute', IElementtPrototype);
-export const removeAttributeNS = interceptMethod('removeAttributeNS', IElementtPrototype);
 export const removeAttributeNode = interceptMethod('removeAttributeNode', IElementtPrototype);
-// export const setAttribute = interceptMethod('setAttribute', IElementtPrototype);
-// export const setAttributeNS = interceptMethod('setAttributeNS', IElementtPrototype);
-// export const setAttributeNode = interceptMethod('setAttributeNode', IElementtPrototype);
-// export const setAttributeNodeNS = interceptMethod('setAttributeNodeNS', IElementtPrototype);
+export const removeAttributeNS = interceptMethod('removeAttributeNS', IElementtPrototype);
+export const replaceChildren = interceptMethod('replaceChildren', IElementtPrototype);
+export const replaceWith = interceptMethod('replaceWith', IElementtPrototype);
 export const toggleAttribute = interceptMethod('toggleAttribute', IElementtPrototype);
 
 export const id = interceptElementAttribute("id", IElementtPrototype);

--- a/packages/hyperion-dom/src/IElement_.ts
+++ b/packages/hyperion-dom/src/IElement_.ts
@@ -3,6 +3,9 @@
  * 
  * This file only contains set of features that ElementAttributeInterceptor
  * needs. They are here to avoid circular depndency between modules.
+ * We should only include what is needed by IElementCustom which is called
+ * by ElementAttributeInterceptor, which in turn is called by IElement.
+ * Specifically, we should never add any attribute interceptor here.
  */
 
 import { interceptMethod } from "hyperion-core/src/MethodInterceptor";
@@ -21,23 +24,6 @@ IElementtPrototype.extension.useCaseInsensitivePropertyName = true;
 
 export const getAttribute = interceptMethod('getAttribute', IElementtPrototype);
 export const getAttributeNS = interceptMethod('getAttributeNS', IElementtPrototype);
-// export const getAttributeNames = interceptMethod('getAttributeNames', IElementtPrototype);
-// export const getAttributeNode = interceptMethod('getAttributeNode', IElementtPrototype);
-// export const getAttributeNodeNS = interceptMethod('getAttributeNodeNS', IElementtPrototype);
-// export const getBoundingClientRect = interceptMethod('getBoundingClientRect', IElementtPrototype);
-// export const getClientRects = interceptMethod('getClientRects', IElementtPrototype);
-// export const getElementsByClassName = interceptMethod('getElementsByClassName', IElementtPrototype);
-// export const getElementsByTagName = interceptMethod('getElementsByTagName', IElementtPrototype);
-// export const getElementsByTagNameNS = interceptMethod('getElementsByTagNameNS', IElementtPrototype);
-// export const hasAttribute = interceptMethod('hasAttribute', IElementtPrototype);
-// export const hasAttributeNS = interceptMethod('hasAttributeNS', IElementtPrototype);
-// export const hasAttributes = interceptMethod('hasAttributes', IElementtPrototype);
-// export const insertAdjacentElement = interceptMethod('insertAdjacentElement', IElementtPrototype);
-// export const insertAdjacentHTML = interceptMethod('insertAdjacentHTML', IElementtPrototype);
-// export const insertAdjacentText = interceptMethod('insertAdjacentText', IElementtPrototype);
-// export const removeAttribute = interceptMethod('removeAttribute', IElementtPrototype);
-// export const removeAttributeNS = interceptMethod('removeAttributeNS', IElementtPrototype);
-// export const removeAttributeNode = interceptMethod('removeAttributeNode', IElementtPrototype);
 export const setAttribute = interceptMethod('setAttribute', IElementtPrototype);
 export const setAttributeNS = interceptMethod('setAttributeNS', IElementtPrototype);
 export const setAttributeNode = interceptMethod('setAttributeNode', IElementtPrototype);

--- a/packages/hyperion-dom/src/index.ts
+++ b/packages/hyperion-dom/src/index.ts
@@ -5,7 +5,7 @@
 'use strict';
 export * as IEvent from "./IEvent";
 export * as IEventTarget from "./IEventTarget";
-// export * as INode from "./INode";
+export * as INode from "./INode";
 export * as ICSSStyleDeclaration from "./ICSSStyleDeclaration";
 export * as IElement from "./IElement";
 export * as IHTMLElement from "./IHTMLElement";

--- a/packages/hyperion-util/src/SyncMutationObserver.ts
+++ b/packages/hyperion-util/src/SyncMutationObserver.ts
@@ -80,3 +80,87 @@ IElement.insertAdjacentElement.onBeforeCallObserverAdd(function (this, where, el
     });
   }
 });
+
+
+function getNodes(nodes: (string | Node)[]): Node[] {
+  /**
+   * Many of the following methods can take a string or node as an argument.
+   * We only want to pass nodes to the observer, so we filter out strings.
+   * we could also try to convert them to nodes, but since that is less likely usage, we just filter to be sure
+   */
+  return nodes.filter<Node>(node => node instanceof Node);
+}
+
+IElement.after.onBeforeCallObserverAdd(function (this, ...nodes) {
+  const target = this.parentNode;
+  if (target) {
+    onDOMMutation.call({
+      action: "added",
+      target,
+      nodes: getNodes(nodes)
+    });
+  }
+});
+
+IElement.append.onBeforeCallObserverAdd(function (this, ...nodes) {
+  onDOMMutation.call({
+    action: "added",
+    target: this,
+    nodes: getNodes(nodes)
+  });
+});
+IElement.before.onBeforeCallObserverAdd(function (this, ...nodes) {
+  const target = this.parentNode;
+  if (target) {
+    onDOMMutation.call({
+      action: "added",
+      target,
+      nodes: getNodes(nodes)
+    });
+  }
+});
+IElement.prepend.onBeforeCallObserverAdd(function (this, ...nodes) {
+  onDOMMutation.call({
+    action: "added",
+    target: this,
+    nodes: getNodes(nodes)
+  });
+});
+IElement.remove.onBeforeCallObserverAdd(function (this) {
+  const target = this.parentNode;
+  if (target) {
+    onDOMMutation.call({
+      action: "removed",
+      target,
+      nodes: [this]
+    });
+  }
+});
+IElement.replaceChildren.onBeforeCallObserverAdd(function (this, ...nodes) {
+  // should we also call this for removed children?
+  onDOMMutation.call({
+    action: "removed",
+    target: this,
+    nodes: getNodes(Array.from(this.childNodes))
+  });
+  onDOMMutation.call({
+    action: "added",
+    target: this,
+    nodes: getNodes(nodes)
+  });
+});
+IElement.replaceWith.onBeforeCallObserverAdd(function (this, ...nodes) {
+  const target = this.parentNode;
+  if (target) {
+    onDOMMutation.call({
+      action: "removed",
+      target,
+      nodes: [this]
+    });
+    onDOMMutation.call({
+      action: "added",
+      target,
+      nodes: getNodes(nodes)
+    });
+  }
+});


### PR DESCRIPTION
    There are more Element.* methods that can modify an element or its
    parent's children. These api are added for interception and then
    included in the SyncMutationObserver for completeness.