### PR TITLE
Keep the text element for rendering covered text

### DIFF
--- a/packages/hyperion-autologging/src/ALInteractableDOMElement.ts
+++ b/packages/hyperion-autologging/src/ALInteractableDOMElement.ts
@@ -429,7 +429,8 @@ export type ALElementText = {
   text: string,
 
   /// The source attribute where we got the elementName from
-  readonly source: 'innerText' | 'aria-label' | 'aria-labelledby' | 'aria-description' | 'aria-describedby' | 'label';
+  readonly source: 'innerText' | 'aria-label' | 'aria-labelledby' | 'aria-description' | 'aria-describedby' | 'label',
+  elements: Array<Element>;
 };
 
 export type ALElementTextEvent = Readonly<{
@@ -489,7 +490,8 @@ function getTextFromTextNode(domSource: ALDOMTextSource, textNode: Text, source:
     return callExternalTextProcessor(
       {
         text,
-        source
+        source,
+        elements: [domSource.element]
       },
       domSource,
       results,
@@ -523,7 +525,7 @@ function getTextFromElementsByIds(domSource: ALDOMTextSource, source: ALElementT
 
   for (let i = 0; i < indirectSources.length; i++) {
     if (i) {
-      results.push({ text: " ", source }); // Insert space between values
+      results.push({ text: " ", source, elements: []}); // Insert space between values
     }
 
     domSource.element = indirectSources[i];
@@ -539,7 +541,8 @@ function getTextFromElementAttribute(domSource: ALDOMTextSource, source: ALEleme
     return callExternalTextProcessor(
       {
         text: label,
-        source
+        source,
+        elements: [domSource.element]
       },
       domSource,
       results
@@ -740,12 +743,14 @@ export function getElementTextEvent(
         ...prev,
         ...current,
         text: prev.text + cleanText,
+        elements: [...prev.elements, ...current.elements]
       };
       return next;
     },
     {
       text: "",
-      source: 'innerText'
+      source: 'innerText',
+      elements: []
     }
   );
   const finalResult: ALElementTextEvent = {

--- a/packages/hyperion-autologging/test/ALInteractableDOMElement.test.ts
+++ b/packages/hyperion-autologging/test/ALInteractableDOMElement.test.ts
@@ -21,7 +21,7 @@ function createTestDom(): DomFragment.DomFragment {
   <span id='7' aria-description="test7" aria-describedby="8"></span>
   <span id='8'>test8</span>
   <span id='9' aria-label="test9">ignored</span>
-  <span id='10'><span aria-label="te"></span>s<span>t10</span></span>
+  <span id='10'><span id='10.1' aria-label="te"></span>s<span id='10.2'>t10</span></span>
   `);
 }
 function createInteractableTestDom(): DomFragment.DomFragment {
@@ -357,5 +357,28 @@ describe("Test various element text options", () => {
       node.addEventListener("mouseover", () => { });
       expect(node.getAttribute("data-interactable")).toContain("|mouseover|");
     }
+  });
+
+  test('element with text elements', () => {
+    ALInteractableDOMElement.init({}); // clear the options from the previous tests
+    const dom = createTestDom();
+    const children = dom.root.children;
+    const texts = Array.from(children).map(child => ALInteractableDOMElement.getElementTextEvent(child, null));
+
+    expect(texts[0].elementText?.elements[0]).toStrictEqual(document.getElementById('1'));
+    expect(texts[1].elementText?.elements[0]).toStrictEqual(document.getElementById('2'));
+    expect(texts[2].elementText?.elements[0]).toStrictEqual(document.getElementById('3'));
+    expect(texts[3].elementText?.elements[0]).toStrictEqual(document.getElementById('3'));
+    expect(texts[4].elementText?.elements[0]).toStrictEqual(document.getElementById('3'));
+    expect(texts[5].elementText?.elements[0]).toStrictEqual(document.getElementById('3'));
+    expect(texts[5].elementText?.elements[1]).toStrictEqual(document.getElementById('8'));
+    expect(texts[6].elementText?.elements[0]).toStrictEqual(document.getElementById('7'));
+    expect(texts[7].elementText?.elements[0]).toStrictEqual(document.getElementById('8'));
+    expect(texts[8].elementText?.elements[0]).toStrictEqual(document.getElementById('9'));
+    expect(texts[9].elementText?.elements[0]).toStrictEqual(document.getElementById('10.1'));
+    expect(texts[9].elementText?.elements[1]).toStrictEqual(document.getElementById('10'));
+    expect(texts[9].elementText?.elements[2]).toStrictEqual(document.getElementById('10.2'));
+
+    dom.cleanup();
   });
 });


### PR DESCRIPTION
I would like to get the text element so I can know which text is covered by AL. In this PR, expose the text element.

