### PR TITLE
Fix the style of the surface wrapper

### DIFF
--- a/packages/hyperion-autologging/src/ALSurface.ts
+++ b/packages/hyperion-autologging/src/ALSurface.ts
@@ -46,6 +46,10 @@ export interface ALSurfaceCapability {
    * When set, will track when the provided ratio [0,1] of the surface becomes visible
    */
   trackVisibilityThreshold?: number;
+  /**
+   * Optional style to apply to the surface wrapper
+   */
+  wrapperStyle?: React.CSSProperties;
 }
 
 function surfaceCapabilityToString(capability?: ALSurfaceCapability | null): string {
@@ -286,11 +290,13 @@ export function init(options: InitOptions): ALSurfaceRenderers {
     const wrapperElementType = proxiedContext?.container instanceof SVGElement ? "g" : "span";
 
     if (addSurfaceWrapper) {
+      const style = props?.capability?.wrapperStyle ?? {display: "contents"};
       children = ReactModule.createElement(
         wrapperElementType,
         {
           [SURFACE_WRAPPER_ATTRIBUTE_NAME]: "1",
           [domAttributeName]: domAttributeValue,
+          style,
           ref: localRef, // addSurfaceWrapper would have been false if a rep was passed in props
         },
         children


### PR DESCRIPTION
Using the GeoALSurface directly for GeoComponent break some UI view due to surface style. Removing  the style fix the issue

Before removing the syle
<img width="471" height="102" alt="Screenshot 2025-09-09 at 10 09 51 AM" src="https://github.com/user-attachments/assets/c5b30328-c795-4340-a5a5-6f3b55d27e88" />

After removing the style
<img width="400" height="66" alt="Screenshot 2025-09-09 at 10 11 04 AM" src="https://github.com/user-attachments/assets/72893e99-2b3b-4e5b-8e8d-003fcce9decc" />
