### PR TITLE
Fix WebpackModuleRuntime fallback and add React Activity support

### DIFF
--- a/packages/hyperion-core/src/IRequire.ts
+++ b/packages/hyperion-core/src/IRequire.ts
@@ -4,9 +4,10 @@
 
 import type { FunctionInterceptor, InterceptableObjectType } from './FunctionInterceptor';
 
+import "./reference";
 import { ShadowPrototype, } from './ShadowPrototype';
 import { interceptMethod } from './MethodInterceptor';
-import { assert } from 'hyperion-globals';
+import { assert, getFlags } from 'hyperion-globals';
 
 export type InterceptedModuleExports<TModuleExports extends InterceptableObjectType> = {
   [K in keyof TModuleExports]: FunctionInterceptor<TModuleExports, string, TModuleExports[K]>;
@@ -39,6 +40,9 @@ class WebpackModuleRuntime extends ModuleRuntimeBase {
   getExports<T>(moduleId: string) {
     const modulePath = new RegExp(`${moduleId}(?:/index)?[.]js$`);
     const wexports = Object.keys(this._cache).filter(m => modulePath.test(m)).map(m => this._cache[m]);
+    if (getFlags().safeWebpackModuleExports) {
+      return (wexports[0]?.exports as unknown as T) ?? null;
+    }
     return wexports[0].exports as unknown as T;
   }
 }
@@ -73,21 +77,37 @@ class MetaModuleRuntime extends ModuleRuntimeBase {
   }
 }
 
-const ModuleRuntime: ModuleRuntimeBase = (() => {
-  if (typeof __webpack_module_cache__ === 'object') {
-    // In webpack world
-    return new WebpackModuleRuntime(__webpack_module_cache__);
-  } else if (typeof require === "function") {
+let _moduleRuntime: ModuleRuntimeBase | null = null;
+function getModuleRuntime(): ModuleRuntimeBase {
+  if (_moduleRuntime) {
+    return _moduleRuntime;
+  }
+  const flags = getFlags();
+  if (flags.preferMetaModuleRuntime && typeof require === "function") {
     try {
       const __debug = require("__debug");
       if (typeof __debug === "object") {
-        // In Meta custom runtime world
-        return new MetaModuleRuntime(__debug);
+        _moduleRuntime = new MetaModuleRuntime(__debug);
+        return _moduleRuntime;
       }
     } catch (e) { }
   }
-  return new ModuleRuntimeBase();
-})();
+  if (typeof __webpack_module_cache__ === 'object') {
+    _moduleRuntime = new WebpackModuleRuntime(__webpack_module_cache__);
+    return _moduleRuntime;
+  }
+  if (!flags.preferMetaModuleRuntime && typeof require === "function") {
+    try {
+      const __debug = require("__debug");
+      if (typeof __debug === "object") {
+        _moduleRuntime = new MetaModuleRuntime(__debug);
+        return _moduleRuntime;
+      }
+    } catch (e) { }
+  }
+  _moduleRuntime = new ModuleRuntimeBase();
+  return _moduleRuntime;
+}
 
 export function interceptModuleExports<TModuleExports extends InterceptableObjectType>(
   moduleId: string,
@@ -96,7 +116,7 @@ export function interceptModuleExports<TModuleExports extends InterceptableObjec
   failedExportsKeys?: ModuleExportsKeys<TModuleExports>
 ): InterceptedModuleExports<TModuleExports> {
   let interceptableModuleExports: TModuleExports = moduleExports;
-  const alternativeExports = ModuleRuntime.getExports<TModuleExports>(moduleId);
+  const alternativeExports = getModuleRuntime().getExports<TModuleExports>(moduleId);
 
   if (alternativeExports && alternativeExports !== interceptableModuleExports) {
     console.warn('different exports objects ', moduleId);
@@ -110,7 +130,7 @@ export function interceptModuleExports<TModuleExports extends InterceptableObjec
     IModule[key] = interceptMethod(key, ModuleExportsShadow);
   };
 
-  ModuleRuntime.updateExports(moduleId, moduleExports, IModule, failedExportsKeys)
+  getModuleRuntime().updateExports(moduleId, moduleExports, IModule, failedExportsKeys)
 
   validateModuleInterceptor(moduleId, moduleExports, IModule, failedExportsKeys);
   return IModule;

--- a/packages/hyperion-core/src/global.d.ts
+++ b/packages/hyperion-core/src/global.d.ts
@@ -1,0 +1,8 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved.
+ */
+
+interface GlobalFlags {
+  preferMetaModuleRuntime?: boolean;
+  safeWebpackModuleExports?: boolean;
+}

--- a/packages/hyperion-core/src/reference.ts
+++ b/packages/hyperion-core/src/reference.ts
@@ -1,0 +1,5 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved.
+ */
+
+/// <reference path="./global.d.ts" />

--- a/packages/hyperion-core/test/IRequire.test.ts
+++ b/packages/hyperion-core/test/IRequire.test.ts
@@ -9,6 +9,45 @@ import * as IRequire from "../src/IRequire";
 import * as TestModule from "./IRequireTestModule";
 import TestModuleDefault from "./IRequireTestModuleDefault";
 import * as TestModuleDefaultExports from "./IRequireTestModuleDefault";
+import { setFlags, getFlags } from "hyperion-globals";
+
+describe("WebpackModuleRuntime graceful handling", () => {
+  const originalFlags = { ...getFlags() };
+
+  afterEach(() => {
+    setFlags(originalFlags);
+  });
+
+  test('interceptModuleExports works when webpack cache has no matching module', () => {
+    const IModule = IRequire.interceptModuleExports("nonExistentModule", TestModule, ["foo"], []);
+    const handler = IModule.foo.onBeforeCallObserverAdd(jest.fn());
+    TestModule.foo(42);
+    expect(handler).toBeCalledTimes(1);
+    expect(handler).toBeCalledWith(42);
+  });
+
+  test('safeWebpackModuleExports flag enables null-safe getExports', () => {
+    setFlags({ ...getFlags(), safeWebpackModuleExports: true });
+    // With flag enabled and no webpack cache in test env, getModuleRuntime()
+    // returns ModuleRuntimeBase (returns null). Verify interception still works.
+    const IModule = IRequire.interceptModuleExports("missingModule", TestModule, ["foo"], []);
+    const handler = IModule.foo.onBeforeCallObserverAdd(jest.fn());
+    TestModule.foo(99);
+    expect(handler).toBeCalledTimes(1);
+    expect(handler).toBeCalledWith(99);
+  });
+
+  test('preferMetaModuleRuntime flag is respected', () => {
+    setFlags({ ...getFlags(), preferMetaModuleRuntime: true });
+    // In test env, require("__debug") will throw/return undefined, so it
+    // falls through to ModuleRuntimeBase. Verify no crash and interception works.
+    const IModule = IRequire.interceptModuleExports("anotherMissing", TestModule, ["foo"], []);
+    const handler = IModule.foo.onBeforeCallObserverAdd(jest.fn());
+    TestModule.foo(77);
+    expect(handler).toBeCalledTimes(1);
+    expect(handler).toBeCalledWith(77);
+  });
+});
 
 describe("Test interception of module exports", () => {
   test('Intercept normal module', () => {

--- a/packages/hyperion-react/src/IReactConsts.ts
+++ b/packages/hyperion-react/src/IReactConsts.ts
@@ -55,3 +55,4 @@ export const REACT_CACHE_TYPE: Sym = SymbolFor(0xeae4, 'react.cache');
 export const REACT_TRACING_MARKER_TYPE: Sym = SymbolFor(0xeae5, 'react.tracing_marker',);
 export const REACT_SERVER_CONTEXT_DEFAULT_VALUE_NOT_LOADED: Sym = SymbolFor(0xeae7, 'react.default_value',);
 export const FAUX_ITERATOR_SYMBOL = '@@iterator';
+export const REACT_ACTIVITY_TYPE: Sym = SymbolFor(0xeae8, 'react.activity');

--- a/packages/hyperion-react/src/IReactElementVisitor.ts
+++ b/packages/hyperion-react/src/IReactElementVisitor.ts
@@ -183,6 +183,7 @@ function optimizeVisitors<
     [IReactConsts.REACT_LEGACY_HIDDEN_TYPE]: ctor(),
     [IReactConsts.REACT_SCOPE_TYPE]: ctor(),
     [IReactConsts.REACT_STRICT_MODE_TYPE]: ctor(),
+    [IReactConsts.REACT_ACTIVITY_TYPE]: ctor(),
   };
 
   visitors._get = (component, visitors) =>
@@ -300,6 +301,8 @@ function getVisitor<
         case IReactConsts.REACT_SCOPE_TYPE:
           break;
         case IReactConsts.REACT_STRICT_MODE_TYPE:
+          break;
+        case IReactConsts.REACT_ACTIVITY_TYPE:
           break;
         default:
           warn(`skip special component $$type: ${String(component)}`);


### PR DESCRIPTION
- Fix WebpackModuleRuntime.getExports() crash when module not found in __webpack_module_cache__ (e.g. browser MCP injecting empty cache). Null-safe access gated behind `safeWebpackModuleExports` flag.

- Convert ModuleRuntime from eager IIFE to lazy getModuleRuntime() so GlobalFlags are respected. `preferMetaModuleRuntime` flag controls whether Meta's __debug runtime is checked before webpack's cache.

- Add REACT_ACTIVITY_TYPE (0xeae8) to IReactConsts, fix broken SymbolFor call, and register in visitor vtable to suppress "optimized visitors missing entry for Symbol(react.activity)" warnings.

- Upgrade react-testapp to React 19 canary with real <Activity> component test and Vite __debug exclusion.