### PR TITLE
[AL]Fix surface metadata logging

### DIFF
--- a/packages/hyperion-autologging/src/ALSurfaceVisibilityPublisher.ts
+++ b/packages/hyperion-autologging/src/ALSurfaceVisibilityPublisher.ts
@@ -85,7 +85,7 @@ export function publish(options: InitOptions): void {
     }
   }
 
-  // lookup surfaces that are mounted by their root element 
+  // lookup surfaces that are mounted by their root element
   const observedRoots = new MapToArray<Element, ALSurfaceData>();
   const surfaceDataRoots = new MapToArray<ALSurfaceData, Element>();
 
@@ -234,6 +234,7 @@ export function publish(options: InitOptions): void {
               element: mutationEvent.element,
               autoLoggingID: mutationEvent.autoLoggingID, // same element, same ID
               metadata: {
+                ...surfaceData.metadata,
                 emit_time: '' + performanceAbsoluteNow(), // just to keep track of the difference
               },
               callFlowlet: mutationEvent.callFlowlet,

--- a/packages/hyperion-autologging/src/ALUIEventPublisher.ts
+++ b/packages/hyperion-autologging/src/ALUIEventPublisher.ts
@@ -314,7 +314,6 @@ export function publish(options: InitOptions): void {
         surface,
         surfaceData,
         ...elementText,
-        metadata: {...surfaceData?.metadata,...uiEventData.metadata},
         reactComponentName: reactComponentData?.name,
         reactComponentStack: reactComponentData?.stack,
       };

--- a/packages/hyperion-autologging/src/ALUIEventPublisher.ts
+++ b/packages/hyperion-autologging/src/ALUIEventPublisher.ts
@@ -314,6 +314,7 @@ export function publish(options: InitOptions): void {
         surface,
         surfaceData,
         ...elementText,
+        metadata: {...surfaceData?.metadata,...uiEventData.metadata},
         reactComponentName: reactComponentData?.name,
         reactComponentStack: reactComponentData?.stack,
       };


### PR DESCRIPTION
Context

We notice no metadata from surface wrapper log into the `ui_event_type` and the `surface` event type. We do have for the mount_event, debug and found it's because we haven't added the metadata from surface into the AL event metadata.

Repro issue: Add metadata in surface wrapper, notice metadata only log for mutation(mount) event
<img width="945" alt="Screenshot 2025-04-23 at 6 09 27 PM" src="https://github.com/user-attachments/assets/58be2e2f-d32a-40b9-a7db-8162aa6d513d" />

| before fix | after fix |
| <img width="545" alt="Screenshot 2025-04-23 at 6 17 25 PM" src="https://github.com/user-attachments/assets/cf4a9a0a-d701-4e8f-80d2-d458e580e1e8" />|
<img width="306" alt="Screenshot 2025-04-23 at 6 19 55 PM" src="https://github.com/user-attachments/assets/864e109b-9d89-4c7a-8532-3c4d0cd8c51e" />|