### PR TITLE
Added a plugin to report FPS of the page

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "./packages/hyperion-react",
     "./packages/hyperion-autologging",
     "./packages/hyperion-autologging-plugin-eventhash",
+    "./packages/hyperion-autologging-plugin-fps",
     "./packages/hyperion-autologging-visualizer",
     "./packages/hyperion-util",
     "./packages/hyperion-react-testapp"
@@ -69,6 +70,7 @@
     "hyperion-async-counter": "*",
     "hyperion-autologging": "*",
     "hyperion-autologging-plugin-eventhash": "*",
+    "hyperion-autologging-plugin-fps": "*",
     "hyperion-autologging-visualizer": "*",
     "hyperion-channel": "*",
     "hyperion-core": "*",

--- a/packages/hyperion-autologging-plugin-fps/.gitignore
+++ b/packages/hyperion-autologging-plugin-fps/.gitignore
@@ -1,0 +1,7 @@
+*.log
+.DS_Store
+node_modules
+dist
+coverage
+package-lock.json
+test/**/*.js

--- a/packages/hyperion-autologging-plugin-fps/.npmignore
+++ b/packages/hyperion-autologging-plugin-fps/.npmignore
@@ -1,0 +1,6 @@
+*.log
+.DS_Store
+coverage
+test/**/*.js
+jest.config.js
+babel.config.js

--- a/packages/hyperion-autologging-plugin-fps/babel.config.js
+++ b/packages/hyperion-autologging-plugin-fps/babel.config.js
@@ -1,0 +1,2 @@
+const baseConfig = require('hyperion-devtools/babel.config');
+module.exports = baseConfig;

--- a/packages/hyperion-autologging-plugin-fps/jest.config.js
+++ b/packages/hyperion-autologging-plugin-fps/jest.config.js
@@ -1,0 +1,6 @@
+const baseConfig = require('hyperion-devtools/jest.config');
+/*
+ * For a detailed explanation regarding each configuration property and type check, visit:
+ * https://jestjs.io/docs/configuration
+ */
+module.exports = baseConfig;

--- a/packages/hyperion-autologging-plugin-fps/package.json
+++ b/packages/hyperion-autologging-plugin-fps/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "hyperion-autologging-plugin-fps",
+  "description": "plugin for autologging to add Frame Per Second event",
+  "version": "0.0.1",
+  "license": "MIT",
+  "scripts": {
+    "build": "tsc",
+    "build-react": "react-scripts build",
+    "watch": "npm run build -- --watch",
+    "start": "npm run watch",
+    "test": "npm run build & jest"
+  },
+  "workspaces": [
+    "../hyperion-devtools",
+    "../hyperion-globals",
+    "../hyperion-channel"
+  ],
+  "dependencies": {
+    "hyperion-channel": "*",
+    "hyperion-globals": "*"
+  },
+  "devDependencies": {
+    "hyperion-devtools": "*",
+    "@types/jest": "^29.5.14"
+  },
+  "eslintConfig": {},
+  "browserslist": {
+    "production": [
+      ">0.2%",
+      "not dead",
+      "not op_mini all"
+    ],
+    "development": [
+      "last 1 chrome version",
+      "last 1 firefox version",
+      "last 1 safari version"
+    ]
+  }
+}

--- a/packages/hyperion-autologging-plugin-fps/src/index.ts
+++ b/packages/hyperion-autologging-plugin-fps/src/index.ts
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved.
+ */
+
+'use strict';
+import { ALMetadataEvent, ALPageEvent, ALTimedEvent } from "hyperion-autologging/src/ALType";
+import { Channel } from "hyperion-channel";
+import * as Types from "hyperion-util/src/Types";
+import { PluginInit } from "hyperion-autologging/src/AutoLogging";
+import performanceAbsoluteNow from "hyperion-util/src/performanceAbsoluteNow";
+import { getCurrMainPageUrl } from "hyperion-autologging/src/MainPageUrl";
+
+
+export type ALFPSEventData = ALTimedEvent & ALPageEvent & ALMetadataEvent & Readonly<{
+  fps: number;
+  fpsThreshold: number;
+}>;
+
+export type ALChannelFPSEvent = Readonly<{
+  al_fps_event: [ALFPSEventData],
+}>;
+
+export type ALFPSChannel = Channel<ALChannelFPSEvent>;
+
+export type InitOptions = Types.Options<{
+  /// The channel to emit FPS events on
+  channel: ALFPSChannel;
+  /// The minimum FPS threshold to trigger an event
+  minFPSThreshold: number;
+}>;
+
+export function init(options: InitOptions): PluginInit {
+  return (_pluginChannel) => {
+    let frames = 0;
+    let lastFrameTime = 0
+    function measureFPS(timestamp: number): void {
+      frames++;
+      let currentFrameTime = timestamp; // performance.now();
+      let delta = currentFrameTime - lastFrameTime;
+      if (delta > 1000) {
+        const fps = frames / (delta / 1000);
+        if (fps < options.minFPSThreshold) {
+          // console.warn(`FPS dropped below threshold: ${fps} < ${options.minFPSThreshold}`);
+          options.channel.emit('al_fps_event', {
+            eventTimestamp: performanceAbsoluteNow(),
+            pageURI: getCurrMainPageUrl(),
+            fps,
+            fpsThreshold: options.minFPSThreshold,
+            metadata: {}
+          });
+        }
+        lastFrameTime = currentFrameTime;
+        frames = 0;
+      }
+      window.requestAnimationFrame(measureFPS);
+    }
+    measureFPS(performance.now());
+  };
+}

--- a/packages/hyperion-autologging-plugin-fps/test/index.test.ts
+++ b/packages/hyperion-autologging-plugin-fps/test/index.test.ts
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved.
+ *
+ * @jest-environment jsdom
+ */
+'use strict';
+
+describe("Hyperion Autologging Plugin FPS", () => {
+  let rafSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    rafSpy = jest.spyOn(window, 'requestAnimationFrame').mockImplementation(cb => {
+      cb(performance.now()); return 0;
+    });
+  });
+
+  afterEach(() => {
+    rafSpy.mockRestore();
+  });
+
+  test("empty test", () => {
+    window.requestAnimationFrame(() => {
+    });
+    expect(0);
+  });
+});

--- a/packages/hyperion-autologging-plugin-fps/tsconfig.json
+++ b/packages/hyperion-autologging-plugin-fps/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  // see https://www.typescriptlang.org/tsconfig to better understand tsconfigs
+  "extends": "hyperion-devtools",
+  "compilerOptions": {
+    // "jsx": "react-jsx",
+    "jsx": "preserve",
+  },
+  "include": [
+    "src",
+  ],
+}

--- a/packages/hyperion-autologging/src/AutoLogging.ts
+++ b/packages/hyperion-autologging/src/AutoLogging.ts
@@ -46,7 +46,7 @@ export type ALChannelEvent = ChannelEventType<
 
 type PublicInitOptions<T> = Omit<T, keyof ALSharedInitOptions<never> | 'react'>;
 
-type PluginInit = (channel: Channel<ALChannelEvent>) => void;
+export type PluginInit = (channel: Channel<ALChannelEvent>) => void;
 
 export type InitOptions = Types.Options<
   ALSharedInitOptions<ALChannelEvent> &

--- a/packages/hyperion-react-testapp/package.json
+++ b/packages/hyperion-react-testapp/package.json
@@ -8,7 +8,8 @@
     "../hyperion-hook",
     "../hyperion-react",
     "../hyperion-autologging",
-    "../hyperion-autologging-visualizer"
+    "../hyperion-autologging-visualizer",
+    "../hyperion-autologging-plugin-fps"
   ],
   "dependencies": {
     "@testing-library/jest-dom": "^6.6.3",
@@ -21,6 +22,7 @@
     "@vitejs/plugin-react": "^4.3.4",
     "hyperion-autologging": "*",
     "hyperion-autologging-visualizer": "*",
+    "hyperion-autologging-plugin-fps": "*",
     "hyperion-globals": "*",
     "hyperion-hook": "*",
     "hyperion-react": "*",

--- a/packages/hyperion-react-testapp/src/AutoLoggingWrapper.ts
+++ b/packages/hyperion-react-testapp/src/AutoLoggingWrapper.ts
@@ -18,6 +18,7 @@ import { getEventExtension } from "hyperion-autologging/src/ALEventExtension";
 import * as Flags from "hyperion-globals/src/Flags";
 import "hyperion-autologging/src/reference";
 import * as PluginEventHash from "hyperion-autologging-plugin-eventhash/src/index";
+import * as PluginFPS from "hyperion-autologging-plugin-fps/src/index";
 import { getSessionFlowID } from "hyperion-autologging/src/ALSessionFlowID";
 
 export let interceptionStatus = "disabled";
@@ -28,7 +29,6 @@ export function init() {
   Flags.setFlags({
     preciseTriggerFlowlet: true,
     optimizeInteractibiltyCheck: true,
-    optimizeSurfaceMaps: true,
   });
 
   interceptionStatus = "enabled";
@@ -68,7 +68,11 @@ export function init() {
     flowletManager,
     channel,
     plugins: [
-      PluginEventHash.init
+      PluginEventHash.init,
+      PluginFPS.init({
+        channel,
+        minFPSThreshold: 10
+      }),
     ],
     componentNameValidator: testCompValidator,
     flowletPublisher: {

--- a/packages/hyperion-react-testapp/src/Channel.ts
+++ b/packages/hyperion-react-testapp/src/Channel.ts
@@ -4,8 +4,10 @@
 
 import { Channel } from "hyperion-channel/src/Channel";
 import * as AutoLogging from "hyperion-autologging/src/AutoLogging";
+import * as PluginFPS from "hyperion-autologging-plugin-fps/src/index";
 
 export const SyncChannel = new Channel<
   AutoLogging.ALChannelEvent &
-  { test: [number, string] }
+  { test: [number, string] } &
+  PluginFPS.ALChannelFPSEvent
 >();

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -111,6 +111,9 @@ export default defineConfig({
       ],
       "hyperionAutoLoggingPluginEventHash": [
         "hyperion-autologging-plugin-eventhash/src/index",
+      ],
+      "hyperionAutoLoggingPluginFPS": [
+        "hyperion-autologging-plugin-fps/src/index",
       ]
     },
     chunkFileNames: "[name].js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,7 @@ export * from "hyperion-hook/src/index";
 export * from "hyperion-channel/src/index";
 
 // hyperionTimedTrigger
-export * from  "hyperion-timed-trigger/src/index";
+export * from "hyperion-timed-trigger/src/index";
 
 // hyperionTestAndSet
 export * from "hyperion-test-and-set/src/index";
@@ -47,14 +47,17 @@ export * from "hyperion-util/src/index";
 export * from "hyperion-flowlet/src/index";
 
 // hyperionReact
-export *  from "hyperion-react/src/index";
+export * from "hyperion-react/src/index";
 
 // hyperionAutoLogging
-export *  from "hyperion-autologging/src/index";
+export * from "hyperion-autologging/src/index";
 
 // hyperionAutoLoggingVisualizer
 export * from "hyperion-autologging-visualizer/src/index";
 
 // hyperionAutoLoggingPluginEventHash
-export * from "hyperion-autologging-plugin-eventhash/src/index";
+export { init as pluginEventHash } from "hyperion-autologging-plugin-eventhash/src/index";
+
+// hyperionAutoLoggingPluginFPS
+export { init as pluginFPS } from "hyperion-autologging-plugin-fps/src/index";
 


### PR DESCRIPTION
This simple plugin reports FPS value if it falls below a given threshold.

It also show cases a few interesting features of the pluging
* we can both consume standard AL events via returning a certain signature function
* we have a configuraiton for the plugin which is called when it is enbaled
* the plugin itself can generate new type of events. In the future, we can possibly split the less used features this way and turn them into plugins.