### PR TITLE
fixed compile breakage from Cytoscape type change

### DIFF
--- a/packages/hyperion-autologging-visualizer/src/component/ALGraph.ts
+++ b/packages/hyperion-autologging-visualizer/src/component/ALGraph.ts
@@ -438,8 +438,8 @@ export class ALGraph<DynamicOptionsType extends ALGraphDynamicOptionsType = ALGr
     }
   }
 
-  protected addNode(node: cytoscape.NodeDefinition): cytoscape.CollectionReturnValue {
-    return this.add(node);
+  protected addNode(node: Omit<cytoscape.NodeDefinition, "group">): cytoscape.CollectionReturnValue {
+    return this.add({ group: "nodes", ...node });
   }
 
   protected addEdge(sourceId: GraphID, targetId: GraphID, classes?: string | string[]): cytoscape.CollectionReturnValue | null {


### PR DESCRIPTION
In the latest version of Cytoscape types, the type of NodeDefinition has changed and has a new field, that's why compilation was failing.