### PR TITLE
Testing Hyperion JS interceptors in a React Native environment

### DIFF
--- a/packages/hyperion-react-native-testapp/.gitignore
+++ b/packages/hyperion-react-native-testapp/.gitignore
@@ -1,13 +1,67 @@
-*.log
+# OSX
+#
 .DS_Store
-node_modules
-coverage
-package-lock.json
-dist/
-packages/*/src/**/*.js
-packages/*/src/**/*.jsx
-src/**/*.js
-test/**/*.js
 
-vendor/
-Pods/
+# Xcode
+#
+build/
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+xcuserdata
+*.xccheckout
+*.moved-aside
+DerivedData
+*.hmap
+*.ipa
+*.xcuserstate
+ios/.xcode.env.local
+ios/.xcode.env
+
+# Android/IntelliJ
+#
+build/
+.idea
+.gradle
+local.properties
+*.iml
+*.hprof
+.cxx/
+*.keystore
+!debug.keystore
+
+# node.js
+#
+node_modules/
+npm-debug.log
+yarn-error.log
+
+# fastlane
+#
+# It is recommended to not store the screenshots in the git repo. Instead, use fastlane to re-generate the
+# screenshots whenever they are needed.
+# For more information about the recommended setup visit:
+# https://docs.fastlane.tools/best-practices/source-control/
+
+**/fastlane/report.xml
+**/fastlane/Preview.html
+**/fastlane/screenshots
+**/fastlane/test_output
+
+# Bundle artifact
+*.jsbundle
+
+# Ruby / CocoaPods
+/ios/Pods/
+/vendor/bundle/
+
+# Temporary files created by Metro to check the health of the file watcher
+.metro-health-check*
+
+# testing
+/coverage

--- a/packages/hyperion-react-native-testapp/HyperionCore.js
+++ b/packages/hyperion-react-native-testapp/HyperionCore.js
@@ -1,22 +1,6 @@
 /**
- * Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved.
- *
- * This file is auto generated from the Hyperion project hosted on
- * https://github.com/facebookincubator/hyperion
- * Instead of changing this file, you should:
- * - git clone https://github.com/facebookincubator/hyperion
- * - npm install
- * - npm run install-packages
- * - <make necessary modifications>
- * - npm run build
- * - npm test
- * - <copy the 'hyperion/dist/' folder>
- * - e.g. 'scp -r  ./dist/hyperion* $USER@my-od.facebook.com:www/html/js/hyperion/dist/'
- *
- * @generated <<SignedSource::d682d7395db265c610d071a8ad43845d>>
+ * @format
  */
-
-
 
 import { assert } from '../hyperion-globals';
 import globalScope from '../hyperion-globals/src/global';

--- a/packages/hyperion-react-native-testapp/HyperionCore.js
+++ b/packages/hyperion-react-native-testapp/HyperionCore.js
@@ -1,4 +1,7 @@
 /**
+ * (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+ *
+ * @flow strict
  * @format
  */
 

--- a/packages/hyperion-react-native-testapp/HyperionCore.js
+++ b/packages/hyperion-react-native-testapp/HyperionCore.js
@@ -1,0 +1,1327 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved.
+ *
+ * This file is auto generated from the Hyperion project hosted on
+ * https://github.com/facebookincubator/hyperion
+ * Instead of changing this file, you should:
+ * - git clone https://github.com/facebookincubator/hyperion
+ * - npm install
+ * - npm run install-packages
+ * - <make necessary modifications>
+ * - npm run build
+ * - npm test
+ * - <copy the 'hyperion/dist/' folder>
+ * - e.g. 'scp -r  ./dist/hyperion* $USER@my-od.facebook.com:www/html/js/hyperion/dist/'
+ *
+ * @generated <<SignedSource::d682d7395db265c610d071a8ad43845d>>
+ */
+
+
+
+import { assert } from '../hyperion-globals';
+import globalScope from '../hyperion-globals/src/global';
+import { Hook } from '../hyperion-hook';
+
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved.
+ */
+class PropertyInterceptor {
+    name;
+    status = 0 /* InterceptionStatus.Unknown */;
+    constructor(name) {
+        this.name = name;
+        __DEV__ && assert(!!this.name, "Interceptor name should have value");
+    }
+    interceptObjectOwnProperties(_obj) {
+        __DEV__ && assert(false, `This method must be overriden`);
+    }
+}
+/**
+  * Searches the object or its prototype chain for a given property name
+  * and the actual object that has the property is stores in the .container
+  * field.
+  */
+function getExtendedPropertyDescriptor(obj, propName) {
+    let desc;
+    while (obj && !desc) {
+        desc = Object.getOwnPropertyDescriptor(obj, propName);
+        if (desc) {
+            desc.container = obj;
+        }
+        obj = Object.getPrototypeOf(obj);
+    }
+    return desc;
+}
+function defineProperty(obj, propName, desc) {
+    __DEV__ && assert(!!desc, "invalid proper description");
+    try {
+        Object.defineProperty(obj, propName, desc);
+    }
+    catch (e) {
+        __DEV__ && console.warn(propName, " defining throws exception : ", e, " on ", obj);
+    }
+}
+const ObjectHasOwnProperty = Object.prototype.hasOwnProperty;
+function hasOwnProperty(obj, propName) {
+    return ObjectHasOwnProperty.call(obj, propName);
+}
+function copyOwnProperties(src, dest, copySpecials) {
+    if (!src || !dest) {
+        // Not much to copy. This can legitimately happen if for example function/attribute value is undefined during interception.
+        return;
+    }
+    __DEV__ && assert((typeof dest === "function" && typeof src === "function") || (typeof dest === "object" && typeof src === "object"), "Can only copy own properties of functions and objects");
+    const ownProps = Object.getOwnPropertyNames(src);
+    for (let i = 0, length = ownProps.length; i < length; ++i) {
+        const propName = ownProps[i];
+        if (!(propName in dest)) {
+            const desc = Object.getOwnPropertyDescriptor(src, propName); //Since we are iterating the getOwnPropertyNames, we know this must have value
+            assert(desc != null, `Unexpected situation, we should have own property for ${propName}`);
+            try {
+                Object.defineProperty(dest, propName, desc);
+            }
+            catch (e) {
+                __DEV__ && console.error("Adding property ", propName, " throws exception: ", e);
+            }
+        }
+    }
+    {
+        dest.toString = function () {
+            return src.toString();
+        };
+        if (src.hasOwnProperty('valueOf')) {
+            dest.valueOf = function () {
+                return src.valueOf();
+            };
+        }
+        dest.prototype = src.prototype;
+        const nameDesc = Object.getOwnPropertyDescriptor(src, 'name');
+        try {
+            Object.defineProperty(dest, 'name', nameDesc);
+        }
+        catch (e) {
+            __DEV__ && console.error("Adding property name threw exception: ", e);
+        }
+    }
+}
+
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved.
+ */
+const ExtensionPropName = "__ext";
+const ShadowPrototypePropName = "__sproto";
+let extensionId = 0;
+const shadowPrototypeGetters = [];
+/**
+ * @param getter function to map a given object to a shadow prototype
+ * @returns a function that can remove the getter.
+ */
+function registerShadowPrototypeGetter(getter) {
+    shadowPrototypeGetters.push(getter);
+    return (() => {
+        const index = shadowPrototypeGetters.indexOf(getter);
+        if (index > -1) {
+            shadowPrototypeGetters.splice(index, 1);
+        }
+    });
+}
+function getOwnShadowPrototypeOf(protoObj) {
+    const shadowProto = Object.getOwnPropertyDescriptor(protoObj, ShadowPrototypePropName);
+    return shadowProto?.value;
+}
+/**
+ * intercept function can look up the prototype chain to find a proper ShadowPrototype for intercepting
+ * a given object.
+ * You should be careful to call this function on non-leaf nodes of the prototype chain.
+ * This will be the last priority after the shadowPrototypeGetters is tried
+ */
+function registerShadowPrototype(protoObj, shadowPrototype) {
+    __DEV__ && assert(!protoObj[ShadowPrototypePropName], `hiding existing ShadowPrototype in the chain of prototype ${protoObj}.`, { logger: { error: msg => console.debug(msg) } });
+    Object.defineProperty(protoObj, ShadowPrototypePropName, {
+        value: shadowPrototype,
+        // configurable: true,
+    });
+    return shadowPrototype;
+}
+let cachedPropertyDescriptor = {
+/** Want all the following fields to be false, but should not specify explicitly
+ * enumerable: false,
+ * writable: false,
+ * configurable: false
+ */
+};
+function isInterceptable(value) {
+    /**
+     * Generally we want to intercept objects and functions
+     * Html tags are generally object, but some browsers use function for tags such as <object>, <embed>, ...
+     */
+    let typeofValue = typeof value;
+    return value &&
+        (typeofValue === "object" || typeofValue === "function");
+}
+export function isIntercepted(value) {
+    return hasOwnProperty(value, ExtensionPropName);
+}
+function intercept(value, shadowPrototype) {
+    if (isInterceptable(value) && !isIntercepted(value)) {
+        __DEV__ && assert(!!shadowPrototype || !value[ExtensionPropName], "Unexpected situation");
+        // TODO: check for custom interceptors
+        let shadowProto = shadowPrototype;
+        for (let i = 0; !shadowProto && i < shadowPrototypeGetters.length; ++i) {
+            shadowProto = shadowPrototypeGetters[i](value);
+        }
+        if (!shadowProto) {
+            shadowProto = value[ShadowPrototypePropName];
+        }
+        if (shadowProto) {
+            let extension = {
+                virtualPropertyValues: {},
+                shadowPrototype: shadowProto,
+                id: extensionId++,
+            };
+            cachedPropertyDescriptor.value = extension;
+            Object.defineProperty(value, ExtensionPropName, cachedPropertyDescriptor); // has to be done before interception starts
+            shadowProto.interceptObject(value);
+        }
+    }
+    return value;
+}
+function getObjectExtension(obj, interceptIfAbsent) {
+    __DEV__ && assert(isInterceptable(obj), "Only objects or functions are allowed");
+    let ext = obj[ExtensionPropName];
+    if (!ext && interceptIfAbsent) {
+        intercept(obj);
+        ext = obj[ExtensionPropName];
+    }
+    return ext;
+}
+function getVirtualPropertyValue(obj, propName) {
+    const ext = getObjectExtension(obj, true);
+    return ext?.virtualPropertyValues[propName];
+}
+function setVirtualPropertyValue(obj, propName, value) {
+    const ext = getObjectExtension(obj, true);
+    if (ext) {
+        ext.virtualPropertyValues[propName] = value;
+    }
+    else {
+        assert(!!ext, `Could not get extension for the object`);
+    }
+    return value;
+}
+
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved.
+ */
+const FuncExtensionPropName = "__ext";
+const unknownFunc = function () {
+    console.warn('Unknown or missing function called! ');
+};
+class OnBeforeCallMapper extends Hook {
+    createMultiCallbackCall(callbacks) {
+        return function (args) {
+            let result = args;
+            for (let i = 0, len = callbacks.length; i < len; ++i) {
+                result = callbacks[i].call(this, result);
+            }
+            return result;
+        };
+    }
+}
+class OnBeforeCallObserver extends Hook {
+    createMultiCallbackCall(callbacks) {
+        return function () {
+            let skipApi = false;
+            for (let i = 0, len = callbacks.length; i < len; ++i) {
+                const cb = callbacks[i];
+                /**
+                 * If any of the callbacks return true (truthy), then we should skip
+                 * calling the original function.
+                 * However, we want to ensure we call of the callbacks and hence should
+                 * avoid short circuting the loop.
+                 */
+                skipApi = cb.apply(this, arguments) || skipApi;
+            }
+            return skipApi;
+        };
+    }
+}
+class OnAfterCallMapper extends Hook {
+    createMultiCallbackCall(callbacks) {
+        return function (value) {
+            let result = value;
+            for (let i = 0, len = callbacks.length; i < len; ++i) {
+                result = callbacks[i].call(this, result);
+            }
+            return result;
+        };
+    }
+}
+class OnAfterCallObserver extends Hook {
+}
+class OnBeforeAndAfterCallMapper extends Hook {
+    createMultiCallbackCall(callbacks) {
+        return function () {
+            const onValueMappers = [];
+            for (let i = 0, len = callbacks.length; i < len; ++i) {
+                const cb = callbacks[i];
+                onValueMappers.push(cb.apply(this, arguments));
+            }
+            return (function (value) {
+                let result = value;
+                for (let i = 0, len = onValueMappers.length; i < len; ++i) {
+                    const cb = onValueMappers[i];
+                    result = cb.call(this, result);
+                }
+                return result;
+            });
+        };
+    }
+}
+class FunctionInterceptor extends PropertyInterceptor {
+    onBeforeCallMapper;
+    onBeforeCallObserver;
+    onAfterCallMapper;
+    onAfterCallObserver;
+    onBeforeAndAterCallMapper;
+    original = unknownFunc;
+    customFunc;
+    implementation; // usually either the .original or the .customFunc
+    interceptor;
+    dispatcherFunc;
+    /**
+     * The following allows the users of this class add additional information to the instances.
+     * One common usecase is checking if certain aspect is added via various callback mechanisms.
+     */
+    data;
+    constructor(name, originalFunc = unknownFunc, interceptOutput = false) {
+        super(name);
+        const that = this;
+        // In all cases we are dealing with methods, we handle constructors separately.
+        // It is too cumbersome (and perf inefficient) to separate classes for methods and constructors.
+        // TODO: is there a runtime check we can do to ensure this? e.g. checking func.prototype? Some constructors are functions too!
+        this.interceptor = !interceptOutput
+            ? function () {
+                const result = (that.dispatcherFunc).apply(this, arguments);
+                return result;
+            }
+            : function () {
+                const result = (that.dispatcherFunc).apply(this, arguments);
+                return intercept(result);
+            };
+        setFunctionInterceptor(this.interceptor, this);
+        this.implementation = originalFunc;
+        this.dispatcherFunc = this.original; // By default just pass on to original
+        this.setOriginal(originalFunc); // to perform any extra bookkeeping
+    }
+    getOriginal() {
+        return this.original;
+    }
+    setOriginal(originalFunc) {
+        if (this.original === originalFunc) {
+            return; // not much left to do
+        }
+        this.original = originalFunc;
+        if (!this.customFunc) {
+            // If no custom function is set, the implementation should point to original function
+            this.implementation = originalFunc;
+        }
+        /**
+         * We should make interceptor look as much like the original as possible.
+         * This includes {.name, .prototype, .toString(), ...}
+         * Note that copyOwnProperties will skip properties that destination already has
+         * therefore we might have to copy some properties manually
+         */
+        copyOwnProperties(originalFunc, this.interceptor);
+        setFunctionInterceptor(originalFunc, this);
+        this.updateDispatcherFunc();
+    }
+    setCustom(customFunc) {
+        // Once we have custom implementation, we chose that from that point on
+        __DEV__ && assert(!this.customFunc, `There is already a custom function assigned to ${this.name}`);
+        this.customFunc = customFunc;
+        this.implementation = customFunc;
+        this.updateDispatcherFunc();
+    }
+    static dispatcherCtors = (() => {
+        // type T = { "foo": InterceptableFunction };
+        // const ctors: { [index: number]: (fi: FunctionInterceptor<"foo", T>) => Function } = {
+        const ctors = {
+            [0 /* InterceptorState.Has_________________ */]: fi => fi.customFunc ?? fi.original,
+            [1 /* InterceptorState.Has_______________VO */]: fi => function () {
+                let result;
+                result = fi.implementation.apply(this, arguments);
+                fi.onAfterCallObserver.call.call(this, result);
+                return result;
+            },
+            [2 /* InterceptorState.Has____________VM___ */]: fi => function () {
+                let result;
+                result = fi.implementation.apply(this, arguments);
+                result = fi.onAfterCallMapper.call.call(this, result);
+                return result;
+            },
+            [3 /* InterceptorState.Has____________VM_VO */]: fi => function () {
+                let result;
+                result = fi.implementation.apply(this, arguments);
+                result = fi.onAfterCallMapper.call.call(this, result);
+                fi.onAfterCallObserver.call.call(this, result);
+                return result;
+            },
+            [4 /* InterceptorState.Has________AO_______ */]: fi => function () {
+                let result;
+                if (!fi.onBeforeCallObserver.call.apply(this, arguments)) {
+                    result = fi.implementation.apply(this, arguments);
+                }
+                return result;
+            },
+            [5 /* InterceptorState.Has________AO_____VO */]: fi => function () {
+                let result;
+                if (!fi.onBeforeCallObserver.call.apply(this, arguments)) {
+                    result = fi.implementation.apply(this, arguments);
+                    fi.onAfterCallObserver.call.call(this, result);
+                }
+                return result;
+            },
+            [6 /* InterceptorState.Has________AO__VM___ */]: fi => function () {
+                let result;
+                if (!fi.onBeforeCallObserver.call.apply(this, arguments)) {
+                    result = fi.implementation.apply(this, arguments);
+                    result = fi.onAfterCallMapper.call.call(this, result);
+                }
+                return result;
+            },
+            [7 /* InterceptorState.Has________AO__VM_VO */]: fi => function () {
+                let result;
+                if (!fi.onBeforeCallObserver.call.apply(this, arguments)) {
+                    result = fi.implementation.apply(this, arguments);
+                    result = fi.onAfterCallMapper.call.call(this, result);
+                    fi.onAfterCallObserver.call.call(this, result);
+                }
+                return result;
+            },
+            [8 /* InterceptorState.Has_____AM__________ */]: fi => function () {
+                let result;
+                const filteredArgs = fi.onBeforeCallMapper.call.call(this, arguments); //Pass as an array
+                result = fi.implementation.apply(this, filteredArgs);
+                return result;
+            },
+            [9 /* InterceptorState.Has_____AM________VO */]: fi => function () {
+                let result;
+                const filteredArgs = fi.onBeforeCallMapper.call.call(this, arguments); //Pass as an array
+                result = fi.implementation.apply(this, filteredArgs);
+                fi.onAfterCallObserver.call.call(this, result);
+                return result;
+            },
+            [10 /* InterceptorState.Has_____AM_____VM___ */]: fi => function () {
+                let result;
+                const filteredArgs = fi.onBeforeCallMapper.call.call(this, arguments); //Pass as an array
+                result = fi.implementation.apply(this, filteredArgs);
+                result = fi.onAfterCallMapper.call.call(this, result);
+                return result;
+            },
+            [11 /* InterceptorState.Has_____AM_____VM_VO */]: fi => function () {
+                let result;
+                const filteredArgs = fi.onBeforeCallMapper.call.call(this, arguments); //Pass as an array
+                result = fi.implementation.apply(this, filteredArgs);
+                result = fi.onAfterCallMapper.call.call(this, result);
+                fi.onAfterCallObserver.call.call(this, result);
+                return result;
+            },
+            [12 /* InterceptorState.Has_____AM_AO_______ */]: fi => function () {
+                let result;
+                const filteredArgs = fi.onBeforeCallMapper.call.call(this, arguments); //Pass as an array
+                if (!fi.onBeforeCallObserver.call.apply(this, filteredArgs)) {
+                    result = fi.implementation.apply(this, filteredArgs);
+                }
+                return result;
+            },
+            [13 /* InterceptorState.Has_____AM_AO_____VO */]: fi => function () {
+                let result;
+                const filteredArgs = fi.onBeforeCallMapper.call.call(this, arguments); //Pass as an array
+                if (!fi.onBeforeCallObserver.call.apply(this, filteredArgs)) {
+                    result = fi.implementation.apply(this, filteredArgs);
+                    fi.onAfterCallObserver.call.call(this, result);
+                }
+                return result;
+            },
+            [14 /* InterceptorState.Has_____AM_AO__VM___ */]: fi => function () {
+                let result;
+                const filteredArgs = fi.onBeforeCallMapper.call.call(this, arguments); //Pass as an array
+                if (!fi.onBeforeCallObserver.call.apply(this, filteredArgs)) {
+                    result = fi.implementation.apply(this, filteredArgs);
+                    result = fi.onAfterCallMapper.call.call(this, result);
+                }
+                return result;
+            },
+            [15 /* InterceptorState.Has_____AM_AO__VM_VO */]: fi => function () {
+                let result;
+                const filteredArgs = fi.onBeforeCallMapper.call.call(this, arguments); //Pass as an array
+                if (!fi.onBeforeCallObserver.call.apply(this, filteredArgs)) {
+                    result = fi.implementation.apply(this, filteredArgs);
+                    result = fi.onAfterCallMapper.call.call(this, result);
+                    fi.onAfterCallObserver.call.call(this, result);
+                }
+                return result;
+            },
+            [16 /* InterceptorState.Has_AVM______________ */]: fi => function () {
+                let result;
+                const onValueMapper = fi.onBeforeAndAterCallMapper.call.call(this, arguments);
+                result = fi.implementation.apply(this, arguments);
+                result = onValueMapper.call(this, result);
+                return result;
+            },
+            [17 /* InterceptorState.Has_AVM____________VO */]: fi => function () {
+                let result;
+                const onValueMapper = fi.onBeforeAndAterCallMapper.call.call(this, arguments);
+                result = fi.implementation.apply(this, arguments);
+                fi.onAfterCallObserver.call.call(this, result);
+                result = onValueMapper.call(this, result);
+                return result;
+            },
+            [18 /* InterceptorState.Has_AVM_________VM___ */]: fi => function () {
+                let result;
+                const onValueMapper = fi.onBeforeAndAterCallMapper.call.call(this, arguments);
+                result = fi.implementation.apply(this, arguments);
+                result = fi.onAfterCallMapper.call.call(this, result);
+                result = onValueMapper.call(this, result);
+                return result;
+            },
+            [19 /* InterceptorState.Has_AVM_________VM_VO */]: fi => function () {
+                let result;
+                const onValueMapper = fi.onBeforeAndAterCallMapper.call.call(this, arguments);
+                result = fi.implementation.apply(this, arguments);
+                result = fi.onAfterCallMapper.call.call(this, result);
+                fi.onAfterCallObserver.call.call(this, result);
+                result = onValueMapper.call(this, result);
+                return result;
+            },
+            [20 /* InterceptorState.Has_AVM_____AO_______ */]: fi => function () {
+                let result;
+                if (!fi.onBeforeCallObserver.call.apply(this, arguments)) {
+                    const onValueMapper = fi.onBeforeAndAterCallMapper.call.call(this, arguments);
+                    result = fi.implementation.apply(this, arguments);
+                    result = onValueMapper.call(this, result);
+                }
+                return result;
+            },
+            [21 /* InterceptorState.Has_AVM_____AO_____VO */]: fi => function () {
+                let result;
+                if (!fi.onBeforeCallObserver.call.apply(this, arguments)) {
+                    const onValueMapper = fi.onBeforeAndAterCallMapper.call.call(this, arguments);
+                    result = fi.implementation.apply(this, arguments);
+                    fi.onAfterCallObserver.call.call(this, result);
+                    result = onValueMapper.call(this, result);
+                }
+                return result;
+            },
+            [22 /* InterceptorState.Has_AVM_____AO__VM___ */]: fi => function () {
+                let result;
+                if (!fi.onBeforeCallObserver.call.apply(this, arguments)) {
+                    const onValueMapper = fi.onBeforeAndAterCallMapper.call.call(this, arguments);
+                    result = fi.implementation.apply(this, arguments);
+                    result = fi.onAfterCallMapper.call.call(this, result);
+                    result = onValueMapper.call(this, result);
+                }
+                return result;
+            },
+            [23 /* InterceptorState.Has_AVM_____AO__VM_VO */]: fi => function () {
+                let result;
+                if (!fi.onBeforeCallObserver.call.apply(this, arguments)) {
+                    const onValueMapper = fi.onBeforeAndAterCallMapper.call.call(this, arguments);
+                    result = fi.implementation.apply(this, arguments);
+                    result = fi.onAfterCallMapper.call.call(this, result);
+                    fi.onAfterCallObserver.call.call(this, result);
+                    result = onValueMapper.call(this, result);
+                }
+                return result;
+            },
+            [24 /* InterceptorState.Has_AVM__AM__________ */]: fi => function () {
+                let result;
+                const filteredArgs = fi.onBeforeCallMapper.call.call(this, arguments); //Pass as an array
+                const onValueMapper = fi.onBeforeAndAterCallMapper.call.call(this, arguments);
+                result = fi.implementation.apply(this, filteredArgs);
+                result = onValueMapper.call(this, result);
+                return result;
+            },
+            [25 /* InterceptorState.Has_AVM__AM________VO */]: fi => function () {
+                let result;
+                const filteredArgs = fi.onBeforeCallMapper.call.call(this, arguments); //Pass as an array
+                const onValueMapper = fi.onBeforeAndAterCallMapper.call.call(this, arguments);
+                result = fi.implementation.apply(this, filteredArgs);
+                fi.onAfterCallObserver.call.call(this, result);
+                result = onValueMapper.call(this, result);
+                return result;
+            },
+            [26 /* InterceptorState.Has_AVM__AM_____VM___ */]: fi => function () {
+                let result;
+                const filteredArgs = fi.onBeforeCallMapper.call.call(this, arguments); //Pass as an array
+                const onValueMapper = fi.onBeforeAndAterCallMapper.call.call(this, arguments);
+                result = fi.implementation.apply(this, filteredArgs);
+                result = fi.onAfterCallMapper.call.call(this, result);
+                result = onValueMapper.call(this, result);
+                return result;
+            },
+            [27 /* InterceptorState.Has_AVM__AM_____VM_VO */]: fi => function () {
+                let result;
+                const filteredArgs = fi.onBeforeCallMapper.call.call(this, arguments); //Pass as an array
+                const onValueMapper = fi.onBeforeAndAterCallMapper.call.call(this, arguments);
+                result = fi.implementation.apply(this, filteredArgs);
+                result = fi.onAfterCallMapper.call.call(this, result);
+                fi.onAfterCallObserver.call.call(this, result);
+                result = onValueMapper.call(this, result);
+                return result;
+            },
+            [28 /* InterceptorState.Has_AVM__AM_AO_______ */]: fi => function () {
+                let result;
+                const filteredArgs = fi.onBeforeCallMapper.call.call(this, arguments); //Pass as an array
+                if (!fi.onBeforeCallObserver.call.apply(this, filteredArgs)) {
+                    const onValueMapper = fi.onBeforeAndAterCallMapper.call.call(this, arguments);
+                    result = fi.implementation.apply(this, filteredArgs);
+                    result = onValueMapper.call(this, result);
+                }
+                return result;
+            },
+            [29 /* InterceptorState.Has_AVM__AM_AO_____VO */]: fi => function () {
+                let result;
+                const filteredArgs = fi.onBeforeCallMapper.call.call(this, arguments); //Pass as an array
+                if (!fi.onBeforeCallObserver.call.apply(this, filteredArgs)) {
+                    const onValueMapper = fi.onBeforeAndAterCallMapper.call.call(this, arguments);
+                    result = fi.implementation.apply(this, filteredArgs);
+                    fi.onAfterCallObserver.call.call(this, result);
+                    result = onValueMapper.call(this, result);
+                }
+                return result;
+            },
+            [30 /* InterceptorState.Has_AVM__AM_AO__VM___ */]: fi => function () {
+                let result;
+                const filteredArgs = fi.onBeforeCallMapper.call.call(this, arguments); //Pass as an array
+                if (!fi.onBeforeCallObserver.call.apply(this, filteredArgs)) {
+                    const onValueMapper = fi.onBeforeAndAterCallMapper.call.call(this, arguments);
+                    result = fi.implementation.apply(this, filteredArgs);
+                    result = fi.onAfterCallMapper.call.call(this, result);
+                    result = onValueMapper.call(this, result);
+                }
+                return result;
+            },
+            [31 /* InterceptorState.Has_AVM__AM_AO__VM_VO */]: fi => function () {
+                let result;
+                const filteredArgs = fi.onBeforeCallMapper.call.call(this, arguments); //Pass as an array
+                if (!fi.onBeforeCallObserver.call.apply(this, filteredArgs)) {
+                    const onValueMapper = fi.onBeforeAndAterCallMapper.call.call(this, arguments);
+                    result = fi.implementation.apply(this, filteredArgs);
+                    result = fi.onAfterCallMapper.call.call(this, result);
+                    fi.onAfterCallObserver.call.call(this, result);
+                    result = onValueMapper.call(this, result);
+                }
+                return result;
+            },
+        };
+        if (__DEV__) {
+            // just to make sure we caovered all cases correctly
+            for (let i = 8 /* InterceptorState.HasArgsMapper */ | 4 /* InterceptorState.HasArgsObserver */ | 2 /* InterceptorState.HasValueMapper */ | 1 /* InterceptorState.HasValueObserver */ | 16 /* InterceptorState.HasArgsAndValueMapper */; i >= 0; --i) {
+                const ctor = ctors[i];
+                assert(!!ctor, `unhandled interceptor state ${i}`);
+                ctors[i] = fi => {
+                    assert((i & 8 /* InterceptorState.HasArgsMapper */) === 0 || !!fi.onBeforeCallMapper, `missing expected .onArgsFilter for state ${i}`);
+                    assert((i & 4 /* InterceptorState.HasArgsObserver */) === 0 || !!fi.onBeforeCallObserver, `missing expected .onArgsObserver for state ${i}`);
+                    assert((i & 2 /* InterceptorState.HasValueMapper */) === 0 || !!fi.onAfterCallMapper, `missing expected .onValueFilter for state ${i}`);
+                    assert((i & 1 /* InterceptorState.HasValueObserver */) === 0 || !!fi.onAfterCallObserver, `missing expected .onValueObserver for state ${i}`);
+                    assert((i & 16 /* InterceptorState.HasArgsAndValueMapper */) === 0 || !!fi.onBeforeAndAterCallMapper, `missing expected .onArgsAndValueMapper for state ${i}`);
+                    return ctor(fi);
+                };
+            }
+        }
+        return ctors;
+    })();
+    updateDispatcherFunc() {
+        let state = 0;
+        state |= this.onBeforeCallMapper ? 8 /* InterceptorState.HasArgsMapper */ : 0;
+        state |= this.onBeforeCallObserver ? 4 /* InterceptorState.HasArgsObserver */ : 0;
+        state |= this.onAfterCallMapper ? 2 /* InterceptorState.HasValueMapper */ : 0;
+        state |= this.onAfterCallObserver ? 1 /* InterceptorState.HasValueObserver */ : 0;
+        state |= this.onBeforeAndAterCallMapper ? 16 /* InterceptorState.HasArgsAndValueMapper */ : 0;
+        //TODO: Check a cached version first
+        const dispatcherCtor = FunctionInterceptor.dispatcherCtors[state];
+        assert(!!dispatcherCtor, `unhandled interceptor state ${state}`);
+        this.dispatcherFunc = dispatcherCtor(this);
+    }
+    //#region helper function to lazily extend hooks
+    onBeforeCallMapperAdd(cb) {
+        if (!this.onBeforeCallMapper) {
+            this.onBeforeCallMapper = new OnBeforeCallMapper();
+            this.updateDispatcherFunc();
+        }
+        return this.onBeforeCallMapper.add(cb);
+    }
+    onBeforeCallMapperRemove(cb) {
+        if (this.onBeforeCallMapper?.remove(cb)) {
+            // Since we rely on the output of the callback, we should avoid empty list
+            if (!this.onBeforeCallMapper.hasCallback()) {
+                this.onBeforeCallMapper = null;
+            }
+            this.updateDispatcherFunc();
+        }
+        return cb;
+    }
+    onBeforeCallObserverAdd(cb) {
+        if (!this.onBeforeCallObserver) {
+            this.onBeforeCallObserver = new OnBeforeCallObserver();
+            this.updateDispatcherFunc();
+        }
+        return this.onBeforeCallObserver.add(cb);
+    }
+    onBeforeCallObserverRemove(cb) {
+        if (this.onBeforeCallObserver?.remove(cb)) {
+            // Since we rely on the output of the callback, we should avoid empty list
+            if (!this.onBeforeCallObserver.hasCallback()) {
+                this.onBeforeCallObserver = null;
+            }
+            this.updateDispatcherFunc();
+        }
+        return cb;
+    }
+    onAfterCallMapperAdd(cb) {
+        if (!this.onAfterCallMapper) {
+            this.onAfterCallMapper = new OnAfterCallMapper();
+            this.updateDispatcherFunc();
+        }
+        return this.onAfterCallMapper.add(cb);
+    }
+    onAfterCallMapperRemove(cb) {
+        if (this.onAfterCallMapper?.remove(cb)) {
+            // Since we rely on the output of the callback, we should avoid empty list
+            if (!this.onAfterCallMapper.hasCallback()) {
+                this.onAfterCallMapper = null;
+            }
+            this.updateDispatcherFunc();
+        }
+        return cb;
+    }
+    onAfterCallObserverAdd(cb) {
+        if (!this.onAfterCallObserver) {
+            this.onAfterCallObserver = new OnAfterCallObserver();
+            this.updateDispatcherFunc();
+        }
+        return this.onAfterCallObserver.add(cb);
+    }
+    onAfterCallObserverRemove(cb) {
+        if (this.onAfterCallObserver?.remove(cb)) {
+            this.updateDispatcherFunc();
+        }
+        return cb;
+    }
+    onBeforeAndAfterCallMapperAdd(cb) {
+        if (!this.onBeforeAndAterCallMapper) {
+            this.onBeforeAndAterCallMapper = new OnBeforeAndAfterCallMapper();
+            this.updateDispatcherFunc();
+        }
+        return this.onBeforeAndAterCallMapper.add(cb);
+    }
+    onBeforeAndAfterCallMapperRemove(cb) {
+        if (this.onBeforeAndAterCallMapper?.remove(cb)) {
+            // Since we rely on the output of the callback, we should avoid empty list
+            if (!this.onBeforeAndAterCallMapper.hasCallback()) {
+                this.onBeforeAndAterCallMapper = null;
+            }
+            this.updateDispatcherFunc();
+        }
+        return cb;
+    }
+    //#endregion
+    getData(dataPropName) {
+        return this.data?.[dataPropName];
+    }
+    setData(dataPropName, value) {
+        if (!this.data) {
+            this.data = {};
+        }
+        this.data[dataPropName] = value;
+    }
+    testAndSet(dataPropName) {
+        const currValue = this.getData(dataPropName) || false;
+        if (!currValue) {
+            this.setData(dataPropName, true);
+        }
+        return currValue;
+    }
+}
+// & { [index: string]: any };
+function getFunctionInterceptor(func) {
+    return func?.[FuncExtensionPropName];
+}
+function setFunctionInterceptor(func, funcInterceptor) {
+    __DEV__ && assert(typeof func === "function" &&
+        !getFunctionInterceptor(func), `Function already has an interceptor assigned to it`, { logger: { error() { debugger; } } });
+    func[FuncExtensionPropName] = funcInterceptor;
+}
+function interceptFunction(func, interceptOutput = false, fiCtor, name = `_annonymous`) {
+    assert(typeof func === "function", `cannot intercept non-function input`);
+    let funcInterceptor = getFunctionInterceptor(func);
+    if (!funcInterceptor) {
+        funcInterceptor = fiCtor
+            ? new fiCtor(name, func, interceptOutput)
+            : new FunctionInterceptor(name, func, interceptOutput);
+    }
+    return funcInterceptor;
+}
+
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved.
+ */
+class MethodInterceptor extends FunctionInterceptor {
+    constructor(name, shadowPrototype, interceptOutput = false, desc) {
+        super(name, void 0, interceptOutput);
+        this.interceptProperty(shadowPrototype.targetPrototype, false, desc);
+        if (this.status !== 1 /* InterceptionStatus.Intercepted */) {
+            shadowPrototype.addPendingPropertyInterceptor(this);
+        }
+    }
+    interceptProperty(obj, isOwnProperty, desc) {
+        desc = desc ?? getExtendedPropertyDescriptor(obj, this.name);
+        if (isOwnProperty) {
+            let virtualProperty; // TODO: we should do this on the object itself
+            if (desc) {
+                if (desc.writable && (desc.value || desc.hasOwnProperty("value"))) { // it has value and can change
+                    virtualProperty = desc.value;
+                    delete desc.value;
+                    delete desc.writable;
+                    desc.get = function () { return virtualProperty; };
+                    desc.set = function (value) { virtualProperty = value; };
+                    desc.configurable = true;
+                }
+            }
+            else {
+                desc = {
+                    get: function () { return virtualProperty; },
+                    set: function (value) { virtualProperty = value; },
+                    enumerable: true,
+                    configurable: true,
+                    container: obj
+                };
+            }
+        }
+        if (desc) {
+            if (desc.value) {
+                this.setOriginal(desc.value);
+                desc.value = this.interceptor;
+                defineProperty(desc.container, this.name, desc);
+                this.status = 1 /* InterceptionStatus.Intercepted */;
+            }
+            else if (desc.get || desc.set) {
+                const that = this;
+                const { get, set } = desc;
+                if (get) {
+                    desc.get = function () {
+                        const originalFunc = get.call(this);
+                        if (typeof originalFunc !== "function") {
+                            return originalFunc; // getter didn't return a func, should maintain that!
+                        }
+                        if (originalFunc !== that.interceptor) {
+                            that.setOriginal(originalFunc);
+                        }
+                        return that.interceptor;
+                    };
+                    setFunctionInterceptor(desc.get, that);
+                }
+                if (set) {
+                    desc.set = function (value) {
+                        // set.call(this, value);
+                        set.call(this, that.interceptor);
+                        if (value !== that.interceptor && value !== that.original) {
+                            that.setOriginal(value);
+                        }
+                        return that.interceptor;
+                    };
+                    setFunctionInterceptor(desc.set, that);
+                }
+                defineProperty(desc.container, this.name, desc);
+                this.status = desc.configurable ? 1 /* InterceptionStatus.Intercepted */ : 4 /* InterceptionStatus.NotConfigurable */;
+            }
+            else if (desc.hasOwnProperty("value")) {
+                /**
+                 * There was a .value = null on the prototype chain. We can assume this value will not change and just
+                 * ignore it.
+                 * We could also treat this just like the (isOwnProperty && desc.hasOwnProperty('value')) above, but
+                 * that does not seem to provide any value.
+                 * Also, since this is supposed to be a function, we would not expect other falsy values here (i.e. "", 0, ...)
+                 * Only null would be fine
+                 *  */
+                __DEV__ && assert(desc.value === null, `unexpected situation! PropertyDescriptor.value must be function or null!`);
+                this.status = 1 /* InterceptionStatus.Intercepted */;
+            }
+            else {
+                __DEV__ && assert(false, `unexpected situation! PropertyDescriptor does not have value or get/set!`);
+            }
+        }
+        else {
+            this.status = 2 /* InterceptionStatus.NotFound */;
+        }
+    }
+    interceptObjectOwnProperties(obj) {
+        this.interceptProperty(obj, true);
+    }
+}
+function getMethodInterceptor(name, shadowPrototype) {
+    const desc = getExtendedPropertyDescriptor(shadowPrototype.targetPrototype, name);
+    let fi;
+    if (desc) {
+        fi = getFunctionInterceptor(desc.value);
+        if (!fi) {
+            /**
+             * let's try getter/setter as well.
+             * we know this is special case (see above) and interceptor is really about the actual func, not its getter/setters
+             * so, we need to supress the type of getter/setter
+             */
+            const getFI = getFunctionInterceptor(desc.get);
+            const setFI = getFunctionInterceptor(desc.set);
+            assert(!(getFI && setFI) || (getFI === setFI), `Getter/Setter of method ${name} have differnt interceptors`);
+            fi = getFI ?? setFI;
+        }
+        desc.interceptor = fi;
+    }
+    return desc;
+}
+function interceptMethod(name, shadowPrototype, interceptOutput = false, miCtor) {
+    const desc = getMethodInterceptor(name, shadowPrototype);
+    return desc?.interceptor ?? new (miCtor ?? MethodInterceptor)(name, shadowPrototype, interceptOutput, desc);
+}
+
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved.
+ */
+function createCtorInterceptor(ctorFunc) {
+    const ctorInterceptor = function () {
+        // let result = new ctorFunc(...arguments);
+        // return result;
+        // NOTE: if we see some browsers may not support ...argument, we should then try the following
+        let result;
+        switch (arguments.length) {
+            case 0:
+                result = new ctorFunc();
+                break;
+            case 1:
+                result = new ctorFunc(arguments[0]);
+                break;
+            case 2:
+                result = new ctorFunc(arguments[0], arguments[1]);
+                break;
+            case 3:
+                result = new ctorFunc(arguments[0], arguments[1], arguments[2]);
+                break;
+            case 4:
+                result = new ctorFunc(arguments[0], arguments[1], arguments[2], arguments[3]);
+                break;
+            case 5:
+                result = new ctorFunc(arguments[0], arguments[1], arguments[2], arguments[3], arguments[4]);
+                break;
+            case 6:
+                result = new ctorFunc(arguments[0], arguments[1], arguments[2], arguments[3], arguments[4], arguments[5]);
+                break;
+            default: throw "Unsupported case!";
+        }
+        return result;
+    };
+    copyOwnProperties(ctorFunc, ctorInterceptor);
+    return ctorInterceptor;
+}
+class ConstructorInterceptor extends FunctionInterceptor {
+    ctorInterceptor = null;
+    constructor(name, originalCtor) {
+        super(name, originalCtor, true); //If we intercept constructor, that means we want the output to be intercepted
+    }
+    setOriginal(originalFunc) {
+        this.ctorInterceptor = createCtorInterceptor(originalFunc);
+        return super.setOriginal(this.ctorInterceptor);
+    }
+}
+function interceptConstructor(ctor, name = `_annonymousCtor`) {
+    return interceptFunction(ctor, true, ConstructorInterceptor, name);
+}
+class ConstructorMethodInterceptor extends MethodInterceptor {
+    ctorInterceptor = null;
+    constructor(name, shadowPrototype, desc) {
+        super(name, shadowPrototype, true, desc); //If we intercept constructor, that means we want the output to be intercepted
+    }
+    setOriginal(originalFunc) {
+        this.ctorInterceptor = createCtorInterceptor(originalFunc);
+        return super.setOriginal(this.ctorInterceptor);
+    }
+}
+function interceptConstructorMethod(name, shadowPrototype) {
+    const desc = getMethodInterceptor(name, shadowPrototype);
+    return desc?.interceptor ?? new ConstructorMethodInterceptor(name, shadowPrototype, desc);
+}
+
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved.
+ */
+function getVirtualPropertyName(name, extension) {
+    return extension?.useCaseInsensitivePropertyName ? ('' + name).toLocaleLowerCase() : name;
+}
+class ShadowPrototype {
+    targetPrototype;
+    parentShadowPrototype;
+    extension;
+    onBeforInterceptObj = new Hook();
+    onAfterInterceptObj = new Hook();
+    pendingPropertyInterceptors;
+    constructor(targetPrototype, parentShadowPrototype) {
+        this.targetPrototype = targetPrototype;
+        this.parentShadowPrototype = parentShadowPrototype;
+        /**
+         * TODO: if we could say <ObjectType extends ParentType> then may be we could avoid the casts
+         * in the following methods
+         */
+        this.extension = Object.create(parentShadowPrototype?.extension ?? null);
+        if ( /* __DEV__ && */this.parentShadowPrototype) {
+            let obj = this.targetPrototype;
+            let proto = this.parentShadowPrototype.targetPrototype;
+            let matched = false;
+            while (obj && !matched) {
+                matched = obj === proto;
+                obj = Object.getPrototypeOf(obj);
+            }
+            assert(matched, `Invalid prototype chain`);
+        }
+    }
+    callOnBeforeInterceptObject(obj) {
+        this.parentShadowPrototype?.callOnBeforeInterceptObject(obj);
+        this.onBeforInterceptObj?.call(obj);
+    }
+    callOnAfterInterceptObject(obj) {
+        this.parentShadowPrototype?.callOnAfterInterceptObject(obj);
+        this.onAfterInterceptObj?.call(obj);
+    }
+    interceptObjectItself(obj) {
+        this.parentShadowPrototype?.interceptObjectItself(obj);
+        // We can make any necessary modificatio to the object itself here
+        if (this.pendingPropertyInterceptors) {
+            for (const pi of this.pendingPropertyInterceptors) {
+                pi.interceptObjectOwnProperties(obj);
+            }
+        }
+    }
+    interceptObject(obj) {
+        // This behaves similar to how constructors work, i.e. from parent class to child class
+        this.callOnBeforeInterceptObject(obj);
+        this.interceptObjectItself(obj);
+        this.callOnAfterInterceptObject(obj);
+    }
+    addPendingPropertyInterceptor(pi) {
+        if (!this.pendingPropertyInterceptors) {
+            this.pendingPropertyInterceptors = [];
+        }
+        this.pendingPropertyInterceptors.push(pi);
+    }
+    getVirtualProperty(name) {
+        const vtable = this.extension;
+        const canonicalName = getVirtualPropertyName(name, vtable);
+        return vtable[canonicalName];
+    }
+    setVirtualProperty(name, virtualProp) {
+        const vtable = this.extension;
+        const canonicalName = getVirtualPropertyName(name, vtable);
+        if (__DEV__) {
+            assert(!hasOwnProperty(vtable, canonicalName), `Vritual property ${name} already exists`);
+            assert(!vtable[canonicalName], `virtual property ${name} will override the parent's.`, { logger: { error(msg) { console.warn(msg); } } });
+        }
+        vtable[canonicalName] = virtualProp;
+        return virtualProp;
+    }
+    removeVirtualPropery(name, virtualProp) {
+        const vtable = this.extension;
+        const canonicalName = getVirtualPropertyName(name, vtable);
+        if (__DEV__) {
+            assert(hasOwnProperty(vtable, canonicalName), `Vritual property ${name} does not exists`);
+        }
+        if (vtable[canonicalName] === virtualProp) {
+            delete vtable[canonicalName];
+        }
+        else {
+            console.error(`Vritual property ${name} does not match and was not deleted`);
+        }
+    }
+}
+
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved.
+ */
+class ModuleRuntimeBase {
+    getExports(_moduleId) {
+        return null;
+    }
+    updateExports(_moduleId, _moduleExports, _moduleExportsInterceptors, _failedExportsKeys) {
+    }
+}
+class WebpackModuleRuntime extends ModuleRuntimeBase {
+    _cache;
+    constructor(_cache) {
+        super();
+        this._cache = _cache;
+    }
+    getExports(moduleId) {
+        const modulePath = new RegExp(`${moduleId}(?:/index)?[.]js$`);
+        const wexports = Object.keys(this._cache).filter(m => modulePath.test(m)).map(m => this._cache[m]);
+        return wexports[0].exports;
+    }
+}
+class MetaModuleRuntime extends ModuleRuntimeBase {
+    _cache;
+    constructor(_cache) {
+        super();
+        this._cache = _cache;
+    }
+    updateExports(moduleId, moduleExports, moduleExportsInterceptors, _failedExportsKeys) {
+        /**
+      * Currently, the module system in Meta uses a different mechanism to import
+      * normal vs. default modules. In order to make sure default exports are also
+      * handled properly, we use the following back channel to grap the module data
+      * and update the values.
+      * See the details in https://www.internalfb.com/code/www/[diffs]/html/shared_core/polyfill/fbmodule-runtime.js?lines=373-378
+      */
+        if (moduleExportsInterceptors.default != null) {
+            this._cache.modulesMap[moduleId].defaultExport = moduleExports.default;
+        }
+    }
+}
+const ModuleRuntime = (() => {
+    if (typeof __webpack_module_cache__ === 'object') {
+        // In webpack world
+        return new WebpackModuleRuntime(__webpack_module_cache__);
+    }
+    else if (typeof require === "function") {
+        try {
+            const __debug = require("__debug");
+            if (typeof __debug === "object") {
+                // In Meta custom runtime world
+                return new MetaModuleRuntime(__debug);
+            }
+        }
+        catch (e) { }
+    }
+    return new ModuleRuntimeBase();
+})();
+function interceptModuleExports(moduleId, moduleExports, moduleExportsKeys, failedExportsKeys) {
+    let interceptableModuleExports = moduleExports;
+    const alternativeExports = ModuleRuntime.getExports(moduleId);
+    if (alternativeExports && alternativeExports !== interceptableModuleExports) {
+        console.warn('different exports objects ', moduleId);
+        interceptableModuleExports = alternativeExports;
+    }
+    const ModuleExportsShadow = new ShadowPrototype(interceptableModuleExports, null);
+    const IModule = {};
+    for (let i = 0; i < moduleExportsKeys.length; ++i) {
+        const key = moduleExportsKeys[i];
+        IModule[key] = interceptMethod(key, ModuleExportsShadow);
+    }
+    ModuleRuntime.updateExports(moduleId, moduleExports, IModule, failedExportsKeys);
+    validateModuleInterceptor(moduleId, moduleExports, IModule, failedExportsKeys);
+    return IModule;
+}
+function validateModuleInterceptor(moduleId, moduleExports, moduleExportsInterceptors, failedExportsKeys) {
+    if (Array.isArray(failedExportsKeys)) {
+        const moduleExportsKeys = Object.keys(moduleExportsInterceptors);
+        for (let i = 0; i < moduleExportsKeys.length; ++i) {
+            const key = moduleExportsKeys[i];
+            if (moduleExports[key] !== moduleExportsInterceptors[key].interceptor) {
+                failedExportsKeys.push(key);
+            }
+        }
+        assert(failedExportsKeys.length === 0, failedExportsKeys.map(key => `could not intercept ${moduleId}.${key}`).join("\n"));
+    }
+}
+
+const IRequire = /*#__PURE__*/Object.freeze({
+  __proto__: null,
+  interceptModuleExports,
+  validateModuleInterceptor
+});
+
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved.
+ */
+/**
+ * Usually in test environment, this module may be initialized multiple times.
+ * But since it updates the global primodials, we should be careful to not redo
+ * all the interception again. Specially since interceptMethod will pickup the
+ * right (original) set of interceptors, we don't want to have a different ShadowPrototype
+ *
+ * Also, in hyperion-dom, we do have interception of Window which is the globalThis of the browsers
+ * That module will need to set the parent of the shadow prototype and register a few more information
+ * To ensure that no one is really using the internal hooks of the ShadowPrototype for tracking object interception
+ * the following IGlobalThisPrototype is kept local to this module and not exported. As of now all usecases of the
+ * hyperion is in browser, if/when we support nodejs, there should be a similar mechanism for handling that environments
+ * globalThis.
+ * For this particular case, we are ok if the ShadowPrototype is not used.
+ */
+const IGlobalThisPrototype = getOwnShadowPrototypeOf(globalScope) ?? new ShadowPrototype(globalScope, null);
+const setInterval = interceptMethod("setInterval", IGlobalThisPrototype);
+const setTimeout = interceptMethod("setTimeout", IGlobalThisPrototype);
+const IPromiseConstructor = interceptConstructorMethod("Promise", IGlobalThisPrototype);
+
+const IGlobalThis = /*#__PURE__*/Object.freeze({
+  __proto__: null,
+  IPromiseConstructor,
+  setInterval,
+  setTimeout
+});
+
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved.
+ */
+const PromisePrototype = Object.getPrototypeOf(Promise.resolve());
+/**
+ * Usually in test environment, this module may be initialized multiple times.
+ * But since it updates the global primodials, we should be careful to not redo
+ * all the interception again. Specially since interceptMethod will pickup the
+ * right (original) set of interceptors, we don't want to have a different ShadowPrototype
+ */
+const IPromisePrototype = getOwnShadowPrototypeOf(PromisePrototype) ?? registerShadowPrototype(PromisePrototype, new ShadowPrototype(PromisePrototype, null));
+const constructor = IPromiseConstructor;
+const then = interceptMethod("then", IPromisePrototype);
+const Catch = interceptMethod("catch", IPromisePrototype);
+const Finally = interceptMethod("finally", IPromisePrototype);
+// The container for static methods
+const IPromise = getOwnShadowPrototypeOf(Promise) ?? registerShadowPrototype(Promise, new ShadowPrototype(Promise, null));
+const all = interceptMethod("all", IPromise);
+const allSettled = interceptMethod("allSettled", IPromise);
+const any = interceptMethod("any", IPromise);
+const race = interceptMethod("race", IPromise);
+const reject = interceptMethod("reject", IPromise);
+const resolve = interceptMethod("resolve", IPromise);
+
+const IPromise$1 = /*#__PURE__*/Object.freeze({
+  __proto__: null,
+  Catch,
+  Finally,
+  IPromisePrototype,
+  all,
+  allSettled,
+  any,
+  constructor,
+  race,
+  reject,
+  resolve,
+  then
+});
+
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved.
+ */
+const ATTRIBUTE_INTERCEPTOR_PROP_NAME = "__attributeInterceptor";
+class AttributeInterceptorBase extends PropertyInterceptor {
+    getter;
+    setter;
+    constructor(name, getter, setter) {
+        super(name);
+        this.getter = new FunctionInterceptor(name, getter);
+        this.setter = new FunctionInterceptor(name, setter);
+        this.getter.setData(ATTRIBUTE_INTERCEPTOR_PROP_NAME, this);
+        this.setter.setData(ATTRIBUTE_INTERCEPTOR_PROP_NAME, this);
+    }
+}
+class AttributeInterceptor extends AttributeInterceptorBase {
+    constructor(name, shadowPrototype, desc) {
+        super(name);
+        this.interceptProperty(shadowPrototype.targetPrototype, false, desc);
+        if (this.status !== 1 /* InterceptionStatus.Intercepted */) {
+            shadowPrototype.addPendingPropertyInterceptor(this);
+        }
+    }
+    interceptProperty(obj, isOwnProperty, desc) {
+        desc = desc ?? getExtendedPropertyDescriptor(obj, this.name);
+        if (isOwnProperty) {
+            let virtualProperty; // TODO: we should do this on the object itself
+            const get = function () {
+                return virtualProperty;
+            };
+            const set = function (value) {
+                virtualProperty = value;
+            };
+            if (desc) {
+                if (desc.value && desc.writable) { // it has value and can change
+                    virtualProperty = desc.value;
+                    delete desc.value;
+                    delete desc.writable;
+                    desc.get = get;
+                    desc.set = set;
+                    desc.configurable = true;
+                }
+            }
+            else {
+                desc = {
+                    get,
+                    set,
+                    enumerable: true,
+                    configurable: true,
+                    container: obj
+                };
+            }
+        }
+        if (desc) {
+            if (desc.get || desc.set) {
+                const { get, set } = desc;
+                if (get) {
+                    this.getter.setOriginal(get);
+                    desc.get = this.getter.interceptor;
+                }
+                if (set) {
+                    this.setter.setOriginal(set);
+                    desc.set = this.setter.interceptor;
+                }
+                __DEV__ && assert(desc.configurable, `Cannot intercept attribute ${this.name}`);
+                defineProperty(desc.container, this.name, desc);
+                if (__DEV__) {
+                    const desc = getExtendedPropertyDescriptor(obj, this.name);
+                    assert(desc?.get === this.getter.interceptor, `getter interceptor did not work`);
+                    assert(desc?.set === this.setter.interceptor, `setter interceptor did not work`);
+                }
+                this.status = desc.configurable ? 1 /* InterceptionStatus.Intercepted */ : 4 /* InterceptionStatus.NotConfigurable */;
+            }
+            else if (desc.value) {
+                //TODO: we should replace this one with get/set
+                console.warn(`Property ${this.name} does not seem to be an attribute`);
+                this.status = 3 /* InterceptionStatus.NoGetterSetter */;
+            }
+            else {
+                if (__DEV__) {
+                    if (hasOwnProperty(desc, "get") || hasOwnProperty(desc, "set")) {
+                        console.warn(`Un expected situation, attribute ${this.name} does not have getter/setter defined`);
+                    }
+                }
+            }
+        }
+        else {
+            this.status = 2 /* InterceptionStatus.NotFound */;
+        }
+    }
+    interceptObjectOwnProperties(obj) {
+        return this.interceptProperty(obj, true);
+    }
+}
+function getAttributeInterceptor(name, shadowPrototype) {
+    const desc = getExtendedPropertyDescriptor(shadowPrototype.targetPrototype, name);
+    if (desc) {
+        /**
+         * let's try getter/setter as well.
+         * we know this is special case (see above) and interceptor is really about the actual func, not its getter/setters
+         * so, we need to supress the type of getter/setter
+         */
+        const getFI = getFunctionInterceptor(desc.get);
+        const setFI = getFunctionInterceptor(desc.set);
+        const getAI = getFI?.getData(ATTRIBUTE_INTERCEPTOR_PROP_NAME);
+        const setAI = setFI?.getData(ATTRIBUTE_INTERCEPTOR_PROP_NAME);
+        assert(!(getAI && setAI) || (getAI === setAI), `Getter/Setter of attribute ${name} have differnt interceptors`);
+        desc.interceptor = getAI ?? setAI;
+    }
+    return desc;
+}
+function interceptAttributeBase(name, shadowPrototype, attributeInterceptorCtor) {
+    const desc = getAttributeInterceptor(name, shadowPrototype);
+    return desc?.interceptor ?? new attributeInterceptorCtor(name, shadowPrototype, desc);
+}
+function interceptAttribute(name, shadowPrototype) {
+    return interceptAttributeBase(name, shadowPrototype, AttributeInterceptor);
+}
+
+export { AttributeInterceptor, AttributeInterceptorBase, Catch, IGlobalThis, IPromise$1 as IPromise, IPromisePrototype, IRequire, ShadowPrototype, all, allSettled, any, constructor, getFunctionInterceptor, getObjectExtension, getOwnShadowPrototypeOf, getVirtualPropertyValue, intercept, interceptAttribute, interceptAttributeBase, interceptConstructor, interceptConstructorMethod, interceptFunction, interceptMethod, interceptModuleExports, race, registerShadowPrototype, registerShadowPrototypeGetter, reject, resolve, setInterval, setTimeout, setVirtualPropertyValue, then, validateModuleInterceptor };

--- a/packages/hyperion-react-native-testapp/HyperionReact.js
+++ b/packages/hyperion-react-native-testapp/HyperionReact.js
@@ -1,0 +1,566 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved.
+ *
+ * This file is auto generated from the Hyperion project hosted on
+ * https://github.com/facebookincubator/hyperion
+ * Instead of changing this file, you should:
+ * - git clone https://github.com/facebookincubator/hyperion
+ * - npm install
+ * - npm run install-packages
+ * - <make necessary modifications>
+ * - npm run build
+ * - npm test
+ * - <copy the 'hyperion/dist/' folder>
+ * - e.g. 'scp -r  ./dist/hyperion* $USER@my-od.facebook.com:www/html/js/hyperion/dist/'
+ *
+ * @generated <<SignedSource::378a2c8aba5a270f6cf75511cbaf450a>>
+ */
+
+
+
+import { interceptModuleExports, validateModuleInterceptor, interceptFunction, ShadowPrototype, interceptMethod, interceptConstructor } from '../hyperion-core';
+import { Hook } from '../hyperion-hook';
+import { TestAndSet } from '../hyperion-test-and-set';
+import { assert } from '../hyperion-globals';
+
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved.
+ */
+let IJsxRuntimeModule = null;
+let IReactModule = null;
+function interceptRuntime(moduleId, moduleExports, failedExportsKeys) {
+    if (!IJsxRuntimeModule) {
+        IJsxRuntimeModule = interceptModuleExports(moduleId, moduleExports, ['jsx', 'jsxs', 'jsxDEV']);
+        /**
+         * https://github.com/facebook/react/blob/cae635054e17a6f107a39d328649137b83f25972/packages/react/src/jsx/ReactJSX.js#L19
+         * The '.jsxs' is a special function that in development it points to a unique
+         * function, but in production, it points to '.jsx'.
+         * Hyperion does not reintercept the same function intentionally to ensure
+         * developer is aware of how the hooks are intalled on the function.
+         *
+         * Therefore, we first call the interceptModuleExport without the failedExportsKeys which prevents validation
+         * then we do the following patch up and then call the validation explicitly.
+         */
+        if (!__DEV__) {
+            if (moduleExports.jsxs !== IJsxRuntimeModule.jsxs.interceptor) {
+                moduleExports.jsxs = IJsxRuntimeModule.jsxs.interceptor;
+            }
+            if (moduleExports.jsxDEV !== IJsxRuntimeModule.jsxDEV.interceptor) {
+                moduleExports.jsxDEV = IJsxRuntimeModule.jsxDEV.interceptor;
+            }
+        }
+        validateModuleInterceptor(moduleId, moduleExports, IJsxRuntimeModule, failedExportsKeys);
+    }
+    return IJsxRuntimeModule;
+}
+function intercept$1(moduleId, moduleExports, failedExportsKeys) {
+    if (!IReactModule) {
+        IReactModule = interceptModuleExports(moduleId, moduleExports, [
+            'createElement',
+            'forwardRef',
+            'useCallback',
+            'useEffect',
+            'useLayoutEffect',
+            'useMemo',
+            'useReducer',
+            'useState'
+        ], failedExportsKeys);
+    }
+    return IReactModule;
+}
+
+const IReact = /*#__PURE__*/Object.freeze({
+    __proto__: null,
+    intercept: intercept$1,
+    interceptRuntime
+});
+
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved.
+ */
+let IReactDOMModule = null;
+function intercept(moduleId, moduleExports, failedExportsKeys) {
+    if (!IReactDOMModule) {
+        IReactDOMModule = interceptModuleExports(moduleId, moduleExports, ['createPortal'], failedExportsKeys);
+    }
+    return IReactDOMModule;
+}
+
+const IReactDOM = /*#__PURE__*/Object.freeze({
+    __proto__: null,
+    intercept
+});
+
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved.
+ */
+const usePolyfill = typeof Symbol !== 'function' || !Symbol.for; // The Symbol used to tag the ReactElement-like types.
+const SymbolFor = usePolyfill
+    ? (symbolValue, _symbolName) => symbolValue
+    : // eslint-disable-next-line fb-www/no-symbol
+        (_symbolValue, symbolName) => Symbol.for(symbolName);
+// export const REACT_ELEMENT_TYPE: Sym = ReactIs.Element;
+// export const REACT_PORTAL_TYPE: Sym = ReactIs.Portal;
+// export const REACT_FRAGMENT_TYPE: Sym = ReactIs.Fragment;
+// export const REACT_STRICT_MODE_TYPE: Sym = ReactIs.StrictMode;
+// export const REACT_PROFILER_TYPE: Sym = ReactIs.Profiler;
+// export const REACT_PROVIDER_TYPE: Sym = ReactIs.ContextProvider;
+// export const REACT_CONTEXT_TYPE: Sym = ReactIs.ContextConsumer;
+// export const REACT_FORWARD_REF_TYPE: Sym = ReactIs.ForwardRef;
+// export const REACT_SUSPENSE_LIST_TYPE: Sym = ReactIs.Suspense;
+// export const REACT_MEMO_TYPE: Sym = ReactIs.Memo;
+// export const REACT_LAZY_TYPE: Sym = ReactIs.Lazy;
+const REACT_ELEMENT_TYPE = SymbolFor(0xeac7, 'react.element');
+const REACT_PORTAL_TYPE = SymbolFor(0xeaca, 'react.portal');
+const REACT_FRAGMENT_TYPE = SymbolFor(0xeacb, 'react.fragment');
+const REACT_STRICT_MODE_TYPE = SymbolFor(0xeacc, 'react.strict_mode');
+const REACT_PROFILER_TYPE = SymbolFor(0xead2, 'react.profiler');
+const REACT_PROVIDER_TYPE = SymbolFor(0xeacd, 'react.provider');
+const REACT_CONSUMER_TYPE = SymbolFor(0xeace, 'react.consumer'); // same as context
+const REACT_CONTEXT_TYPE = SymbolFor(0xeace, 'react.context');
+const REACT_FORWARD_REF_TYPE = SymbolFor(0xead0, 'react.forward_ref');
+const REACT_SUSPENSE_LIST_TYPE = SymbolFor(0xead8, 'react.suspense_list');
+const REACT_MEMO_TYPE = SymbolFor(0xead3, 'react.memo');
+const REACT_SUSPENSE_TYPE = SymbolFor(0xead1, 'react.suspense');
+const REACT_SCOPE_TYPE = SymbolFor(0xead7, 'react.scope');
+const REACT_LEGACY_HIDDEN_TYPE = SymbolFor(0xeae3, 'react.legacy_hidden');
+
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved.
+ */
+function warn(msg) {
+    if (__DEV__) {
+        console.warn(msg);
+    }
+}
+function optimizeVisitors(visitors) {
+    function callVtable(index, component, visitors) {
+        const getter = vtable[index];
+        if (getter) {
+            return getter(component, visitors);
+        }
+        else {
+            warn(`optimized visitors missing entry for ${String(index)}`);
+        }
+        return;
+    }
+    function ctor(visitorName) {
+        if (visitorName != null && visitors[visitorName] != null) {
+            // This visitor exists, so we can use it
+            return (_, visitors) => visitors[visitorName];
+        }
+        else {
+            // Use the __default visitor instead
+            return (_, visitors) => visitors.__default;
+        }
+    }
+    const vtable = {
+        string: ctor('domElement'),
+        function: ctor('component'),
+        object: (component, visitors) => callVtable(component?.$$typeof, component, visitors),
+        symbol: (component, visitors) => callVtable(component, component, visitors),
+        [REACT_FORWARD_REF_TYPE]: ctor('forwardRef'),
+        [REACT_MEMO_TYPE]: ctor('memo'),
+        [REACT_PROVIDER_TYPE]: ctor('provider'),
+        [REACT_CONSUMER_TYPE]: ctor('context'), // this is same as 'context'
+        [REACT_CONTEXT_TYPE]: ctor('context'),
+        [REACT_FRAGMENT_TYPE]: ctor('fragment'),
+        [REACT_SUSPENSE_TYPE]: ctor(),
+        [REACT_SUSPENSE_LIST_TYPE]: ctor(),
+        [REACT_PROFILER_TYPE]: ctor(),
+        [REACT_LEGACY_HIDDEN_TYPE]: ctor(),
+        [REACT_SCOPE_TYPE]: ctor(),
+        [REACT_STRICT_MODE_TYPE]: ctor(),
+    };
+    visitors._get = (component, visitors) => callVtable(typeof component, component, visitors);
+}
+let ReactModule = null;
+function init$1(options) {
+    ReactModule = options.ReactModule;
+}
+function getVisitor(component, visitors) {
+    const optVisitor = visitors._get?.(component, visitors);
+    if (optVisitor || !visitors.__default) {
+        // either we found something, or there was no default.
+        return optVisitor;
+    }
+    // Otherwise, let's try the old way!
+    let visitor;
+    switch (typeof component) {
+        case 'string':
+            visitor = visitors.domElement;
+            break;
+        case 'function':
+            visitor = visitors.component;
+            break;
+        case 'object':
+            {
+                if (!component) {
+                    break;
+                }
+                /**
+                 * This is a component object, e.g. from createForwardRef(...)
+                 * React still process it as if it was a functional component
+                 */
+                const specialComp =
+                // $FlowIgnore[incompatible-type] // https://fb.workplace.com/groups/flow/permalink/9565274296854433/
+                component;
+                switch (specialComp.$$typeof) {
+                    case REACT_FORWARD_REF_TYPE:
+                        visitor = visitors.forwardRef;
+                        break;
+                    case REACT_MEMO_TYPE:
+                        visitor = visitors.memo;
+                        break;
+                    case REACT_PROVIDER_TYPE:
+                        visitor = visitors.provider;
+                        break;
+                    case REACT_CONSUMER_TYPE:
+                    case REACT_CONTEXT_TYPE:
+                        visitor = visitors.context;
+                        break;
+                    default:
+                        warn(`skip object component $$type: ${String(specialComp.$$typeof)}`);
+                        break;
+                }
+            }
+            break;
+        case 'symbol':
+            switch (component) {
+                case REACT_FRAGMENT_TYPE:
+                    /**
+                     * do we need to recurse inside? probably not, each child itself should
+                     * be called by the jsx* api
+                     */
+                    visitor = visitors.fragment;
+                    break;
+                case REACT_SUSPENSE_TYPE:
+                    /**
+                     * props is {fallback, suspenseCallback}
+                     * probably need to interncep those
+                     */
+                    break;
+                case REACT_PROFILER_TYPE:
+                    break;
+                case REACT_LEGACY_HIDDEN_TYPE:
+                    /**
+                     * props is {children, ...}
+                     * assumption is those are already processed before
+                     */
+                    break;
+                case REACT_SCOPE_TYPE:
+                    break;
+                case REACT_STRICT_MODE_TYPE:
+                    break;
+                default:
+                    warn(`skip special component $$type: ${String(component)}`);
+                    break;
+            }
+            break;
+        default: {
+            warn(`Did not know how to handle component type ${typeof component}`);
+        }
+    }
+    visitor = visitor ?? visitors.__default;
+    return visitor;
+}
+function visitElement(component, props, param, visitors, node) {
+    const visitor = getVisitor(component, visitors);
+    // @ts-ignore
+    return visitor?.(
+    // @ts-ignore
+    component, props, param, node);
+}
+function createReactElementVisitor(visitors) {
+    optimizeVisitors(visitors);
+    return (component, props, param) => visitElement(component, props, param, visitors);
+}
+function visitNode(node, param, visitors) {
+    if (typeof node !== 'object' ||
+        node == null ||
+        node instanceof Node // See this: https://fb.workplace.com/groups/reactjs/permalink/9019994061382462/
+    ) {
+        return;
+    }
+    if (Array.isArray(node)) {
+        for (let i = 0; i < node.length; ++i) {
+            visitNode(node[i], param, visitors);
+        }
+    }
+    else {
+        // @ts-ignore
+        const element = node;
+        const $$typeof = element.$$typeof;
+        switch ($$typeof) {
+            case REACT_ELEMENT_TYPE:
+            case REACT_FORWARD_REF_TYPE: {
+                const props = element.props;
+                if (!props || typeof props !== 'object') {
+                    return;
+                }
+                return visitElement(element.type, props, param, visitors, element);
+            }
+            case REACT_PORTAL_TYPE:
+                // return visitNode(node.children, param, visitors);
+                return;
+            case REACT_MEMO_TYPE:
+            case REACT_PROVIDER_TYPE:
+                // These component won't have children so safe to skip
+                if (__DEV__) {
+                    if (typeof element.props === 'object') {
+                        warn(`Unexpected object props type when skiping: ${String($$typeof)}`);
+                    }
+                }
+                return;
+            default: {
+                /**
+                 * We have tried every known option so far, now we can try the builtin
+                 * React mechanism to visit the node.
+                 * the React.Children.forEach is expensive and creates extra array objects
+                 * during iteration. Therefore, we should regularly try to minimize the
+                 * reliance on this code.
+                 */
+                let visited = false;
+                try {
+                    ReactModule?.Children.forEach(node, child => {
+                        visited = true;
+                        visitNode(child, param, visitors);
+                    });
+                }
+                catch (e) {
+                    // FBLogger('ads_manager_auto_logging')
+                    //   .catching(e)
+                    //   .mustfix('Error during visiting children of react element');
+                }
+                if (!visited) {
+                    warn(`Unexpected child component type to skip: ${String($$typeof)}`);
+                }
+                break;
+            }
+        }
+    }
+    return;
+}
+function createReactNodeVisitor(visitors) {
+    const visitor = (node, param) => visitNode(node, param, visitors);
+    if (!visitors.fragment) {
+        visitors.fragment = (_comp, props, param, _node) => visitor(props.children, param);
+    }
+    optimizeVisitors(visitors);
+    return visitor;
+}
+
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved.
+ */
+class ReactClassComponentShadowPrototype extends ShadowPrototype {
+    name;
+    ctor;
+    render = interceptMethod('render', this);
+    componentWillMount = interceptMethod('componentWillMount', this);
+    componentDidMount = interceptMethod('componentDidMount', this);
+    componentWillReceiveProps = interceptMethod('componentWillReceiveProps', this);
+    shouldComponentUpdate = interceptMethod('shouldComponentUpdate', this);
+    componentWillUpdate = interceptMethod('componentWillUpdate', this);
+    componentDidUpdate = interceptMethod('componentDidUpdate', this);
+    componentWillUnmount = interceptMethod('componentWillUnmount', this);
+    componentDidCatch = interceptMethod('componentDidCatch', this);
+    setState = interceptMethod('setState', this);
+    constructor(component, classComponentParentClass) {
+        if (__DEV__) {
+            const classComponentParentClass1 = component.prototype;
+            assert(classComponentParentClass === classComponentParentClass1, 'Unexpected setup');
+        }
+        super(classComponentParentClass, null);
+        this.name = component.displayName ?? component.name;
+        this.ctor = interceptConstructor(component);
+    }
+}
+const onReactClassComponentIntercept = new Hook();
+const onReactFunctionComponentIntercept = new Hook();
+const onReactDOMElement = new Hook();
+const onReactClassComponentElement = new Hook();
+const onReactFunctionComponentElement = new Hook();
+const onReactSpecialObjectElement = new Hook();
+const initialized = new TestAndSet();
+function init(options) {
+    if (initialized.testAndSet()) {
+        return;
+    }
+    const { ReactModule, IReactModule, IJsxRuntimeModule } = options;
+    init$1(options);
+    const interceptionInfo = new Map();
+    function processReactClassComponent(component, classComponentParentClass) {
+        if (!options.enableInterceptClassComponentMethods && !options.enableInterceptClassComponentConstructor) {
+            return component;
+        }
+        // For class components, we just need to intercept them once
+        if (interceptionInfo.has(component)) {
+            return component;
+        }
+        interceptionInfo.set(component, null);
+        let info = interceptionInfo.get(classComponentParentClass);
+        if (!info) {
+            info = new ReactClassComponentShadowPrototype(component, classComponentParentClass);
+            interceptionInfo.set(classComponentParentClass, info);
+            onReactClassComponentIntercept.call(info);
+        }
+        return options.enableInterceptClassComponentConstructor ? info.ctor.interceptor : component;
+    }
+    function processReactFunctionComponent(functionComponent) {
+        if (!options.enableInterceptFunctionComponentRender) {
+            return functionComponent;
+        }
+        /**
+         * For functional components, we should always replace them with the
+         * intercepted version of them.
+         * however, the interceptFunction itself will only assign a FunctionIntercetpr
+         * to the function once.
+         * So, we don't need to use the interceptionInfo map here.
+         */
+        const fi = interceptFunction(functionComponent, false, null, (functionComponent.displayName ?? functionComponent.name) || void 0);
+        onReactFunctionComponentIntercept.call(fi);
+        return fi.interceptor;
+    }
+    const processComponent = createReactElementVisitor({
+        domElement: options.enableInterceptDomElement
+            ? (component, props) => {
+                onReactDOMElement.call(component, props);
+            }
+            : void 0,
+        component: options.enableInterceptComponentElement
+            || options.enableInterceptFunctionComponentRender
+            || options.enableInterceptClassComponentMethods
+            || options.enableInterceptClassComponentConstructor
+            ? (component, props) => {
+                let interceptedComponent = component;
+                /**
+                 * This is a react component, and can be a class component constructor
+                 * or functional component.
+                 *
+                 * Note that react itself has no types, and flow compiler has some built-in
+                 * hard coded types just to be able to handle react types.
+                 * (see all the React$* types in react.js)
+                 * So, sadly the code bellow effectively cannot rely on types much.
+                 *
+                 * We need to check for two conditions:
+                 * 1- the component is a class constructor and it inherits from ReactModule.Component
+                 *    or something that has a .render() function.
+                 * 2- the component is a normal function, i.e. the .prototype is a plain object with just one .constructor in it.
+                   *  That means the __proto__ of this object is an empty object (i.e. the __proto__ of that object is null)
+                   *  https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/prototype#:~:text=prototype%20property%2C%20by%20default
+                 */
+                const classComponentParentClass = component.prototype;
+                let classComponentParentClassParent;
+                if (classComponentParentClass && (classComponentParentClass instanceof ReactModule.Component ||
+                    typeof classComponentParentClass.render === 'function' || // possibly created via React.createClass
+                    ((classComponentParentClassParent = Object.getPrototypeOf(classComponentParentClass)) &&
+                        Object.getPrototypeOf(classComponentParentClassParent)) || // not a plain function, may be with some other lifecycle methods.
+                    classComponentParentClass === ReactModule.Component.prototype // in case buggy code didn't properly inherit from ReactModule.Component
+                )) {
+                    // @ts-ignore
+                    const classComponent = component;
+                    interceptedComponent = processReactClassComponent(classComponent, classComponentParentClass);
+                    onReactClassComponentElement.call(classComponent, props);
+                }
+                else {
+                    // @ts-ignore
+                    const functionalComponent = component;
+                    interceptedComponent =
+                        processReactFunctionComponent(functionalComponent);
+                    onReactFunctionComponentElement.call(functionalComponent, props);
+                }
+                return interceptedComponent;
+            }
+            : void 0,
+        forwardRef: options.enableInterceptSpecialElement
+            ? (component, props) => {
+                if (component.render && typeof component.render === 'function') {
+                    // $FlowIgnore[incompatible-type] // https://fb.workplace.com/groups/flow/permalink/9565274296854433/
+                    // @ts-ignore
+                    component.render = processReactFunctionComponent(component.render);
+                }
+                onReactSpecialObjectElement.call(component, props);
+            }
+            : void 0,
+        memo: options.enableInterceptSpecialElement
+            ? (component, _props) => {
+                if (typeof component.type === 'object') {
+                    const comp = component.type;
+                    if (comp.render && typeof comp.render === 'function') {
+                        // $FlowIgnore[incompatible-type] // https://fb.workplace.com/groups/flow/permalink/9565274296854433/
+                        // @ts-ignore
+                        comp.render = processReactFunctionComponent(comp.render);
+                    }
+                }
+            }
+            : void 0,
+        provider: options.enableInterceptSpecialElement
+            ? (component, props) => {
+                onReactSpecialObjectElement.call(component, props);
+            }
+            : void 0,
+        context: options.enableInterceptSpecialElement
+            ? (component, props) => {
+                onReactSpecialObjectElement.call(component, props);
+            }
+            : void 0,
+    });
+    function interceptArgs(component, props) {
+        // $FlowIgnore[incompatible-return]
+        // @ts-ignore
+        return processComponent(component, props) ?? component;
+    }
+    const interceptArgsFunc = /* AdsALProfiler
+      ? (
+        component: ReactComponentType<PropsType>,
+        props: PropsType,
+      ): ReactComponentType<PropsType> => {
+        const timer = AdsALProfiler.getALProfiler()?.timers.interceptArgs;
+        timer?.start();
+        const result = interceptArgs(component, props);
+        timer?.stop();
+        return result;
+      }
+      : */ interceptArgs;
+    const handler = IJsxRuntimeModule.jsx.onBeforeCallMapperAdd(args => {
+        /**
+         * TODO: T132536682 remove this guard later to speed things up
+         * NOTE: tried using ErrorGuard.guard, and ErrorGuard.applyWithGuard but
+         * as usual, Flow cannot handle complex function input/ouput types.
+         * So, putting the raw try/catch, which is the actual implementation of
+         * ErrorGaurd.applyWithGuard anyways.
+         *
+         * The rest of the logic in this module and ALSurface all run under this
+         * function, so this should catch all possible errors.
+         */
+        try {
+            const type = interceptArgsFunc(args[0], args[1]);
+            args[0] = type;
+        }
+        catch (e) {
+            // FBLogger('ads_manager_auto_logging')
+            //   .catching(e)
+            //   .mustfix('Error during React args interception: %s', e.message);
+        }
+        return args;
+    });
+    if (IJsxRuntimeModule.jsxs !== IJsxRuntimeModule.jsx) {
+        IJsxRuntimeModule.jsxs.onBeforeCallMapperAdd(handler);
+    }
+    IJsxRuntimeModule.jsxDEV.onBeforeCallMapperAdd(handler);
+    IReactModule.createElement.onBeforeCallMapperAdd(handler);
+}
+
+const IReactComponent = /*#__PURE__*/Object.freeze({
+    __proto__: null,
+    init,
+    onReactClassComponentElement,
+    onReactClassComponentIntercept,
+    onReactDOMElement,
+    onReactFunctionComponentElement,
+    onReactFunctionComponentIntercept,
+    onReactSpecialObjectElement
+});
+
+export { IReact, IReactComponent, IReactDOM, createReactNodeVisitor, init, onReactClassComponentIntercept, onReactDOMElement, onReactFunctionComponentIntercept };

--- a/packages/hyperion-react-native-testapp/ios/Podfile.lock
+++ b/packages/hyperion-react-native-testapp/ios/Podfile.lock
@@ -1654,7 +1654,7 @@ PODS:
     - React-logger (= 0.79.2)
     - React-perflogger (= 0.79.2)
     - React-utils (= 0.79.2)
-  - ReactNativeHost (0.5.8):
+  - ReactNativeHost (0.5.9):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1680,7 +1680,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - ReactTestApp-DevSupport (4.3.10):
+  - ReactTestApp-DevSupport (4.3.15):
     - React-Core
     - React-jsi
   - ReactTestApp-Resources (1.0.0-dev)
@@ -1987,12 +1987,12 @@ SPEC CHECKSUMS:
   ReactAppDependencyProvider: d5dcc564f129632276bd3184e60f053fcd574d6b
   ReactCodegen: fda99a79c866370190e162083a35602fdc314e5d
   ReactCommon: 4d0da92a5eb8da86c08e3ec34bd23ab439fb2461
-  ReactNativeHost: 2002cc963022a296ef9e85fc7825aa8f62c55ac7
-  ReactTestApp-DevSupport: 8f2bfaea9444fcf141b1f694c02d2af51fd6ec1c
+  ReactNativeHost: 5a6ea16a1b3ccb4bcb8fe27edcbb54752d0571b8
+  ReactTestApp-DevSupport: f58269a9a36b8dbd726e576b8af1b318a51b84d4
   ReactTestApp-Resources: 1bd9ff10e4c24f2ad87101a32023721ae923bccf
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   Yoga: 9f110fc4b7aa538663cba3c14cbb1c335f43c13f
 
 PODFILE CHECKSUM: 68e23d81c86a616329b89ef189269b6dd97123e1
 
-COCOAPODS: 1.16.2
+COCOAPODS: 1.15.2

--- a/packages/hyperion-react-native-testapp/test/hyperion-core/AttributeInterceptor.test.ts
+++ b/packages/hyperion-react-native-testapp/test/hyperion-core/AttributeInterceptor.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved.
+ */
+
+import "jest";
+import { ShadowPrototype } from "../../HyperionCore";
+import { interceptAttribute } from "../../HyperionCore";
+
+describe("test Attribute Interceptor", () => {
+
+  function testSetup() {
+    class A {
+      _a: number = 10;
+      get a() { return this._a; }
+      set a(v: number) { this._a = v; }
+
+      foo: boolean;
+      baz: number;
+
+      constructor() {
+        this.baz = 21;
+      }
+
+    }
+
+    class B extends A {
+      _b: string = "hello";
+      get b() { return this._b; }
+      set b(v: string) { this._b = v; }
+    }
+
+    const IAShadow = new ShadowPrototype(A.prototype, null);
+    const IA = {
+      a: interceptAttribute('a', IAShadow),
+      foo: interceptAttribute('foo', IAShadow),
+      baz: interceptAttribute('baz', IAShadow),
+      bar: interceptAttribute('bar', IAShadow),
+    };
+
+    const IBShadow = new ShadowPrototype(B.prototype, IAShadow);
+    const IB = {
+      b: interceptAttribute('b', IBShadow),
+    }
+
+    return { IAShadow, IBShadow, IA, IB, A, B }
+  }
+
+  test("test getter / setter", () => {
+    const { IBShadow, IA, IB, B } = testSetup();
+
+    const o = new B();
+    IBShadow.interceptObject(o);
+
+    const observer = jest.fn();
+    function expectGetSet(getValue, setValue) {
+      expect(observer.mock.calls.length).toBe(2);
+      expect(observer.mock.calls[0][0]).toBe(getValue);
+      expect(observer.mock.calls[1][0]).toBe(setValue);
+      observer.mockClear();
+    }
+
+    IA.a.getter.onAfterCallObserverAdd(observer);
+    IA.a.setter.onBeforeCallObserverAdd(observer);
+
+    IA.foo.getter.onAfterCallObserverAdd(observer);
+    IA.foo.setter.onBeforeCallObserverAdd(observer);
+
+    IA.bar.getter.onAfterCallObserverAdd(observer);
+    IA.bar.setter.onBeforeCallObserverAdd(observer);
+
+    IA.baz.getter.onAfterCallObserverAdd(observer);
+    IA.baz.setter.onBeforeCallObserverAdd(observer);
+
+    IB.b.getter.onAfterCallObserverAdd(observer);
+    IB.b.setter.onBeforeCallObserverAdd(observer);
+
+    // a sequence of read/writes
+    o.a = o.a + 20;
+    expectGetSet(10, 30);
+
+    o.foo = !o.foo;
+    expectGetSet(void 0, true);
+
+    o.baz *= 2;
+    expectGetSet(21, 42);
+
+    o.b = o.b + "world";
+    expectGetSet("hello", "helloworld");
+  });
+
+  test("test repeated interception of same attribute", () => {
+    class A {
+      _a: number = 10;
+      get a() { return this._a; }
+      set a(v: number) { this._a = v; }
+
+      _b: string = "hello";
+      get b() { return this._b; }
+      set b(v: string) { this._b = v; }
+    }
+
+    class B extends A {
+      get a() { return super.a * 2; }
+      set a(v: number) { super.a = v * 10; }
+    }
+
+    const IAShadow = new ShadowPrototype(A.prototype, null);
+    const IA = {
+      a: interceptAttribute('a', IAShadow),
+      b: interceptAttribute('b', IAShadow),
+    };
+
+    const IBShadow = new ShadowPrototype(B.prototype, IAShadow);
+    const IB = {
+      a: interceptAttribute('a', IBShadow),
+      b: interceptAttribute('b', IBShadow),
+    }
+
+    expect(IA.a === IB.a).toBe(false);
+    expect(IA.b === IB.b).toBe(true);
+
+    const testPropName = 'randomProp';
+    IA.b.getter.setData(testPropName, true);
+    expect(IB.b.getter.getData(testPropName)).toBe(true);
+
+    const a = new A();
+    const b = new B();
+
+    const A_a_getter_observer = jest.fn();
+    IA.a.getter.onAfterCallObserverAdd(A_a_getter_observer);
+
+    const A_a_setter_observer = jest.fn();
+    IA.a.setter.onBeforeCallObserverAdd(A_a_setter_observer);
+
+    const B_a_getter_observer = jest.fn();
+    IB.a.getter.onAfterCallObserverAdd(B_a_getter_observer);
+
+    const B_a_setter_observer = jest.fn();
+    IB.a.setter.onBeforeCallObserverAdd(B_a_setter_observer);
+
+    a.a = 1;
+    expect(A_a_setter_observer.mock.calls.length).toBe(1);
+    expect(A_a_setter_observer.mock.calls[0][0]).toBe(1);
+    expect(A_a_getter_observer.mock.calls.length).toBe(0);
+
+    expect(B_a_setter_observer.mock.calls.length).toBe(0);
+    expect(B_a_getter_observer.mock.calls.length).toBe(0);
+
+    A_a_setter_observer.mockClear();
+
+    b.a = 10;
+    expect(b.a).toBe(200);
+    expect(A_a_setter_observer.mock.calls.length).toBe(1);
+    expect(A_a_setter_observer.mock.calls[0][0]).toBe(100);
+    expect(A_a_getter_observer.mock.calls.length).toBe(1);
+    expect(A_a_getter_observer.mock.calls[0][0]).toBe(100);
+
+    expect(B_a_setter_observer.mock.calls.length).toBe(1);
+    expect(B_a_setter_observer.mock.calls[0][0]).toBe(10);
+    expect(B_a_getter_observer.mock.calls.length).toBe(1);
+    expect(B_a_getter_observer.mock.calls[0][0]).toBe(200);
+  });
+});

--- a/packages/hyperion-react-native-testapp/test/hyperion-core/AttributeInterceptor.test.ts
+++ b/packages/hyperion-react-native-testapp/test/hyperion-core/AttributeInterceptor.test.ts
@@ -3,8 +3,7 @@
  */
 
 import "jest";
-import { ShadowPrototype } from "../../HyperionCore";
-import { interceptAttribute } from "../../HyperionCore";
+import { ShadowPrototype, interceptAttribute } from "../../HyperionCore";
 
 describe("test Attribute Interceptor", () => {
 

--- a/packages/hyperion-react-native-testapp/test/hyperion-core/ConstructorInterceptor.test.ts
+++ b/packages/hyperion-react-native-testapp/test/hyperion-core/ConstructorInterceptor.test.ts
@@ -6,7 +6,7 @@ import "jest";
 import { ShadowPrototype } from "../../HyperionCore";
 import { interceptConstructor, interceptConstructorMethod } from "../../HyperionCore";
 import { AttributeInterceptor } from "../../HyperionCore";
-import * as intercept from "../../HyperionCore";
+import { registerShadowPrototype } from "../../HyperionCore";
 
 describe("test Constructor Interceptor", () => {
 
@@ -44,7 +44,7 @@ describe("test Constructor Interceptor", () => {
     const IB = {
       b: new AttributeInterceptor('b', IBShadow),
     }
-    intercept.registerShadowPrototype(B.prototype, IBShadow);
+    registerShadowPrototype(B.prototype, IBShadow);
 
 
     const Ctors = { A, B };

--- a/packages/hyperion-react-native-testapp/test/hyperion-core/ConstructorInterceptor.test.ts
+++ b/packages/hyperion-react-native-testapp/test/hyperion-core/ConstructorInterceptor.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved.
+ */
+
+import "jest";
+import { ShadowPrototype } from "../../HyperionCore";
+import { interceptConstructor, interceptConstructorMethod } from "../../HyperionCore";
+import { AttributeInterceptor } from "../../HyperionCore";
+import * as intercept from "../../HyperionCore";
+
+describe("test Constructor Interceptor", () => {
+
+  function testSetup() {
+    class A {
+      _a: number = 10;
+      get a() { return this._a; }
+      set a(v: number) { this._a = v; }
+
+      foo: boolean;
+      baz: number;
+
+      constructor(i = 21) {
+        this.baz = i;
+      }
+
+    }
+
+    class B extends A {
+      _b: string = "hello";
+      get b() { return this._b; }
+      set b(v: string) { this._b = v; }
+    }
+
+    const IAShadow = new ShadowPrototype(A.prototype, null);
+    const IA = {
+      a: new AttributeInterceptor('a', IAShadow),
+      foo: new AttributeInterceptor('foo', IAShadow),
+      baz: new AttributeInterceptor('baz', IAShadow),
+      bar: new AttributeInterceptor('bar', IAShadow),
+    };
+    // intercept.registerShadowPrototype(A.prototype, IAShadow);
+
+    const IBShadow = new ShadowPrototype(B.prototype, IAShadow);
+    const IB = {
+      b: new AttributeInterceptor('b', IBShadow),
+    }
+    intercept.registerShadowPrototype(B.prototype, IBShadow);
+
+
+    const Ctors = { A, B };
+    const ICtorsShadow = new ShadowPrototype(Ctors, null);
+    const IBCtor = interceptConstructorMethod<'B', typeof Ctors, { new(i: number): B }>('B', ICtorsShadow);
+
+    type T1 = { new(i: number): B };
+    type T2 = ConstructorParameters<T1>
+
+    return { IAShadow, IBShadow, IA, IB, Ctors, IBCtor }
+  }
+
+  test("test direct constructor interceptor", () => {
+    class B {
+      constructor(public n: number, public s: string) {
+      }
+    }
+
+    const IBCtor = interceptConstructor(B);
+
+    let result: any[] = [];
+    let observer = <T>(value: T) => { result.push(value) };
+    const expectResultTobe = (id: any, expected: any[]) => {
+      result.push(id);
+      expected.push(id);
+      expect(result).toStrictEqual(expected);
+      result = [];
+    }
+
+    IBCtor.onBeforeCallMapperAdd(function (this, args) {
+      observer([...args]);
+      args[0] += 1;
+      args[1] += "-world";
+      return args;
+    })
+    IBCtor.onBeforeCallObserverAdd(function (this, n, s) {
+      observer([n, s]);
+    })
+
+    IBCtor.onAfterCallMapperAdd(function (this, value) {
+      observer(value);
+      return value;
+    })
+
+    IBCtor.onAfterCallObserverAdd(function (this, value) {
+      observer(value);
+    })
+
+    const o = new IBCtor.interceptor(20, "Hello");
+    expectResultTobe("ctor", [[20, "Hello"], [21, "Hello-world"], o, o]);
+  });
+
+  test("test ctor interceptor", () => {
+    const { IBShadow, IAShadow, IA, IB, IBCtor, Ctors } = testSetup();
+
+
+    let result: any[] = [];
+    let observer = <T>(value: T) => { result.push(value) };
+    const expectResultTobe = (id: any, expected: any[]) => {
+      result.push(id);
+      expected.push(id);
+      expect(result).toStrictEqual(expected);
+      result = [];
+    }
+
+    // IAShadow.onAfterInterceptObj(argsObserver);
+    IBCtor.onBeforeCallObserverAdd(function (value) {
+      observer(value);
+    })
+    IBCtor.onBeforeCallMapperAdd(function (this, value) {
+      const a0 = value[0];
+      observer(a0);
+      value[0] = a0 + 1;
+      return value;
+    })
+    IBCtor.onAfterCallObserverAdd(function (this, value) {
+      observer(value);
+    })
+    IBCtor.onAfterCallMapperAdd(function (this, value) {
+      observer(value);
+      return value;
+    })
+
+    const o = new Ctors.B(20);
+    expectResultTobe("ctor", [20, 21, o, o]);
+
+    IA.a.getter.onAfterCallObserverAdd(observer);
+    IA.a.setter.onBeforeCallObserverAdd(observer);
+
+    IA.foo.getter.onAfterCallObserverAdd(observer);
+    IA.foo.setter.onBeforeCallObserverAdd(observer);
+
+    IA.bar.getter.onAfterCallObserverAdd(observer);
+    IA.bar.setter.onBeforeCallObserverAdd(observer);
+
+    IA.baz.getter.onAfterCallObserverAdd(observer);
+    IA.baz.setter.onBeforeCallObserverAdd(observer);
+
+    IB.b.getter.onAfterCallObserverAdd(observer);
+    IB.b.setter.onBeforeCallObserverAdd(observer);
+
+    // a sequence of read/writes
+    o.a = o.a + 20;
+    expectResultTobe("a", [10, 30]);
+
+    o.foo = !o.foo;
+    expectResultTobe("foo", [undefined, true]);
+
+    o.baz *= 2;
+    expectResultTobe("baz", [21, 42]);
+
+    o.b = o.b + "world";
+    expectResultTobe("b", ["hello", "helloworld"]);
+  });
+
+});

--- a/packages/hyperion-react-native-testapp/test/hyperion-core/FunctionInterceptor.test.ts
+++ b/packages/hyperion-react-native-testapp/test/hyperion-core/FunctionInterceptor.test.ts
@@ -398,6 +398,7 @@ describe("test modern classes", () => {
     expect(observer.mock.results[1].value).toBe(output);
   });
 
+  // TODO investigate why this case fails
   test.skip("test prototype + name prop copied to interceptor", () => {
     function someFuncName(a: string, b: number) {
       return a + b;

--- a/packages/hyperion-react-native-testapp/test/hyperion-core/FunctionInterceptor.test.ts
+++ b/packages/hyperion-react-native-testapp/test/hyperion-core/FunctionInterceptor.test.ts
@@ -1,0 +1,511 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved.
+ */
+
+import "jest";
+import { ShadowPrototype } from "../../HyperionCore";
+import { interceptFunction } from "../../HyperionCore";
+import { interceptMethod } from "../../HyperionCore";
+import { registerShadowPrototype } from "../../HyperionCore";
+
+describe("test modern classes", () => {
+
+  function testSetup() {
+    class A {
+      result: string[] = [];
+      a(s: string) {
+        const tmp = `[a:${s}]`;
+        this.result.push(tmp);
+        return tmp;
+      }
+
+      foo: (b: boolean) => boolean;
+      baz: (n: number) => number;
+
+      _bar: (n: number) => number;
+      get bar() { return this._bar; }
+      set bar(func: (n: number) => number) { this._bar = func; }
+
+      constructor() {
+        this.baz = n => -n;
+      }
+    }
+
+    class B extends A {
+      b() {
+        const tmp = "[b]";
+        this.result.push(tmp);
+        return tmp;
+      }
+    }
+
+    const IAShadow = new ShadowPrototype(A.prototype, null);
+    const IA = {
+      a: interceptMethod('a', IAShadow),
+      foo: interceptMethod('foo', IAShadow),
+      baz: interceptMethod('baz', IAShadow),
+      bar: interceptMethod('bar', IAShadow),
+    };
+
+    const IBShadow = new ShadowPrototype(B.prototype, IAShadow);
+    const IB = {
+      b: interceptMethod('b', IBShadow),
+    }
+
+    return { IAShadow, IBShadow, IA, IB, A, B }
+  }
+
+  test("test direct interception", () => {
+    const func = (i: number, s: string) => i + s.length;
+    func.x = 42;
+    const fi = interceptFunction(func, false, null, "tester");
+    const argObserver = fi.onBeforeCallObserverAdd(jest.fn());
+    const valueObserver = fi.onAfterCallObserverAdd(jest.fn());
+    expect(fi.getOriginal()).toStrictEqual(func);
+    expect(fi.interceptor.x).toBe(func.x);
+    const result = fi.interceptor(10, "12345");
+    expect(result).toBe(15);
+    expect(argObserver).toBeCalledTimes(1);
+    expect(argObserver).toBeCalledWith(10, "12345");
+    expect(valueObserver).toBeCalledWith(15);
+
+    const fi2 = interceptFunction(func, false, null, "test2");
+    const fi3 = interceptFunction(fi.interceptor, false, null, "test3");
+    expect(fi2).toStrictEqual(fi);
+    expect(fi3).toStrictEqual(fi);
+  });
+
+  test("test function interceptor data", () => {
+    const func = (i: number, s: string) => i + s.length;
+    func.x = 42;
+    const fi = interceptFunction(func, false, null, "tester");
+    const testPropName = 'randomProp';
+    fi.setData(testPropName, true);
+    expect(fi.getData(testPropName)).toBe(true);
+
+    fi.setData(testPropName, false);
+    expect(fi.getData(testPropName)).toBe(false);
+    expect(fi.testAndSet(testPropName)).toBe(false);
+    expect(fi.getData(testPropName)).toBe(true);
+  });
+
+  test("Ensure props are carried over", () => {
+    {
+      const func = (i: number, s: string) => i + s.length;
+      func.x = 42;
+      func.toString = () => "SECRET";
+      const fi = interceptFunction(func);
+
+      expect(fi.getOriginal()).toStrictEqual(func);
+      expect(fi.interceptor.x).toBe(func.x);
+      expect(fi.interceptor.toString()).toBe(func.toString());
+      expect(fi.interceptor + "").toBe("SECRET"); // check .toString
+    }
+    {
+      const func = function () { return 1; };
+      func.toString = () => "BAR";
+      func.valueOf = () => 42;
+      const fi = interceptFunction(func);
+      expect(fi.interceptor.toString()).toBe(func.toString());
+      expect(fi.interceptor + "").toBe("42"); // check .valueOf
+      expect(<any>func == 42).toBe(true); // check .valueOf
+      expect(<any>fi.interceptor == 42).toBe(true); // check .valueOf
+    }
+  });
+
+  test("test output interception", () => {
+    class A { };
+    const AShadow = new ShadowPrototype(A.prototype, null);
+    registerShadowPrototype(A.prototype, AShadow);
+
+    const func = () => new A();
+    const fi = interceptFunction(func, true);
+
+    const observer = jest.fn();
+    AShadow.onAfterInterceptObj.add(observer);
+
+    const o = fi.interceptor();
+    expect(o instanceof A).toBe(true);
+    expect(observer.mock.calls.length).toBe(1);
+    expect(observer.mock.calls[0][0]).toStrictEqual(o);
+  });
+
+  test("test .original", () => {
+    const { IBShadow, IA, IB, B } = testSetup();
+
+    const o = new B();
+    IBShadow.interceptObject(o);
+
+    IA.a.getOriginal().apply(o, ['1']);
+    IB.b.getOriginal().apply(o);
+
+    expect(o.result.join("")).toBe("[a:1][b]");
+  });
+
+  test("test .interceptor", () => {
+    const { IBShadow, IA, IB, B } = testSetup();
+
+    const o = new B();
+    IBShadow.interceptObject(o);
+
+    IA.a.interceptor.apply(o, ['1']);
+    IB.b.interceptor.apply(o);
+
+    expect(o.result.join("")).toBe("[a:1][b]");
+  });
+
+  test("test .custom", () => {
+    const { IBShadow, IA, IB, B } = testSetup();
+
+    const o = new B();
+    IBShadow.interceptObject(o);
+
+    IA.a.setCustom(function (this, s) {
+      const tmp = `[CC:${s}]`;
+      this.result.push(tmp);
+      return tmp;
+    });
+    IB.b.setCustom(function (this) {
+      const tmp = "[CC]";
+      this.result.push(tmp);
+      return tmp;
+    })
+
+    o.a('1');
+    o.b();
+
+    expect(o.result.join("")).toBe("[CC:1][CC]");
+  });
+
+  // TODO: somehow JEST is not able to import and understand const enums! For now copy this value here from FunctionInterceptor.ts
+  const enum InterceptorState {
+    HasArgsMapper = 1 << 3,
+    HasArgsObserver = 1 << 2,
+    HasValueMapper = 1 << 1,
+    HasValueObserver = 1 << 0,
+    Has_____________ = 0 | 0 | 0 | 0,
+    Has_AF_AO__VF_VO = HasArgsMapper | HasArgsObserver | HasValueMapper | HasValueObserver,
+
+  }
+
+  test("test .interception hooks", () => {
+    function testState(state: number) {
+      // console.log(`testing state ${state}`);
+
+      const { IBShadow, IA, IB, B } = testSetup();
+
+      let result = "";
+      let expectedResult = "";
+      const arg0 = '1';
+      let arg0Filtered = arg0;
+
+      if (state & InterceptorState.HasArgsMapper) {
+        IA.a.onBeforeCallMapperAdd(function (value) {
+          const a1 = value[0];
+          expect(a1).toBe(arg0);
+
+          result += a1;
+          value[0] = `-${a1}`;
+          return value;
+        });
+        expectedResult += arg0;
+        arg0Filtered = `-${arg0}`;
+      }
+
+      if (state & InterceptorState.HasArgsObserver) {
+        IA.a.onBeforeCallObserverAdd(value => {
+          result += value;
+          expect(value).toBe(arg0Filtered);
+        });
+        expectedResult += arg0Filtered;
+      }
+
+      let value0 = `[a:${arg0Filtered}]`;
+      let value0Filtered = value0;
+
+      if (state & InterceptorState.HasValueMapper) {
+        IA.a.onAfterCallMapperAdd(value => {
+          expect(value).toBe(value0);
+          result += value;
+          return `{${value}}`;
+        });
+        expectedResult += value0;
+        value0Filtered = `{${value0}}`;
+      }
+      if (state & InterceptorState.HasValueObserver) {
+        IA.a.onAfterCallObserverAdd(value => {
+          result += value;
+          expect(value).toBe(value0Filtered);
+        });
+        expectedResult += value0Filtered;
+      }
+
+      const o = new B();
+      IBShadow.interceptObject(o);
+      o.a(arg0);
+      // expect(o.result.join("")).toBe("-a-b+a+b...[a:-1]");
+      expect(result).toBe(expectedResult);
+    }
+    for (let i = InterceptorState.Has_____________; i <= InterceptorState.Has_AF_AO__VF_VO; ++i) {
+      testState(i);
+    }
+  });
+
+  test("test .interception remove hooks", () => {
+    const { IA, B } = testSetup();
+    let hookCalled = 0;
+    IA.a.onBeforeCallMapperRemove(IA.a.onBeforeCallMapperAdd(value => (hookCalled++, value)));
+    IA.a.onBeforeCallObserverRemove(IA.a.onBeforeCallObserverAdd(_ => { hookCalled++ }));
+    IA.a.onAfterCallMapperRemove(IA.a.onAfterCallMapperAdd(value => (hookCalled++, value)));
+    IA.a.onAfterCallObserverRemove(IA.a.onAfterCallObserverAdd(_ => { hookCalled++ }));
+
+    const o = new B();
+    o.a('1');
+    expect(hookCalled).toBe(0);
+  });
+
+  test("test interception hooks this-arg type", () => {
+    const { IA, A, IB, B } = testSetup();
+    const o = new B();
+    IA.a.onBeforeCallObserverAdd(function (this, value) {
+      expect(this instanceof A).toBe(true);
+
+      expect(typeof this.a).toBe("function");
+
+      //@ts-expect-error this.b should give error
+      expect(typeof this.b).toBe("function");
+    });
+
+    IB.b.onBeforeCallObserverAdd(function (this) {
+      expect(this instanceof A).toBe(true);
+      expect(this instanceof B).toBe(true);
+
+      // The following line checks both compile time and runtime correctness
+      expect(typeof this.a).toBe("function");
+      expect(typeof this.b).toBe("function");
+      return false;
+    });
+  });
+
+  test("test interception of object's own properties", () => {
+    const { IBShadow, IA, B } = testSetup();
+    const o = new B();
+    IBShadow.interceptObject(o);
+
+    let result: any[] = [];
+
+    const argsObserver = <T>(value: T) => {
+      result.push(value);
+    };
+
+    IA.foo.onBeforeCallObserverAdd(argsObserver);
+    IA.bar.onBeforeCallObserverAdd(argsObserver)
+    IA.baz.onBeforeCallObserverAdd(argsObserver)
+
+    o.foo = function (this, b) { return !b; }
+    o.bar = n => 2 * n;
+
+    result.push(o.foo(true));
+    result.push(o.baz(10));
+    result.push(o.bar(21));
+
+    expect(result.join(",")).toBe("true,false,10,-10,21,42");
+
+  });
+
+  test("test repeated interception of same methods", () => {
+    const { } = testSetup();
+
+    const testFn = jest.fn<void, [number]>();
+    class A {
+      foo(n: number) {
+        testFn(n);
+      }
+      bar() { }
+    }
+
+    class B extends A {
+      foo(n: number) {
+        super.foo(n * 10);
+      }
+    }
+
+    const IAShadow = new ShadowPrototype(A.prototype, null);
+    const IA_foo = interceptMethod("foo", IAShadow);
+    const IA_bar = interceptMethod("bar", IAShadow);
+
+    const IBShadow = new ShadowPrototype(B.prototype, IAShadow);
+    const IB_foo = interceptMethod('foo', IBShadow);
+    const IB_bar = interceptMethod("bar", IBShadow);
+
+    expect(IA_foo === IB_foo).toBe(false); // each have their own method
+    expect(IA_bar === IB_bar).toBe(true); // only one method, B inherits from A
+
+    const a = new A();
+    const b = new B();
+
+    const A_foo_observer = jest.fn();
+    IA_foo.onBeforeCallObserverAdd(A_foo_observer);
+
+    const B_foo_observer = jest.fn();
+    IB_foo.onBeforeCallObserverAdd(B_foo_observer);
+
+    a.foo(1);
+    expect(A_foo_observer.mock.calls.length).toBe(1);
+    expect(A_foo_observer.mock.calls[0][0]).toBe(1);
+    expect(B_foo_observer.mock.calls.length).toBe(0);
+
+    b.foo(1);
+    expect(A_foo_observer.mock.calls.length).toBe(2);
+    expect(A_foo_observer.mock.calls[1][0]).toBe(10);
+    expect(B_foo_observer.mock.calls.length).toBe(1);
+  });
+
+  test("test multiple mappers", () => {
+    const observer = jest.fn<number, [number]>(i => i);
+    const fi = interceptFunction(observer);
+    const argMappers = [
+      fi.onBeforeCallMapperAdd(([i]) => [i * 2]),
+      fi.onBeforeCallMapperAdd(([i]) => [i * 3]),
+    ];
+
+    const input = 1;
+    let output = fi.interceptor(input);
+    expect(output).toBe(6);
+    expect(observer).toBeCalledTimes(1);
+    expect(observer.mock.calls[0][0]).toBe(output);
+    expect(observer.mock.results[0].value).toBe(output);
+
+    argMappers.forEach(h => fi.onBeforeCallMapperRemove(h));
+
+    const valueMappers = [
+      fi.onAfterCallMapperAdd(i => i * 5),
+      fi.onAfterCallMapperAdd(i => i * 7),
+    ];
+
+    output = fi.interceptor(input);
+    expect(output).toBe(35);
+    expect(observer).toBeCalledTimes(2);
+    expect(observer.mock.calls[1][0]).toBe(input);
+    expect(observer.mock.results[1].value).toBe(input);
+
+    valueMappers.forEach(h => fi.onAfterCallMapperRemove(h));
+
+    output = fi.interceptor(input);
+    expect(output).toBe(input);
+    expect(observer).toBeCalledTimes(3);
+    expect(observer.mock.calls[1][0]).toBe(input);
+    expect(observer.mock.results[1].value).toBe(output);
+  });
+
+  test.skip("test prototype + name prop copied to interceptor", () => {
+    function someFuncName(a: string, b: number) {
+      return a + b;
+    };
+    expect(someFuncName.name).toStrictEqual('someFuncName');
+
+    const fi = interceptFunction(someFuncName, false, null, "tester");
+
+    expect(someFuncName.name).toStrictEqual('someFuncName');
+    expect(fi.interceptor.name).toStrictEqual(someFuncName.name);
+    expect(fi.interceptor.prototype).toStrictEqual(someFuncName.prototype);
+
+    const noProto = () => { };
+    expect(noProto.prototype).toBeUndefined();
+    const fiNoProto = interceptFunction(noProto, false, null, "tester");
+    expect(fiNoProto.interceptor.prototype).toBeUndefined();
+  });
+
+  test("arg observers blocking call", () => {
+    const fn = jest.fn<void, [number]>(i => { });
+    const fi = interceptFunction(fn);
+    fi.onBeforeCallObserverAdd(i => i === 0); // filters 0
+
+    fi.interceptor(0); // should be blocked
+    fi.interceptor(1); // should go through
+    expect(fn).toBeCalledTimes(1);
+    expect(fn.mock.calls[0][0]).toBe(1);
+
+    fi.onBeforeCallObserverAdd(i => i === 1); // filters 1
+
+    fn.mockClear();
+    fi.interceptor(0); // should be blocked
+    fi.interceptor(1); // should be blocked
+    expect(fn).toBeCalledTimes(0);
+  });
+
+  test("onArgsAndValueMapper feature", () => {
+    const fn = jest.fn<number, [number]>(i => i);
+    const fi = interceptFunction(fn);
+
+    const handler1 = fi.onBeforeAndAfterCallMapperAdd(args => {
+      args[0] *= 3;
+      return value => {
+        return value * 5;
+      };
+    });
+
+    let result = fi.interceptor(2);
+    expect(fn).toBeCalledTimes(1);
+    expect(fn.mock.calls[0][0]).toBe((2) * 3);
+    expect(fn.mock.results[0].value).toBe((2 * 3));
+    expect(result).toBe((2 * 3) * 5);
+
+    const handler2 = fi.onBeforeAndAfterCallMapperAdd(args => {
+      args[0] *= 7;
+      return value => {
+        return value * 11;
+      };
+    });
+
+    result = fi.interceptor(2);
+    expect(fn).toBeCalledTimes(2);
+    expect(fn.mock.calls[1][0]).toBe((2 * 3) * 7);
+    expect(fn.mock.results[1].value).toBe(((2 * 3) * 7));
+    expect(result).toBe((((2 * 3) * 7) * 5) * 11);
+
+    fi.onBeforeAndAfterCallMapperRemove(handler2);
+    fi.onBeforeAndAfterCallMapperRemove(handler1);
+
+    result = fi.interceptor(2);
+    expect(fn).toBeCalledTimes(3);
+    expect(fn.mock.calls[2][0]).toBe(2);
+    expect(fn.mock.results[2].value).toBe(2);
+    expect(result).toBe(2);
+  });
+
+
+  test("intercept recursive function with args and value observers", () => {
+    // Test when original function is replaced with its intercepted version
+    let func = function (i: number): number[] {
+      if (i > 0) {
+        return func(i - 1).concat([i]);
+      } else {
+        return [];
+      }
+    };
+
+    const fi = interceptFunction(func);
+    func = fi.interceptor;
+
+    let ephemeralValue: number = 0;
+    fi.onBeforeCallObserverAdd(i => {
+      ephemeralValue = i;
+    });
+    fi.onAfterCallObserverAdd(value => {
+      expect(ephemeralValue).toBe(0);
+    });
+
+    let callCount = 0;
+    fi.onBeforeAndAfterCallMapperAdd(args => {
+      callCount++;
+      return value => {
+        expect(value.length).toBe(args[0]);
+        return value;
+      };
+    });
+
+    func(2);
+    expect(callCount).toBe(3);
+  });
+});

--- a/packages/hyperion-react-native-testapp/test/hyperion-core/IGlobalThis.test.ts
+++ b/packages/hyperion-react-native-testapp/test/hyperion-core/IGlobalThis.test.ts
@@ -4,8 +4,7 @@
 
 import "jest";
 import { AsyncCounter } from "hyperion-async-counter/src/AsyncCounter";
-import * as IGlobalThis from "../../HyperionCore";
-import { interceptFunction } from "../../HyperionCore";
+import { interceptFunction, IGlobalThis } from "../../HyperionCore";
 
 function wrapHandler(handler: Function | string, observer: jest.Mock<any, any>) {
   if (typeof handler === "string") {

--- a/packages/hyperion-react-native-testapp/test/hyperion-core/IGlobalThis.test.ts
+++ b/packages/hyperion-react-native-testapp/test/hyperion-core/IGlobalThis.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved.
+ */
+
+import "jest";
+import { AsyncCounter } from "hyperion-async-counter/src/AsyncCounter";
+import * as IGlobalThis from "../../HyperionCore";
+import { interceptFunction } from "../../HyperionCore";
+
+function wrapHandler(handler: Function | string, observer: jest.Mock<any, any>) {
+  if (typeof handler === "string") {
+    handler = new Function(handler);
+  };
+  const fi = interceptFunction(handler);
+  fi.onBeforeCallObserverAdd(observer);
+  return fi.interceptor;
+}
+
+describe('test Global Scope interception', () => {
+
+  test('test setTImeout', async () => {
+    const observer = jest.fn();
+    IGlobalThis.setTimeout.onBeforeCallMapperAdd(args => {
+      args[0] = wrapHandler(args[0], observer);
+      return args;
+    });
+
+    const counter = new AsyncCounter(1);
+    setTimeout(
+      () => {
+        counter.countUp();
+      },
+      1000
+    );
+
+    const finalCount = await counter.reachTarget();
+
+    expect(observer).toBeCalledTimes(finalCount);
+  });
+
+  test('test setInterval', async () => {
+    const observer = jest.fn();
+    IGlobalThis.setInterval.onBeforeCallMapperAdd(args => {
+      args[0] = wrapHandler(args[0], observer);
+      return args;
+    });
+
+    const counter = new AsyncCounter(5);
+    const id = setInterval(
+      () => {
+        counter.countUp();
+      },
+      100
+    );
+
+    const finalCount = await counter.reachTarget();
+
+    clearInterval(id);
+
+    expect(observer).toBeCalledTimes(finalCount);
+  });
+});

--- a/packages/hyperion-react-native-testapp/test/hyperion-core/IPromise.test.ts
+++ b/packages/hyperion-react-native-testapp/test/hyperion-core/IPromise.test.ts
@@ -5,7 +5,7 @@
  */
 
 import "jest";
-import * as IPromise from "../../HyperionCore";
+import { IPromise } from "../../HyperionCore";
 import { interceptFunction } from "../../HyperionCore";
 
 describe('test Promise', () => {
@@ -118,12 +118,12 @@ describe('test Promise', () => {
     // [IPromise.any, () => Promise.any([Promise.resolve(1), Promise.resolve(2)])],
     [IPromise.race, () => Promise.race([1, Promise.resolve(2)])],
     [IPromise.reject, () => Promise.reject(1)],
-    [IPromise.resolve, () => Promise.resolve(2)],
+    // TODO investigate why this case fails
+    // [IPromise.resolve, () => Promise.resolve(2)],
   ] as const).forEach(([interceptor, tester]) => {
-    test.skip(`test Promise.${interceptor.name} static method`, async () => {
+    test(`test Promise.${interceptor.name} static method`, async () => {
       const argsObserver = jest.fn();
       const handler = interceptor.onBeforeCallObserverAdd(values => {
-        console.trace(values);
         argsObserver(values);
       });
       try {

--- a/packages/hyperion-react-native-testapp/test/hyperion-core/IPromise.test.ts
+++ b/packages/hyperion-react-native-testapp/test/hyperion-core/IPromise.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved.
+ *
+ * @jest-environment jsdom
+ */
+
+import "jest";
+import * as IPromise from "../../HyperionCore";
+import { interceptFunction } from "../../HyperionCore";
+
+describe('test Promise', () => {
+  test('test promise.constructor', async () => {
+    const argsObserver = jest.fn();
+    const valueObserver = jest.fn();
+
+    const handler = IPromise.constructor.onBeforeAndAfterCallMapperAdd(args => {
+      const executor = args[0];
+      const fi = interceptFunction(executor);
+      args[0] = fi.interceptor;
+      fi.onBeforeCallMapperAdd(args => {
+        const resolve = args[0];
+        const resolveFI = interceptFunction(resolve);
+        args[0] = resolveFI.interceptor;
+        resolveFI.onBeforeCallObserverAdd(argsObserver);
+        return args;
+      })
+      return value => {
+        valueObserver(value);
+        return value;
+      }
+    });
+
+    const p = new Promise<number>((resolve, reject) => {
+      Promise.resolve(10).then(resolve, reject);
+    });
+
+    await p;
+
+    expect(argsObserver).toBeCalledWith(10);
+    expect(valueObserver).toBeCalledWith(p);
+
+    IPromise.constructor.onBeforeAndAfterCallMapperRemove(handler);
+  });
+
+  test('test promise.then', async () => {
+    const thenArgsObserver = jest.fn();
+    const thenValueObserver = jest.fn();
+
+    const argsMapper = IPromise.then.onBeforeCallMapperAdd(([onfulfilled, onrejected]) => {
+      if (onfulfilled) {
+        const wrappedOnfulfilled = interceptFunction(onfulfilled);
+        wrappedOnfulfilled.onBeforeCallObserverAdd(thenArgsObserver);
+        wrappedOnfulfilled.onAfterCallObserverAdd(thenValueObserver);
+        onfulfilled = wrappedOnfulfilled.interceptor;
+      }
+      return [onfulfilled, onrejected];
+    });
+
+    await Promise.resolve(10).then(value => value + 32);
+    expect(thenArgsObserver).toBeCalledWith(10);
+    expect(thenValueObserver).toBeCalledWith(42);
+
+    IPromise.then.onBeforeCallMapperRemove(argsMapper);
+  });
+
+  test('test promise.catch', async () => {
+    const thenArgsObserver = jest.fn();
+    const thenValueObserver = jest.fn();
+
+    const argsMapper1 = IPromise.then.onBeforeCallMapperAdd(([onfulfilled, onrejected]) => {
+      if (onfulfilled) {
+        const wrappedOnfulfilled = interceptFunction(onfulfilled);
+        wrappedOnfulfilled.onBeforeCallObserverAdd(thenArgsObserver);
+        wrappedOnfulfilled.onAfterCallObserverAdd(thenValueObserver);
+        onfulfilled = wrappedOnfulfilled.interceptor;
+      }
+      return [onfulfilled, onrejected];
+    });
+
+
+    const catchArgsObserver = jest.fn();
+    const catchValueObserver = jest.fn();
+    const argsMapper2 = IPromise.Catch.onBeforeCallMapperAdd(([onrejected]) => {
+      if (onrejected) {
+        const wrapped = interceptFunction(onrejected);
+        wrapped.onBeforeCallObserverAdd(catchArgsObserver);
+        wrapped.onAfterCallObserverAdd(catchValueObserver);
+        onrejected = wrapped.interceptor;
+      }
+      return [onrejected];
+    });
+
+
+
+    await Promise.reject(10).catch(reason => reason + 500).then(value => value + 32);
+    expect(catchArgsObserver).toBeCalledWith(10);
+    expect(catchValueObserver).toBeCalledWith(510);
+    expect(thenArgsObserver).toBeCalledWith(510);
+    expect(thenValueObserver).toBeCalledWith(542);
+
+    IPromise.then.onBeforeCallMapperRemove(argsMapper1);
+
+  });
+
+  test("test Promise behavior back to normal", async () => {
+    const result = await Promise.resolve(1).then(value => value + 1);
+    expect(result).toBe(2);
+
+    const observer = jest.fn();
+    await Promise.reject(1).catch(observer);
+    expect(observer).toBeCalledTimes(1);
+  });
+
+
+  ([
+    [IPromise.all, () => Promise.all([Promise.resolve(1), Promise.resolve(2)])],
+    [IPromise.allSettled, () => Promise.allSettled([Promise.resolve(1), Promise.reject(2)])],
+    // [IPromise.any, () => Promise.any([Promise.resolve(1), Promise.resolve(2)])],
+    [IPromise.race, () => Promise.race([1, Promise.resolve(2)])],
+    [IPromise.reject, () => Promise.reject(1)],
+    [IPromise.resolve, () => Promise.resolve(2)],
+  ] as const).forEach(([interceptor, tester]) => {
+    test.skip(`test Promise.${interceptor.name} static method`, async () => {
+      const argsObserver = jest.fn();
+      const handler = interceptor.onBeforeCallObserverAdd(values => {
+        console.trace(values);
+        argsObserver(values);
+      });
+      try {
+        await tester();
+      } catch { }
+      expect(argsObserver).toBeCalledTimes(1);
+      interceptor.onBeforeCallObserverRemove(handler);
+    });
+  });
+
+});

--- a/packages/hyperion-react-native-testapp/test/hyperion-core/IRequire.test.ts
+++ b/packages/hyperion-react-native-testapp/test/hyperion-core/IRequire.test.ts
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved.
+ *
+ * @jest-environment jsdom
+ */
+
+import "jest";
+import * as IRequire from "../../HyperionCore";
+import * as TestModule from "./IRequireTestModule";
+import TestModuleDefault from "./IRequireTestModuleDefault";
+import * as TestModuleDefaultExports from "./IRequireTestModuleDefault";
+
+describe("Test interception of module exports", () => {
+  test('Intercept normal module', () => {
+    const IModule = IRequire.interceptModuleExports("IRequireTestModule", TestModule, ["foo"], []);
+    const handler = IModule.foo.onBeforeCallObserverAdd(jest.fn(i => console.log(i)));
+    TestModule.foo(10);
+    expect(handler).toBeCalledTimes(1);
+    expect(handler).toBeCalledWith(10);
+  });
+
+  test('Intercept module with defaults', () => {
+    const IModule = IRequire.interceptModuleExports("IRequireTestModuleDefaultExports", TestModuleDefaultExports, ["default"], []);
+
+    const handler = IModule.default.onBeforeCallObserverAdd(jest.fn(i => console.log(i)));
+
+    TestModuleDefaultExports.default(20);
+    expect(handler).toBeCalledTimes(1);
+    expect(handler).toBeCalledWith(20);
+
+    TestModuleDefault(30);
+    expect(handler).toBeCalledTimes(2);
+    expect(handler).toBeCalledWith(30);
+  });
+
+});

--- a/packages/hyperion-react-native-testapp/test/hyperion-core/IRequire.test.ts
+++ b/packages/hyperion-react-native-testapp/test/hyperion-core/IRequire.test.ts
@@ -5,7 +5,7 @@
  */
 
 import "jest";
-import * as IRequire from "../../HyperionCore";
+import { IRequire } from "../../HyperionCore";
 import * as TestModule from "./IRequireTestModule";
 import TestModuleDefault from "./IRequireTestModuleDefault";
 import * as TestModuleDefaultExports from "./IRequireTestModuleDefault";

--- a/packages/hyperion-react-native-testapp/test/hyperion-core/IRequireTestModule.ts
+++ b/packages/hyperion-react-native-testapp/test/hyperion-core/IRequireTestModule.ts
@@ -1,0 +1,8 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved.
+ *
+ */
+
+export function foo(i: number): number {
+  return i + 1;
+}

--- a/packages/hyperion-react-native-testapp/test/hyperion-core/IRequireTestModuleDefault.ts
+++ b/packages/hyperion-react-native-testapp/test/hyperion-core/IRequireTestModuleDefault.ts
@@ -1,0 +1,8 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved.
+ *
+ */
+
+export default function foo(i: number): number {
+  return i + 1;
+}

--- a/packages/hyperion-react-native-testapp/test/hyperion-core/ShadowPrototype.test.ts
+++ b/packages/hyperion-react-native-testapp/test/hyperion-core/ShadowPrototype.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved.
+ */
+
+import "jest";
+import { ShadowPrototype } from "../../HyperionCore";
+
+describe("test modern classes", () => {
+
+  class A {
+    result: string[] = [];
+    a() { return "[a]"; }
+  }
+
+  class B extends A {
+    b() { return "[b]"; }
+  }
+
+  test("test ShadowPrototype", () => {
+    const IA = new (class extends ShadowPrototype<A>{
+      interceptObjectItself(obj: A) {
+        super.interceptObjectItself(obj);
+        obj.result.push(obj.a());
+      }
+    })(A.prototype, null);
+
+    const IB = new (class extends ShadowPrototype<B, A>{
+      interceptObjectItself(obj: B) {
+        super.interceptObjectItself(obj);
+        obj.result.push(obj.b());
+      }
+    })(B.prototype, IA);
+
+    IA.onBeforInterceptObj.add(o => o.result.push("-a"));
+    IA.onAfterInterceptObj.add(o => o.result.push("+a"));
+    IB.onBeforInterceptObj.add(o => o.result.push("-b"));
+    IB.onAfterInterceptObj.add(o => o.result.push("+b"));
+
+    const b = new B();
+
+    IB.interceptObject(b);
+    expect(b.result.join("")).toBe("-a-b[a][b]+a+b");
+  });
+});
+
+describe("test traditional classes", () => {
+
+  interface A {
+    result: string[];
+    a(): string;
+  }
+  function A_(this: A) {
+    this.result = [];
+  }
+  A_.prototype.a = function () { return "[a]"; };
+
+  interface B extends A {
+    b(): string;
+  }
+  function B_(this: B) {
+    A_.call(this);
+  }
+  B_.prototype = new A_();
+  B_.prototype.b = function () { return "[b]"; }
+
+
+  test("test ShadowPrototype", () => {
+    const IA = new (class extends ShadowPrototype<A>{
+      interceptObjectItself(obj: A) {
+        super.interceptObjectItself(obj);
+        obj.result.push(obj.a());
+      }
+    })(A_.prototype, null);
+
+    const IB = new (class extends ShadowPrototype<B, A>{
+      interceptObjectItself(obj: B) {
+        super.interceptObjectItself(obj);
+        obj.result.push(obj.b());
+      }
+    })(B_.prototype, IA);
+
+    IA.onBeforInterceptObj.add(o => o.result.push("-a"));
+    IA.onAfterInterceptObj.add(o => o.result.push("+a"));
+    IB.onBeforInterceptObj.add(o => o.result.push("-b"));
+    IB.onAfterInterceptObj.add(o => o.result.push("+b"));
+
+    const b = new B_();
+
+    IB.interceptObject(b);
+    expect(b.result.join("")).toBe("-a-b[a][b]+a+b");
+  });
+})

--- a/packages/hyperion-react-native-testapp/test/hyperion-core/Timers.test.ts
+++ b/packages/hyperion-react-native-testapp/test/hyperion-core/Timers.test.ts
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved.
+ */
+
+import "jest";
+
+
+describe('Test interception via test. ', () => {
+
+  test('Check global this interception during test', async () => {
+    /**
+     * We use timers because we know they will internally use setTimeout
+     * and other timer related api that we have intercepted.
+     */
+    jest.useFakeTimers();
+
+    console.log('BEFORE FIRST');
+    jest.advanceTimersByTime(100);
+    console.log('AFTER FIRST');
+
+    /**
+     * We load the following here to test what happens if jest starts first
+     * and then we install the interceptors.
+     * Goal is to see everyting continue to function correctly.
+     */
+    const x = require("../../HyperionCore");
+    x.setTimeout.onBeforeCallObserverAdd(() => {
+      console.log("something");
+    });
+
+    console.log('BEFORE SECOND');
+    let y: number = 0;
+    setTimeout(() => {
+      y = 1;
+    }, 50);
+
+    jest.advanceTimersByTime(100);
+    console.log('AFTER SECOND');
+    expect(y).toBe(1);
+  });
+
+});

--- a/packages/hyperion-react-native-testapp/test/hyperion-core/intercept.test.ts
+++ b/packages/hyperion-react-native-testapp/test/hyperion-core/intercept.test.ts
@@ -1,0 +1,208 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved.
+ */
+
+import "jest";
+import { ShadowPrototype } from "../../HyperionCore";
+import { AttributeInterceptor } from "../../HyperionCore";
+import { interceptMethod } from "../../HyperionCore";
+import { getVirtualPropertyValue, intercept, isIntercepted, registerShadowPrototype, registerShadowPrototypeGetter, setVirtualPropertyValue } from "../../HyperionCore";
+
+describe("test interception mechanism", () => {
+
+  function testSetup() {
+    class A {
+      result: string[] = [];
+
+      _a1: number = 10;
+      get a1() { return this._a1; }
+      set a1(v: number) { this._a1 = v; }
+
+      a2: boolean;
+      a3: number;
+
+      f1(s: string) {
+        const tmp = `[a:${s}]`;
+        this.result.push(tmp);
+        return tmp;
+      }
+
+      f2: (b: boolean) => boolean;
+      f3: (n: number) => number;
+
+      _f4: (n: number) => number;
+      get f4() { return this._f4; }
+      set f4(func: (n: number) => number) { this._f4 = func; }
+
+      constructor() {
+        this.f3 = n => -n;
+        this.a3 = 21;
+      }
+
+    }
+
+    class B extends A {
+      _b: string = "hello";
+      get b() { return this._b; }
+      set b(v: string) { this._b = v; }
+    }
+
+    const IAShadow = new ShadowPrototype(A.prototype, null);
+    const IA = {
+      a1: new AttributeInterceptor('a1', IAShadow),
+      a2: new AttributeInterceptor('a2', IAShadow),
+      a3: new AttributeInterceptor('a3', IAShadow),
+      a4: new AttributeInterceptor('a4', IAShadow),
+      f1: interceptMethod('f1', IAShadow),
+      f2: interceptMethod('f2', IAShadow),
+      f3: interceptMethod('f3', IAShadow),
+      f4: interceptMethod('f4', IAShadow),
+    };
+
+    const IBShadow = new ShadowPrototype(B.prototype, IAShadow);
+    const IB = {
+      b: new AttributeInterceptor('b', IBShadow),
+    }
+
+
+    return { IAShadow, IBShadow, IA, IB, A, B }
+  }
+
+  test("test registerShadowPrototype", () => {
+    const { IAShadow, IBShadow, IA, IB, A, B } = testSetup();
+
+    const o = new B();
+
+    let testCount = 0;
+    const expectObjIntercepted = <T>(obj) => {
+      expect(obj).toBe(o);
+      testCount++;
+    };
+    IAShadow.onAfterInterceptObj.add(expectObjIntercepted);
+    IBShadow.onAfterInterceptObj.add(expectObjIntercepted);
+
+    intercept(o);
+    expect(testCount).toBe(0); // Not yet set up the shadow prototypes
+    expect(isIntercepted(o)).toBe(false);
+
+    registerShadowPrototype(A.prototype, IAShadow);
+    registerShadowPrototype(B.prototype, IBShadow);
+    intercept(o);
+    expect(testCount).toBe(2); // Now interceptors must have run
+    expect(isIntercepted(o)).toBe(true);
+  });
+
+  test("test custom ShadowPrototype getter", () => {
+    const { IAShadow, IBShadow, IA, IB, A, B } = testSetup();
+
+    const o = new B();
+
+    let testCount = 0;
+    const expectObjIntercepted = <T>(obj) => {
+      expect(obj).toBe(o);
+      testCount++;
+    };
+    IAShadow.onAfterInterceptObj.add(expectObjIntercepted);
+    IBShadow.onAfterInterceptObj.add(expectObjIntercepted);
+
+    // The custom getter should have priority and if it does not work only IAShadow will be picked up
+    registerShadowPrototype(A.prototype, IAShadow);
+    const unregister = registerShadowPrototypeGetter(obj => {
+      expectObjIntercepted(obj);
+      if (obj instanceof B) {
+        return IBShadow
+      }
+    });
+
+    intercept(o);
+    expect(testCount).toBe(3);
+    expect(isIntercepted(o)).toBe(true);
+    unregister();
+  });
+
+  test("test intercept", () => {
+    const { IAShadow, IBShadow, IA, IB, A, B } = testSetup();
+    registerShadowPrototype(A.prototype, IAShadow);
+    registerShadowPrototype(B.prototype, IBShadow);
+
+    const o = new B();
+
+    let testCount = 0;
+    const expectObjIntercepted = <T>(obj) => {
+      expect(obj).toBe(o);
+      testCount++;
+    };
+    IAShadow.onAfterInterceptObj.add(expectObjIntercepted);
+    IBShadow.onAfterInterceptObj.add(expectObjIntercepted);
+
+    let result: any[] = [];
+    const observer = <T>(value: T) => {
+      result.push(value);
+    };
+    const expectResultTobe = (expected: any[]) => {
+      expect(result).toStrictEqual(expected);
+      result = [];
+    }
+
+    IA.a1.getter.onAfterCallObserverAdd(observer);
+    IA.a1.setter.onBeforeCallObserverAdd(observer);
+
+    IA.a2.getter.onAfterCallObserverAdd(observer);
+    IA.a2.setter.onBeforeCallObserverAdd(observer);
+
+    IA.a3.getter.onAfterCallObserverAdd(observer);
+    IA.a3.setter.onBeforeCallObserverAdd(observer);
+
+    IA.a4.getter.onAfterCallObserverAdd(observer);
+    IA.a4.setter.onBeforeCallObserverAdd(observer);
+
+    IB.b.getter.onAfterCallObserverAdd(observer);
+    IB.b.setter.onBeforeCallObserverAdd(observer);
+
+    [IA.f1, IA.f2, IA.f3, IA.f4].forEach(fi => {
+      fi.onBeforeCallObserverAdd(observer);
+      fi.onAfterCallObserverAdd(observer);
+    });
+
+    intercept(o);
+    expect(testCount).toBe(2);
+
+    // a sequence of read/writes
+    o.a1 = o.a1 + 20;
+    expectResultTobe([10, 30]);
+
+    o.a2 = !o.a2;
+    expectResultTobe([undefined, true]);
+
+    o.a3 *= 2;
+    expectResultTobe([21, 42]);
+
+    o.b = o.b + "world";
+    expectResultTobe(["hello", "helloworld"]);
+
+
+    o.f2 = function (this, b) { return !b; }
+    o.f2(true);
+    expectResultTobe([true, false]);
+
+    o.f3(10);
+    expectResultTobe([10, -10]);
+
+    o.f4 = n => 2 * n;
+    o.f4(21);
+    expectResultTobe([21, 42]);
+  });
+
+  test("test virtual attribute values", () => {
+    const { IAShadow, IBShadow, IA, IB, A, B } = testSetup();
+    registerShadowPrototype(B.prototype, IBShadow);
+
+    const o = new B();
+
+    type VA = number;
+    const VANAME = "_tmp";
+
+    const va = getVirtualPropertyValue<VA>(o, VANAME) ?? setVirtualPropertyValue<VA>(o, VANAME, 42);
+    expect(va).toBe(42);
+  });
+});


### PR DESCRIPTION
This PR is adding the JS interceptors in a playground react native in order to test its compatibility to RN.

It was tested running the tests wrote to the original file, which were also copied in the playground. Only 2 tests didn't pass and need further investigation on what is generating the unexpected behavior. 

The tests that are not passing are:
* `FunctionInterceptor.test` -> `test prototype + name prop copied to interceptor`
* `IPromise.test` -> `test Promise.resolver static method`