### PR TITLE
Remove flags, always use null-safe getExports and prefer Meta runtime

### DIFF
--- a/packages/hyperion-core/src/IRequire.ts
+++ b/packages/hyperion-core/src/IRequire.ts
@@ -4,10 +4,9 @@
 
 import type { FunctionInterceptor, InterceptableObjectType } from './FunctionInterceptor';
 
-import "./reference";
 import { ShadowPrototype, } from './ShadowPrototype';
 import { interceptMethod } from './MethodInterceptor';
-import { assert, getFlags } from 'hyperion-globals';
+import { assert } from 'hyperion-globals';
 
 export type InterceptedModuleExports<TModuleExports extends InterceptableObjectType> = {
   [K in keyof TModuleExports]: FunctionInterceptor<TModuleExports, string, TModuleExports[K]>;
@@ -40,10 +39,7 @@ class WebpackModuleRuntime extends ModuleRuntimeBase {
   getExports<T>(moduleId: string) {
     const modulePath = new RegExp(`${moduleId}(?:/index)?[.]js$`);
     const wexports = Object.keys(this._cache).filter(m => modulePath.test(m)).map(m => this._cache[m]);
-    if (getFlags().safeWebpackModuleExports) {
-      return (wexports[0]?.exports as unknown as T) ?? null;
-    }
-    return wexports[0].exports as unknown as T;
+    return (wexports[0]?.exports as unknown as T) ?? null;
   }
 }
 
@@ -77,37 +73,24 @@ class MetaModuleRuntime extends ModuleRuntimeBase {
   }
 }
 
-let _moduleRuntime: ModuleRuntimeBase | null = null;
-function getModuleRuntime(): ModuleRuntimeBase {
-  if (_moduleRuntime) {
-    return _moduleRuntime;
-  }
-  const flags = getFlags();
-  if (flags.preferMetaModuleRuntime && typeof require === "function") {
+const ModuleRuntime: ModuleRuntimeBase = (() => {
+  if (typeof require === "function") {
     try {
       const __debug = require("__debug");
       if (typeof __debug === "object") {
-        _moduleRuntime = new MetaModuleRuntime(__debug);
-        return _moduleRuntime;
+        // In Meta custom runtime world — check first since Meta's module
+        // system is authoritative in Meta's environment, even if
+        // __webpack_module_cache__ is also present (e.g. injected by tools).
+        return new MetaModuleRuntime(__debug);
       }
     } catch (e) { }
   }
   if (typeof __webpack_module_cache__ === 'object') {
-    _moduleRuntime = new WebpackModuleRuntime(__webpack_module_cache__);
-    return _moduleRuntime;
+    // In webpack world
+    return new WebpackModuleRuntime(__webpack_module_cache__);
   }
-  if (!flags.preferMetaModuleRuntime && typeof require === "function") {
-    try {
-      const __debug = require("__debug");
-      if (typeof __debug === "object") {
-        _moduleRuntime = new MetaModuleRuntime(__debug);
-        return _moduleRuntime;
-      }
-    } catch (e) { }
-  }
-  _moduleRuntime = new ModuleRuntimeBase();
-  return _moduleRuntime;
-}
+  return new ModuleRuntimeBase();
+})();
 
 export function interceptModuleExports<TModuleExports extends InterceptableObjectType>(
   moduleId: string,
@@ -116,7 +99,7 @@ export function interceptModuleExports<TModuleExports extends InterceptableObjec
   failedExportsKeys?: ModuleExportsKeys<TModuleExports>
 ): InterceptedModuleExports<TModuleExports> {
   let interceptableModuleExports: TModuleExports = moduleExports;
-  const alternativeExports = getModuleRuntime().getExports<TModuleExports>(moduleId);
+  const alternativeExports = ModuleRuntime.getExports<TModuleExports>(moduleId);
 
   if (alternativeExports && alternativeExports !== interceptableModuleExports) {
     console.warn('different exports objects ', moduleId);
@@ -130,7 +113,7 @@ export function interceptModuleExports<TModuleExports extends InterceptableObjec
     IModule[key] = interceptMethod(key, ModuleExportsShadow);
   };
 
-  getModuleRuntime().updateExports(moduleId, moduleExports, IModule, failedExportsKeys)
+  ModuleRuntime.updateExports(moduleId, moduleExports, IModule, failedExportsKeys)
 
   validateModuleInterceptor(moduleId, moduleExports, IModule, failedExportsKeys);
   return IModule;

--- a/packages/hyperion-core/src/global.d.ts
+++ b/packages/hyperion-core/src/global.d.ts
@@ -1,8 +1,0 @@
-/**
- * Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved.
- */
-
-interface GlobalFlags {
-  preferMetaModuleRuntime?: boolean;
-  safeWebpackModuleExports?: boolean;
-}

--- a/packages/hyperion-core/src/reference.ts
+++ b/packages/hyperion-core/src/reference.ts
@@ -1,5 +1,0 @@
-/**
- * Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved.
- */
-
-/// <reference path="./global.d.ts" />

--- a/packages/hyperion-core/test/IRequire.test.ts
+++ b/packages/hyperion-core/test/IRequire.test.ts
@@ -9,43 +9,16 @@ import * as IRequire from "../src/IRequire";
 import * as TestModule from "./IRequireTestModule";
 import TestModuleDefault from "./IRequireTestModuleDefault";
 import * as TestModuleDefaultExports from "./IRequireTestModuleDefault";
-import { setFlags, getFlags } from "hyperion-globals";
-
 describe("WebpackModuleRuntime graceful handling", () => {
-  const originalFlags = { ...getFlags() };
-
-  afterEach(() => {
-    setFlags(originalFlags);
-  });
-
   test('interceptModuleExports works when webpack cache has no matching module', () => {
+    // When ModuleRuntime falls through to ModuleRuntimeBase (no webpack cache
+    // or __debug in test env), getExports returns null and the passed-in
+    // moduleExports is used as-is.
     const IModule = IRequire.interceptModuleExports("nonExistentModule", TestModule, ["foo"], []);
     const handler = IModule.foo.onBeforeCallObserverAdd(jest.fn());
     TestModule.foo(42);
     expect(handler).toBeCalledTimes(1);
     expect(handler).toBeCalledWith(42);
-  });
-
-  test('safeWebpackModuleExports flag enables null-safe getExports', () => {
-    setFlags({ ...getFlags(), safeWebpackModuleExports: true });
-    // With flag enabled and no webpack cache in test env, getModuleRuntime()
-    // returns ModuleRuntimeBase (returns null). Verify interception still works.
-    const IModule = IRequire.interceptModuleExports("missingModule", TestModule, ["foo"], []);
-    const handler = IModule.foo.onBeforeCallObserverAdd(jest.fn());
-    TestModule.foo(99);
-    expect(handler).toBeCalledTimes(1);
-    expect(handler).toBeCalledWith(99);
-  });
-
-  test('preferMetaModuleRuntime flag is respected', () => {
-    setFlags({ ...getFlags(), preferMetaModuleRuntime: true });
-    // In test env, require("__debug") will throw/return undefined, so it
-    // falls through to ModuleRuntimeBase. Verify no crash and interception works.
-    const IModule = IRequire.interceptModuleExports("anotherMissing", TestModule, ["foo"], []);
-    const handler = IModule.foo.onBeforeCallObserverAdd(jest.fn());
-    TestModule.foo(77);
-    expect(handler).toBeCalledTimes(1);
-    expect(handler).toBeCalledWith(77);
   });
 });
 


### PR DESCRIPTION
Remove safeWebpackModuleExports and preferMetaModuleRuntime flags in favor of unconditionally applying both fixes:

- getExports always uses null-safe access (wexports[0]?.exports ?? null)
- IIFE checks Meta __debug runtime before __webpack_module_cache__ since Meta's module system is authoritative in Meta's environment

Reverts to the simpler IIFE pattern per reviewer feedback.