### PR TITLE
Update AsyncCounter.test.ts

### DIFF
--- a/packages/hyperion-async-counter/test/AsyncCounter.test.ts
+++ b/packages/hyperion-async-counter/test/AsyncCounter.test.ts
@@ -38,4 +38,57 @@ describe("test AsyncCounter", () => {
     expect(counter.getSteps()).toBe(2 + finalCount + 5);
     expect(trigger).toBeCalledTimes(finalCount + 5);
   });
+  test('should resolve the promise when the counter reaches the target count', async () => {
+    // Arrange: Create an instance of AsyncCounter with a target of 3.
+    const target = 3;
+    const counter = new AsyncCounter(target);
+
+    // Act: Increment the counter in separate steps.
+    const promise = counter.reachTarget();
+    
+    counter.countUp(); // count = 1
+    counter.countUp(); // count = 2
+    counter.countUp(); // count = 3
+
+    // Assert: The promise should now be resolved.
+    // Use `await` to wait for the promise to settle.
+    await expect(promise).resolves.toBe(target);
+  });
+
+  test('should not resolve the promise before the target count is reached', async () => {
+    // Arrange: Create an instance with a target of 5.
+    const target = 5;
+    const counter = new AsyncCounter(target);
+
+    // Act: Increment the counter but stop before the target.
+    const promise = counter.reachTarget();
+    
+    counter.countUp(2); // count = 2
+    counter.countUp(2); // count = 4
+
+    // Assert: The promise should still be pending.
+    // We can't directly check if a promise is "pending" without a race condition.
+    // A better way is to use a promise that rejects after a short timeout if the main promise resolves.
+    const timeoutPromise = new Promise((_, reject) => {
+      setTimeout(() => reject(new Error('Promise should not have resolved')), 100);
+    });
+
+    // Use Promise.race to check that our target promise doesn't resolve before the timeout.
+    await expect(Promise.race([promise, timeoutPromise])).rejects.toThrow('Promise should not have resolved');
+  });
+
+  test('should resolve even when the target is reached with a negative count', async () => {
+    // Arrange: Set a negative target and count down.
+    const target = -2;
+    const counter = new AsyncCounter(target);
+
+    // Act: Decrement the counter to reach the negative target.
+    const promise = counter.reachTarget();
+    
+    counter.countDown(); // count = -1
+    counter.countDown(); // count = -2
+
+    // Assert: The promise should resolve with the negative target value.
+    await expect(promise).resolves.toBe(target);
+  });
 });


### PR DESCRIPTION
Test Rationale
it('should resolve...'): This is the primary test case. It verifies the core functionality of reachTarget. It creates a counter, gets the promise, and then calls countUp until the target is met. The use of await expect(promise).resolves.toBe(target) is the standard way to test if an asynchronous operation completes successfully with the expected value.

it('should not resolve...'): This is a crucial negative test case. It ensures that reachTarget doesn't resolve prematurely. Since there's no direct way in Jest to check if a promise is "pending," a common technique is to create a second promise that rejects after a short timeout. Promise.race is then used to check which promise settles first. If the AsyncCounter's promise resolves, Promise.race will not reject, and the test will fail as intended.

it('should resolve with a negative count'): This test ensures the method works correctly with different data types, in this case, a negative targetCount. It uses countDown to reach the target, proving that the tryResolve logic works regardless of the direction the counter is moving.