### PR TITLE
Put surface deletion behind a flag

### DIFF
--- a/packages/hyperion-autologging/src/ALSurfaceTypes.ts
+++ b/packages/hyperion-autologging/src/ALSurfaceTypes.ts
@@ -41,6 +41,7 @@ export type ALSurfaceRenderers = {
 
 
 export type ALChannelSurfaceEvent = Readonly<{
+  al_surface_render: [Omit<ALSurfaceEventData, "element">];
   al_surface_mount: [ALSurfaceEventData];
   al_surface_unmount: [ALSurfaceEventData];
 }>;
@@ -71,9 +72,9 @@ export interface ALSurfaceCapability {
 }
 
 export type ALSurfaceEvent = Readonly<{
-    surface: string;
-    surfaceData: ALSurfaceData;
-  }>;
+  surface: string;
+  surfaceData: ALSurfaceData;
+}>;
 
 
 export type ALSurfaceEventData =

--- a/packages/hyperion-autologging/src/AutoLogging.ts
+++ b/packages/hyperion-autologging/src/AutoLogging.ts
@@ -129,10 +129,6 @@ export function init(options: InitOptions): boolean {
 
   // Enumerating the cases where we need react interception and visitors
   const reactOptions = options.react;
-  if (typeof reactOptions.enableInterceptDomElement !== 'boolean') {
-    reactOptions.enableInterceptDomElement =
-      options.surface.enableReactDomPropsExtension;
-  }
   if (typeof reactOptions.enableInterceptClassComponentConstructor !== "boolean") {
     reactOptions.enableInterceptClassComponentConstructor =
       options.triggerFlowlet?.enableReactMethodFlowlet;

--- a/packages/hyperion-autologging/src/global.d.ts
+++ b/packages/hyperion-autologging/src/global.d.ts
@@ -8,4 +8,5 @@ interface GlobalFlags {
   preciseTriggerFlowlet?: boolean;
   optimizeInteractibiltyCheck?: boolean;
   enableDynamicChildTracking?: boolean;
+  enableSurfaceDataGC?: boolean;
 }


### PR DESCRIPTION
Noticed that in React strict mode, the useEffect called multiple times, which causes surfaces to be deleted and not put back again. Anyways, we are not seeing much saving from adding/removing these surfaces since most of them are used as user navigates around the UI. For now, put it behind a flag in case we wanted to enable it immediately in production.

To help debug such situations, introduced an `al_surface_render` flag that allows us to track how react calls render vs. mount/unmount the components. It is actually useful to track rerenders at a high level. Since this could be expensive, put this event also behind a flag.

Also cleaned up a few other unused flags.