### PR TITLE
docs: fix typos in comments

### DIFF
--- a/packages/hyperion-autologging/src/ALTriggerFlowlet.ts
+++ b/packages/hyperion-autologging/src/ALTriggerFlowlet.ts
@@ -225,7 +225,7 @@ export function init(options: InitOptions) {
       IReactModule.useCallback,
     ].forEach(fi => {
       /**
-       * useCallback will recieve a new callback function each time, but may return a previous
+       * useCallback will receive a new callback function each time, but may return a previous
        * one. So, it might be more efficient to only focus on the return value.
        */
       // fi.onArgsMapperAdd(args => {

--- a/packages/hyperion-core/src/PropertyInterceptor.ts
+++ b/packages/hyperion-core/src/PropertyInterceptor.ts
@@ -21,7 +21,7 @@ export abstract class PropertyInterceptor {
   }
 
   interceptObjectOwnProperties(_obj: object) {
-    __DEV__ && assert(false, `This method must be overriden`);
+    __DEV__ && assert(false, `This method must be overridden`);
   }
 }
 

--- a/packages/hyperion-flowlet/src/FlowletManager.ts
+++ b/packages/hyperion-flowlet/src/FlowletManager.ts
@@ -45,7 +45,7 @@ export class FlowletManager<T extends Flowlet = Flowlet> {
 
   private scheduleCleanup() {
     /**
-     * We schdule a listner to see when stack reaches the threshold size.
+     * We schedule a listener to see when stack reaches the threshold size.
      * Then we don't need to have this listener any more until cleanup is finished, at which
      * point we can schedule the stack size monitoring again.
      * This should save some cycles during busy times.

--- a/packages/hyperion-react/src/IReactComponent.ts
+++ b/packages/hyperion-react/src/IReactComponent.ts
@@ -321,7 +321,7 @@ export function init(options: InitOptions): void {
     /**
      * TODO: T132536682 remove this guard later to speed things up
      * NOTE: tried using ErrorGuard.guard, and ErrorGuard.applyWithGuard but
-     * as usual, Flow cannot handle complex function input/ouput types.
+     * as usual, Flow cannot handle complex function input/output types.
      * So, putting the raw try/catch, which is the actual implementation of
      * ErrorGaurd.applyWithGuard anyways.
      *


### PR DESCRIPTION
## Summary
- Fix 5 spelling errors across 4 source files in code comments:
  - `schdule` → `schedule` and `listner` → `listener` in FlowletManager.ts
  - `ouput` → `output` in IReactComponent.ts
  - `overriden` → `overridden` in PropertyInterceptor.ts
  - `recieve` → `receive` in ALTriggerFlowlet.ts

## Test plan
- No functional changes — comment-only edits
- Verified each typo exists in the current `main` branch before fixing