### PR TITLE
remove unused code from Surface

### DIFF
--- a/packages/hyperion-autologging/src/global.d.ts
+++ b/packages/hyperion-autologging/src/global.d.ts
@@ -8,5 +8,4 @@ interface GlobalFlags {
   preciseTriggerFlowlet?: boolean;
   optimizeInteractibiltyCheck?: boolean;
   enableDynamicChildTracking?: boolean;
-  optimizeSurfaceRendering?: boolean;
 }


### PR DESCRIPTION
To make it easier to use surface in react native, and to enable some features by default, cleaned up old unused code.