### PR TITLE
Add an element with a label to the list of aspects that should be ignored as the Interactive element

### DIFF
--- a/packages/hyperion-autologging/src/ALInteractableDOMElement.ts
+++ b/packages/hyperion-autologging/src/ALInteractableDOMElement.ts
@@ -148,7 +148,7 @@ let ignoreInteractiveElement: (node: Element) => boolean = node => {
    * Later, when we wanted to remove the flag, the cleanup is easy.
    */
   function ignoreInteractiveElementCore(node: Element): boolean {
-    return node.tagName === 'BODY' || node.tagName === 'HTML' ||
+    return node.tagName === 'BODY' || node.tagName === 'HTML' || node.tagName === 'LABEL' ||
       (node.clientHeight === window.innerHeight && node.clientWidth === window.innerWidth);
   }
 


### PR DESCRIPTION
The error is reported when an item in GeoRadioList is selected; two separate and similar events are fired. The first one is associated with the input element, and the second one is related to the label element.
The solution is to put the label element, as the list of elements should be ignored, in an interactive state.